### PR TITLE
Specifying website root for generated docs to fix broken links

### DIFF
--- a/docs/tools/generate.fsx
+++ b/docs/tools/generate.fsx
@@ -6,7 +6,7 @@
 // Binaries that have XML documentation (in a corresponding generated XML file)
 let referenceBinaries = [ "Frank.dll" ]
 // Web site location for the generated documentation
-let website = ""
+let website = "http://frank-fs.github.io/frank"
 
 // Specify more information about your project
 let info =

--- a/docs/tools/templates/template.cshtml
+++ b/docs/tools/templates/template.cshtml
@@ -34,7 +34,7 @@
           @RenderBody()
         </div>
         <div class="span3">
-          <img src="img/logo.png" alt="F# Project" style="width:150px;margin:10px" />  
+          <img src="@Root/img/logo.png" alt="F# Project" style="width:150px;margin:10px" />  
           <ul class="nav nav-list" id="menu">
             <li class="nav-header">@Properties["project-name"]</li>
             <li><a href="@Root/index.html">Home page</a></li>


### PR DESCRIPTION
Attempts to fix broken links to API docs and tutorial (e.g. links [here](http://frank-fs.github.io/reference/index.html) from [here](http://frank-fs.github.io/frank/)), and broken image ref on api doc's [index.html](http://frank-fs.github.io/frank/reference/index.html).

Not sure if this change will work, but thought I should at least attempt a fix at the same time as raising the issue. :)
