### PR TITLE
Use WebApplicationBuilder for net10.0 targets

### DIFF
--- a/src/Frank/Builder.fs
+++ b/src/Frank/Builder.fs
@@ -13,208 +13,257 @@ module Builder =
     open Microsoft.Extensions.Hosting
 
     [<Struct>]
-    type Resource = { Endpoints : Endpoint[] }
+    type Resource = { Endpoints: Endpoint[] }
 
     type ResourceSpec =
-        { Name : string
-          Handlers : (string * RequestDelegate) list
-          Metadata : (EndpointBuilder -> unit) list }
-        static member Empty = { Name = Unchecked.defaultof<_>; Handlers = []; Metadata = [] }
+        { Name: string
+          Handlers: (string * RequestDelegate) list
+          Metadata: (EndpointBuilder -> unit) list }
+
+        static member Empty =
+            { Name = Unchecked.defaultof<_>
+              Handlers = []
+              Metadata = [] }
+
         member spec.Build(routeTemplate) =
-            let {Name=name; Handlers=handlers; Metadata=metadata} = spec
+            let { Name = name
+                  Handlers = handlers
+                  Metadata = metadata } =
+                spec
+
             let routePattern = Patterns.RoutePatternFactory.Parse routeTemplate
+
             let endpoints =
                 [| for httpMethod, handler in handlers ->
-                    let displayName = httpMethod+" "+(if String.IsNullOrEmpty name then routeTemplate else name)
-                    let builder = RouteEndpointBuilder(handler, routePattern, 0)
-                    builder.DisplayName <- displayName
-                    builder.Metadata.Add(HttpMethodMetadata [|httpMethod|])
-                    builder.Metadata.Add(handler.Method)
-                    for convention in metadata do
-                        convention builder
-                    builder.Build() |]
+                       let displayName =
+                           httpMethod + " " + (if String.IsNullOrEmpty name then routeTemplate else name)
+
+                       let builder = RouteEndpointBuilder(handler, routePattern, 0)
+                       builder.DisplayName <- displayName
+                       builder.Metadata.Add(HttpMethodMetadata [| httpMethod |])
+                       builder.Metadata.Add(handler.Method)
+
+                       for convention in metadata do
+                           convention builder
+
+                       builder.Build() |]
+
             { Endpoints = endpoints }
 
     [<Sealed>]
-    type ResourceBuilder (routeTemplate) =
-        static let methodNotAllowed (ctx:HttpContext) =
+    type ResourceBuilder(routeTemplate) =
+        static let methodNotAllowed (ctx: HttpContext) =
             ctx.Response.StatusCode <- 405
             Task.FromResult(Some ctx)
 
-        member __.Run(spec:ResourceSpec) : Resource =
-            spec.Build(routeTemplate)
-        
+        member __.Run(spec: ResourceSpec) : Resource = spec.Build(routeTemplate)
+
         member __.Yield(_) = ResourceSpec.Empty
 
         [<CustomOperation("name")>]
         member __.Name(spec, name) = { spec with Name = name }
 
         static member AddMetadata(spec: ResourceSpec, convention: EndpointBuilder -> unit) : ResourceSpec =
-            { spec with Metadata = spec.Metadata @ [ convention ] }
+            { spec with
+                Metadata = spec.Metadata @ [ convention ] }
 
         static member AddHandler(httpMethod, spec, handler) =
-            { spec with Handlers=(httpMethod, handler)::spec.Handlers }
+            { spec with
+                Handlers = (httpMethod, handler) :: spec.Handlers }
 
-        static member AddHandler(httpMethod, spec, handler:HttpContext -> Task<'a>) =
-            { spec with Handlers=(httpMethod, RequestDelegate(fun ctx -> handler ctx :> Task))::spec.Handlers }
+        static member AddHandler(httpMethod, spec, handler: HttpContext -> Task<'a>) =
+            { spec with
+                Handlers = (httpMethod, RequestDelegate(fun ctx -> handler ctx :> Task)) :: spec.Handlers }
 
-        static member AddHandler(httpMethod, spec, handler:(HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>) =
-            { spec with Handlers=(httpMethod, RequestDelegate(fun ctx -> handler methodNotAllowed ctx :> Task))::spec.Handlers }
+        static member AddHandler
+            (
+                httpMethod,
+                spec,
+                handler: (HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>
+            ) =
+            { spec with
+                Handlers =
+                    (httpMethod, RequestDelegate(fun ctx -> handler methodNotAllowed ctx :> Task))
+                    :: spec.Handlers }
 
-        static member AddHandler(httpMethod, spec, handler:HttpContext -> Async<'a>) =
-            { spec with Handlers=(httpMethod, RequestDelegate(fun ctx -> handler ctx |> Async.StartAsTask :> Task))::spec.Handlers }
+        static member AddHandler(httpMethod, spec, handler: HttpContext -> Async<'a>) =
+            { spec with
+                Handlers =
+                    (httpMethod, RequestDelegate(fun ctx -> handler ctx |> Async.StartAsTask :> Task))
+                    :: spec.Handlers }
 
-        static member AddHandler(httpMethod, spec, handler:HttpContext -> unit) =
-            { spec with Handlers=(httpMethod, RequestDelegate(fun ctx -> Task.FromResult(handler ctx) :> Task))::spec.Handlers }
+        static member AddHandler(httpMethod, spec, handler: HttpContext -> unit) =
+            { spec with
+                Handlers =
+                    (httpMethod, RequestDelegate(fun ctx -> Task.FromResult(handler ctx) :> Task))
+                    :: spec.Handlers }
 
         [<CustomOperation("connect")>]
-        member __.Connect(spec, handler:RequestDelegate) =
+        member __.Connect(spec, handler: RequestDelegate) =
             ResourceBuilder.AddHandler(HttpMethods.Connect, spec, handler)
 
-        member __.Connect(spec, handler:HttpContext -> Task<'a>) =
+        member __.Connect(spec, handler: HttpContext -> Task<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Connect, spec, handler)
 
-        member __.Connect(spec, handler:(HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>) =
+        member __.Connect
+            (spec, handler: (HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>)
+            =
             ResourceBuilder.AddHandler(HttpMethods.Connect, spec, handler)
 
-        member __.Connect(spec, handler:HttpContext -> Async<'a>) =
+        member __.Connect(spec, handler: HttpContext -> Async<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Connect, spec, handler)
 
-        member __.Connect(spec, handler:HttpContext -> unit) =
+        member __.Connect(spec, handler: HttpContext -> unit) =
             ResourceBuilder.AddHandler(HttpMethods.Connect, spec, handler)
 
         [<CustomOperation("delete")>]
-        member __.Delete(spec, handler:RequestDelegate) =
+        member __.Delete(spec, handler: RequestDelegate) =
             ResourceBuilder.AddHandler(HttpMethods.Delete, spec, handler)
 
-        member __.Delete(spec, handler:HttpContext -> Task<'a>) =
+        member __.Delete(spec, handler: HttpContext -> Task<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Delete, spec, handler)
 
-        member __.Delete(spec, handler:(HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>) =
+        member __.Delete
+            (spec, handler: (HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>)
+            =
             ResourceBuilder.AddHandler(HttpMethods.Delete, spec, handler)
 
-        member __.Delete(spec, handler:HttpContext -> Async<'a>) =
+        member __.Delete(spec, handler: HttpContext -> Async<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Delete, spec, handler)
 
-        member __.Delete(spec, handler:HttpContext -> unit) =
+        member __.Delete(spec, handler: HttpContext -> unit) =
             ResourceBuilder.AddHandler(HttpMethods.Delete, spec, handler)
 
         [<CustomOperation("get")>]
-        member __.Get(spec, handler:RequestDelegate) =
+        member __.Get(spec, handler: RequestDelegate) =
             ResourceBuilder.AddHandler(HttpMethods.Get, spec, handler)
 
-        member __.Get(spec, handler:HttpContext -> Task<'a>) =
+        member __.Get(spec, handler: HttpContext -> Task<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Get, spec, handler)
 
-        member __.Get(spec, handler:(HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>) =
+        member __.Get
+            (spec, handler: (HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>)
+            =
             ResourceBuilder.AddHandler(HttpMethods.Get, spec, handler)
 
-        member __.Get(spec, handler:HttpContext -> Async<'a>) =
+        member __.Get(spec, handler: HttpContext -> Async<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Get, spec, handler)
 
-        member __.Get(spec, handler:HttpContext -> unit) =
+        member __.Get(spec, handler: HttpContext -> unit) =
             ResourceBuilder.AddHandler(HttpMethods.Get, spec, handler)
 
         [<CustomOperation("head")>]
-        member __.Head(spec, handler:RequestDelegate) =
+        member __.Head(spec, handler: RequestDelegate) =
             ResourceBuilder.AddHandler(HttpMethods.Head, spec, handler)
 
-        member __.Head(spec, handler:HttpContext -> Task<'a>) =
+        member __.Head(spec, handler: HttpContext -> Task<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Head, spec, handler)
 
-        member __.Head(spec, handler:(HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>) =
+        member __.Head
+            (spec, handler: (HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>)
+            =
             ResourceBuilder.AddHandler(HttpMethods.Head, spec, handler)
 
-        member __.Head(spec, handler:HttpContext -> Async<'a>) =
+        member __.Head(spec, handler: HttpContext -> Async<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Head, spec, handler)
 
-        member __.Head(spec, handler:HttpContext -> unit) =
+        member __.Head(spec, handler: HttpContext -> unit) =
             ResourceBuilder.AddHandler(HttpMethods.Head, spec, handler)
 
         [<CustomOperation("options")>]
-        member __.Options(spec, handler:RequestDelegate) =
+        member __.Options(spec, handler: RequestDelegate) =
             ResourceBuilder.AddHandler(HttpMethods.Options, spec, handler)
 
-        member __.Options(spec, handler:HttpContext -> Task<'a>) =
+        member __.Options(spec, handler: HttpContext -> Task<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Options, spec, handler)
 
-        member __.Options(spec, handler:(HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>) =
+        member __.Options
+            (spec, handler: (HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>)
+            =
             ResourceBuilder.AddHandler(HttpMethods.Options, spec, handler)
 
-        member __.Options(spec, handler:HttpContext -> Async<'a>) =
+        member __.Options(spec, handler: HttpContext -> Async<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Options, spec, handler)
 
-        member __.Options(spec, handler:HttpContext -> unit) =
+        member __.Options(spec, handler: HttpContext -> unit) =
             ResourceBuilder.AddHandler(HttpMethods.Options, spec, handler)
 
         [<CustomOperation("patch")>]
-        member __.Patch(spec, handler:RequestDelegate) =
+        member __.Patch(spec, handler: RequestDelegate) =
             ResourceBuilder.AddHandler(HttpMethods.Patch, spec, handler)
 
-        member __.Patch(spec, handler:HttpContext -> Task<'a>) =
+        member __.Patch(spec, handler: HttpContext -> Task<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Patch, spec, handler)
 
-        member __.Patch(spec, handler:(HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>) =
+        member __.Patch
+            (spec, handler: (HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>)
+            =
             ResourceBuilder.AddHandler(HttpMethods.Patch, spec, handler)
 
-        member __.Patch(spec, handler:HttpContext -> Async<'a>) =
+        member __.Patch(spec, handler: HttpContext -> Async<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Patch, spec, handler)
 
-        member __.Patch(spec, handler:HttpContext -> unit) =
+        member __.Patch(spec, handler: HttpContext -> unit) =
             ResourceBuilder.AddHandler(HttpMethods.Patch, spec, handler)
 
         [<CustomOperation("post")>]
-        member __.Post(spec, handler:RequestDelegate) =
+        member __.Post(spec, handler: RequestDelegate) =
             ResourceBuilder.AddHandler(HttpMethods.Post, spec, handler)
 
-        member __.Post(spec, handler:HttpContext -> Task<'a>) =
+        member __.Post(spec, handler: HttpContext -> Task<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Post, spec, handler)
 
-        member __.Post(spec, handler:(HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>) =
+        member __.Post
+            (spec, handler: (HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>)
+            =
             ResourceBuilder.AddHandler(HttpMethods.Post, spec, handler)
 
-        member __.Post(spec, handler:HttpContext -> Async<'a>) =
+        member __.Post(spec, handler: HttpContext -> Async<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Post, spec, handler)
 
-        member __.Post(spec, handler:HttpContext -> unit) =
+        member __.Post(spec, handler: HttpContext -> unit) =
             ResourceBuilder.AddHandler(HttpMethods.Post, spec, handler)
 
         [<CustomOperation("put")>]
-        member __.Put(spec, handler:RequestDelegate) =
+        member __.Put(spec, handler: RequestDelegate) =
             ResourceBuilder.AddHandler(HttpMethods.Put, spec, handler)
 
-        member __.Put(spec, handler:HttpContext -> Task<'a>) =
+        member __.Put(spec, handler: HttpContext -> Task<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Put, spec, handler)
 
-        member __.Put(spec, handler:(HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>) =
+        member __.Put
+            (spec, handler: (HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>)
+            =
             ResourceBuilder.AddHandler(HttpMethods.Put, spec, handler)
 
-        member __.Put(spec, handler:HttpContext -> Async<'a>) =
+        member __.Put(spec, handler: HttpContext -> Async<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Put, spec, handler)
 
-        member __.Put(spec, handler:HttpContext -> unit) =
+        member __.Put(spec, handler: HttpContext -> unit) =
             ResourceBuilder.AddHandler(HttpMethods.Put, spec, handler)
 
         [<CustomOperation("trace")>]
-        member __.Trace(spec, handler:RequestDelegate) =
+        member __.Trace(spec, handler: RequestDelegate) =
             ResourceBuilder.AddHandler(HttpMethods.Trace, spec, handler)
 
-        member __.Trace(spec, handler:HttpContext -> Task<'a>) =
+        member __.Trace(spec, handler: HttpContext -> Task<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Trace, spec, handler)
 
-        member __.Trace(spec, handler:(HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>) =
+        member __.Trace
+            (spec, handler: (HttpContext -> Task<HttpContext option>) -> HttpContext -> Task<HttpContext option>)
+            =
             ResourceBuilder.AddHandler(HttpMethods.Trace, spec, handler)
 
-        member __.Trace(spec, handler:HttpContext -> Async<'a>) =
+        member __.Trace(spec, handler: HttpContext -> Async<'a>) =
             ResourceBuilder.AddHandler(HttpMethods.Trace, spec, handler)
 
-        member __.Trace(spec, handler:HttpContext -> unit) =
+        member __.Trace(spec, handler: HttpContext -> unit) =
             ResourceBuilder.AddHandler(HttpMethods.Trace, spec, handler)
 
     let resource routeTemplate = ResourceBuilder(routeTemplate)
 
     [<Sealed>]
-    type internal ResourceEndpointDataSource(endpoints:Endpoint[]) =
+    type internal ResourceEndpointDataSource(endpoints: Endpoint[]) =
         inherit EndpointDataSource()
 
         override __.Endpoints = endpoints :> _
@@ -227,59 +276,92 @@ module Builder =
           Endpoints: Endpoint[]
           Services: (IServiceCollection -> IServiceCollection)
           UseDefaults: bool }
+
         static member Empty =
-            { Host=id
-              BeforeRoutingMiddleware=id
-              Middleware=id
-              Endpoints=[||]
-              Services=(fun services ->
-                services.AddMvcCore(fun options -> options.ReturnHttpNotAcceptable <- true) |> ignore
-                services)
-              UseDefaults=false }
+            { Host = id
+              BeforeRoutingMiddleware = id
+              Middleware = id
+              Endpoints = [||]
+              Services =
+                (fun services ->
+                    services.AddMvcCore(fun options -> options.ReturnHttpNotAcceptable <- true)
+                    |> ignore
+
+                    services)
+              UseDefaults = false }
 
     [<Sealed>]
-    type WebHostBuilder (args) =
+    type WebHostBuilder(args: string[]) =
 
-        member __.Run(spec:WebHostSpec) =
+        member __.Run(spec: WebHostSpec) =
+#if NET10_0_OR_GREATER
+            let builder =
+                if spec.UseDefaults then
+                    WebApplication.CreateBuilder(args)
+                else
+                    WebApplication.CreateSlimBuilder(args)
+
+            spec.Host(builder.WebHost) |> ignore
+            spec.Services(builder.Services) |> ignore
+            let app = builder.Build()
+
+            (app :> IApplicationBuilder)
+            |> spec.BeforeRoutingMiddleware
+            |> fun app -> app.UseRouting()
+            |> spec.Middleware
+            |> ignore
+
+            let dataSource = ResourceEndpointDataSource(spec.Endpoints)
+            (app :> IEndpointRouteBuilder).DataSources.Add(dataSource)
+            app.Run()
+#else
             let builder = Host.CreateDefaultBuilder(args)
-            let config = Action<_>(fun webBuilder ->
-                spec.Host(webBuilder)
-                    .ConfigureServices(spec.Services >> ignore)
-                    .Configure(fun app ->
-                        app
-                        |> spec.BeforeRoutingMiddleware
-                        |> fun app -> app.UseRouting()
-                        |> spec.Middleware
-                        |> fun app ->
-                            app.UseEndpoints(fun endpoints ->
-                                let dataSource = ResourceEndpointDataSource(spec.Endpoints)
-                                endpoints.DataSources.Add(dataSource))
-                        |> ignore)
+
+            let config =
+                Action<_>(fun webBuilder ->
+                    spec
+                        .Host(webBuilder)
+                        .ConfigureServices(spec.Services >> ignore)
+                        .Configure(fun app ->
+                            app
+                            |> spec.BeforeRoutingMiddleware
+                            |> fun app -> app.UseRouting()
+                            |> spec.Middleware
+                            |> fun app ->
+                                app.UseEndpoints(fun endpoints ->
+                                    let dataSource = ResourceEndpointDataSource(spec.Endpoints)
+                                    endpoints.DataSources.Add(dataSource))
+                            |> ignore)
                     |> ignore)
+
             let configured =
                 if spec.UseDefaults then
                     builder.ConfigureWebHostDefaults(config)
                 else
                     builder.ConfigureWebHost(config)
+
             configured.Build().Run()
+#endif
 
         member __.Yield(_) = WebHostSpec.Empty
 
         [<CustomOperation("configure")>]
-        member __.Configure(spec, f) =
-            { spec with Host = spec.Host >> f }
+        member __.Configure(spec, f) = { spec with Host = spec.Host >> f }
 
         [<CustomOperation("plugBeforeRouting")>]
         member __.PlugBeforeRouting(spec, f) =
-            { spec with BeforeRoutingMiddleware = spec.BeforeRoutingMiddleware >> f }
+            { spec with
+                BeforeRoutingMiddleware = spec.BeforeRoutingMiddleware >> f }
 
         [<CustomOperation("plugBeforeRoutingWhen")>]
         member __.PlugBeforeRoutingWhen(spec, cond, f) =
             { spec with
-                BeforeRoutingMiddleware = fun app ->
-                    if cond app then
-                        f(spec.BeforeRoutingMiddleware(app))
-                    else spec.BeforeRoutingMiddleware(app) }
+                BeforeRoutingMiddleware =
+                    fun app ->
+                        if cond app then
+                            f (spec.BeforeRoutingMiddleware(app))
+                        else
+                            spec.BeforeRoutingMiddleware(app) }
 
         [<CustomOperation("plugBeforeRoutingWhenNot")>]
         member __.PlugBeforeRoutingWhenNot(spec, cond, f) =
@@ -287,30 +369,33 @@ module Builder =
 
         [<CustomOperation("plug")>]
         member __.Plug(spec, f) =
-            { spec with Middleware = spec.Middleware >> f }
+            { spec with
+                Middleware = spec.Middleware >> f }
 
         [<CustomOperation("plugWhen")>]
         member __.PlugWhen(spec, cond, f) =
             { spec with
-                Middleware = fun app ->
-                    if cond app then
-                        f(spec.Middleware(app))
-                    else spec.Middleware(app) }
+                Middleware =
+                    fun app ->
+                        if cond app then
+                            f (spec.Middleware(app))
+                        else
+                            spec.Middleware(app) }
 
         [<CustomOperation("plugWhenNot")>]
-        member __.PlugWhenNot(spec, cond, f) =
-            __.PlugWhen(spec, not << cond, f)
+        member __.PlugWhenNot(spec, cond, f) = __.PlugWhen(spec, not << cond, f)
 
         [<CustomOperation("resource")>]
-        member __.Resource(spec, resource:Resource) : WebHostSpec =
-            { spec with Endpoints = Array.append spec.Endpoints resource.Endpoints }
+        member __.Resource(spec, resource: Resource) : WebHostSpec =
+            { spec with
+                Endpoints = Array.append spec.Endpoints resource.Endpoints }
 
         [<CustomOperation("service")>]
         member __.Service(spec, f) =
-            { spec with Services = spec.Services >> f }
-        
+            { spec with
+                Services = spec.Services >> f }
+
         [<CustomOperation("useDefaults")>]
-        member __.UseDefaults(spec) =
-            { spec with UseDefaults = true }
+        member __.UseDefaults(spec) = { spec with UseDefaults = true }
 
     let webHost args = WebHostBuilder(args)

--- a/test/Frank.Tests/MiddlewareOrderingTests.fs
+++ b/test/Frank.Tests/MiddlewareOrderingTests.fs
@@ -17,11 +17,13 @@ open Frank.Builder
 let simpleAuthMiddleware (next: RequestDelegate) (ctx: HttpContext) =
     task {
         let hasToken = ctx.Request.Headers.ContainsKey("X-Auth-Token")
+
         if hasToken then
             do! next.Invoke(ctx)
         else
             ctx.Response.StatusCode <- 401
-    } :> Task
+    }
+    :> Task
 
 /// Middleware that adds a marker header to track execution order
 let markerMiddleware (name: string) (next: RequestDelegate) (ctx: HttpContext) =
@@ -31,263 +33,369 @@ let markerMiddleware (name: string) (next: RequestDelegate) (ctx: HttpContext) =
                 ctx.Items["markers"] :?> string
             else
                 ""
+
         ctx.Items["markers"] <- existingMarkers + name + ","
         do! next.Invoke(ctx)
-    } :> Task
+    }
+    :> Task
 
 /// Creates a test server with the given webHost configuration
 let createTestServer (configureSpec: WebHostSpec -> WebHostSpec) =
-    let builder =
-        Host.CreateDefaultBuilder([||])
-            .ConfigureWebHost(fun webBuilder ->
-                webBuilder
-                    .UseTestServer()
-                    .ConfigureServices(fun services ->
-                        services.AddRouting() |> ignore)
-                    .Configure(fun app ->
-                        let spec = WebHostSpec.Empty |> configureSpec
+    let spec = WebHostSpec.Empty |> configureSpec
+    let builder = WebApplication.CreateBuilder([||])
+    builder.WebHost.UseTestServer() |> ignore
+    builder.Services.AddRouting() |> ignore
+    spec.Services(builder.Services) |> ignore
+    let app = builder.Build()
 
-                        app
-                        |> spec.BeforeRoutingMiddleware
-                        |> fun app -> app.UseRouting()
-                        |> spec.Middleware
-                        |> fun app ->
-                            app.UseEndpoints(fun endpoints ->
-                                endpoints.MapGet("/test", Func<HttpContext, Task>(fun ctx ->
-                                    task {
-                                        let markers =
-                                            if ctx.Items.ContainsKey("markers") then
-                                                ctx.Items["markers"] :?> string
-                                            else
-                                                ""
-                                        ctx.Response.Headers.Append("X-Markers", markers)
-                                        do! ctx.Response.WriteAsync("OK")
-                                    } :> Task)) |> ignore)
-                        |> ignore)
-                |> ignore)
+    (app :> IApplicationBuilder)
+    |> spec.BeforeRoutingMiddleware
+    |> fun app -> app.UseRouting()
+    |> spec.Middleware
+    |> ignore
 
-    let host = builder.Build()
-    host.Start()
-    host.GetTestClient()
+    app.MapGet(
+        "/test",
+        Func<HttpContext, Task>(fun ctx ->
+            task {
+                let markers =
+                    if ctx.Items.ContainsKey("markers") then
+                        ctx.Items["markers"] :?> string
+                    else
+                        ""
+
+                ctx.Response.Headers.Append("X-Markers", markers)
+                do! ctx.Response.WriteAsync("OK")
+            }
+            :> Task)
+    )
+    |> ignore
+
+    app.Start()
+    app.GetTestClient()
 
 [<Tests>]
 let middlewareOrderingTests =
-    testList "Middleware Ordering" [
-        testTask "plug middleware executes after UseRouting" {
-            let client = createTestServer (fun spec ->
-                { spec with
-                    Middleware = fun app ->
-                        app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                            markerMiddleware "plug" next ctx)) })
+    testList
+        "Middleware Ordering"
+        [ testTask "plug middleware executes after UseRouting" {
+              let client =
+                  createTestServer (fun spec ->
+                      { spec with
+                          Middleware =
+                              fun app ->
+                                  app.Use(
+                                      Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                          markerMiddleware "plug" next ctx)
+                                  ) })
 
-            let! (response : HttpResponseMessage) = client.GetAsync("/test")
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
-        }
+              let! (response: HttpResponseMessage) = client.GetAsync("/test")
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
+          }
 
-        testTask "plugBeforeRouting middleware executes before UseRouting" {
-            let client = createTestServer (fun spec ->
-                { spec with
-                    BeforeRoutingMiddleware = fun app ->
-                        app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                            markerMiddleware "beforeRouting" next ctx)) })
+          testTask "plugBeforeRouting middleware executes before UseRouting" {
+              let client =
+                  createTestServer (fun spec ->
+                      { spec with
+                          BeforeRoutingMiddleware =
+                              fun app ->
+                                  app.Use(
+                                      Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                          markerMiddleware "beforeRouting" next ctx)
+                                  ) })
 
-            let! (response : HttpResponseMessage) = client.GetAsync("/test")
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
-        }
+              let! (response: HttpResponseMessage) = client.GetAsync("/test")
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
+          }
 
-        testTask "middleware execution order is plugBeforeRouting then plug" {
-            let client = createTestServer (fun spec ->
-                { spec with
-                    BeforeRoutingMiddleware = fun app ->
-                        app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                            markerMiddleware "before" next ctx))
-                    Middleware = fun app ->
-                        app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                            markerMiddleware "after" next ctx)) })
+          testTask "middleware execution order is plugBeforeRouting then plug" {
+              let client =
+                  createTestServer (fun spec ->
+                      { spec with
+                          BeforeRoutingMiddleware =
+                              fun app ->
+                                  app.Use(
+                                      Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                          markerMiddleware "before" next ctx)
+                                  )
+                          Middleware =
+                              fun app ->
+                                  app.Use(
+                                      Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                          markerMiddleware "after" next ctx)
+                                  ) })
 
-            let! (response : HttpResponseMessage) = client.GetAsync("/test")
-            let markers =
-                if response.Headers.Contains("X-Markers") then
-                    response.Headers.GetValues("X-Markers") |> Seq.head
-                else
-                    ""
+              let! (response: HttpResponseMessage) = client.GetAsync("/test")
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
-            Expect.isTrue (markers.StartsWith("before,")) "before marker should come first"
-            Expect.isTrue (markers.Contains("after,")) "after marker should be present"
-        }
+              let markers =
+                  if response.Headers.Contains("X-Markers") then
+                      response.Headers.GetValues("X-Markers") |> Seq.head
+                  else
+                      ""
 
-        testTask "authentication middleware via plug can reject unauthenticated requests" {
-            let client = createTestServer (fun spec ->
-                { spec with
-                    Middleware = fun app ->
-                        app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                            simpleAuthMiddleware next ctx)) })
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
+              Expect.isTrue (markers.StartsWith("before,")) "before marker should come first"
+              Expect.isTrue (markers.Contains("after,")) "after marker should be present"
+          }
 
-            let! (response : HttpResponseMessage) = client.GetAsync("/test")
-            Expect.equal response.StatusCode HttpStatusCode.Unauthorized "Should return 401 for unauthenticated"
-        }
+          testTask "authentication middleware via plug can reject unauthenticated requests" {
+              let client =
+                  createTestServer (fun spec ->
+                      { spec with
+                          Middleware =
+                              fun app ->
+                                  app.Use(
+                                      Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                          simpleAuthMiddleware next ctx)
+                                  ) })
 
-        testTask "authentication middleware via plug allows authenticated requests" {
-            let client = createTestServer (fun spec ->
-                { spec with
-                    Middleware = fun app ->
-                        app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                            simpleAuthMiddleware next ctx)) })
+              let! (response: HttpResponseMessage) = client.GetAsync("/test")
+              Expect.equal response.StatusCode HttpStatusCode.Unauthorized "Should return 401 for unauthenticated"
+          }
 
-            let request = new HttpRequestMessage(HttpMethod.Get, "/test")
-            request.Headers.Add("X-Auth-Token", "valid-token")
-            let! (response : HttpResponseMessage) = client.SendAsync(request)
+          testTask "authentication middleware via plug allows authenticated requests" {
+              let client =
+                  createTestServer (fun spec ->
+                      { spec with
+                          Middleware =
+                              fun app ->
+                                  app.Use(
+                                      Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                          simpleAuthMiddleware next ctx)
+                                  ) })
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK for authenticated"
-        }
+              let request = new HttpRequestMessage(HttpMethod.Get, "/test")
+              request.Headers.Add("X-Auth-Token", "valid-token")
+              let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-        testTask "no middleware registered still works" {
-            let client = createTestServer id
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK for authenticated"
+          }
 
-            let! (response : HttpResponseMessage) = client.GetAsync("/test")
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK with no middleware"
-        }
+          testTask "no middleware registered still works" {
+              let client = createTestServer id
 
-        // Tests for plugBeforeRoutingWhen (User Story 1)
-        testTask "plugBeforeRoutingWhen executes middleware when condition is true" {
-            let alwaysTrue (_: IApplicationBuilder) = true
-            let builder = WebHostBuilder([||])
-            let spec =
-                WebHostSpec.Empty
-                |> fun s -> builder.PlugBeforeRoutingWhen(s, alwaysTrue, fun app ->
-                    app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                        markerMiddleware "conditional" next ctx)))
+              let! (response: HttpResponseMessage) = client.GetAsync("/test")
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK with no middleware"
+          }
 
-            let client = createTestServer (fun _ -> spec)
-            let! (response : HttpResponseMessage) = client.GetAsync("/test")
-            let markers =
-                if response.Headers.Contains("X-Markers") then
-                    response.Headers.GetValues("X-Markers") |> Seq.head
-                else
-                    ""
+          // Tests for plugBeforeRoutingWhen (User Story 1)
+          testTask "plugBeforeRoutingWhen executes middleware when condition is true" {
+              let alwaysTrue (_: IApplicationBuilder) = true
+              let builder = WebHostBuilder([||])
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
-            Expect.isTrue (markers.Contains("conditional,")) "Middleware should execute when condition is true"
-        }
+              let spec =
+                  WebHostSpec.Empty
+                  |> fun s ->
+                      builder.PlugBeforeRoutingWhen(
+                          s,
+                          alwaysTrue,
+                          fun app ->
+                              app.Use(
+                                  Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                      markerMiddleware "conditional" next ctx)
+                              )
+                      )
 
-        testTask "plugBeforeRoutingWhen skips middleware when condition is false" {
-            let alwaysFalse (_: IApplicationBuilder) = false
-            let builder = WebHostBuilder([||])
-            let spec =
-                WebHostSpec.Empty
-                |> fun s -> builder.PlugBeforeRoutingWhen(s, alwaysFalse, fun app ->
-                    app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                        markerMiddleware "conditional" next ctx)))
+              let client = createTestServer (fun _ -> spec)
+              let! (response: HttpResponseMessage) = client.GetAsync("/test")
 
-            let client = createTestServer (fun _ -> spec)
-            let! (response : HttpResponseMessage) = client.GetAsync("/test")
-            let markers =
-                if response.Headers.Contains("X-Markers") then
-                    response.Headers.GetValues("X-Markers") |> Seq.head
-                else
-                    ""
+              let markers =
+                  if response.Headers.Contains("X-Markers") then
+                      response.Headers.GetValues("X-Markers") |> Seq.head
+                  else
+                      ""
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
-            Expect.isFalse (markers.Contains("conditional,")) "Middleware should NOT execute when condition is false"
-        }
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
+              Expect.isTrue (markers.Contains("conditional,")) "Middleware should execute when condition is true"
+          }
 
-        // Tests for plugBeforeRoutingWhenNot (User Story 2)
-        testTask "plugBeforeRoutingWhenNot executes middleware when condition is false" {
-            let alwaysFalse (_: IApplicationBuilder) = false
-            let builder = WebHostBuilder([||])
-            let spec =
-                WebHostSpec.Empty
-                |> fun s -> builder.PlugBeforeRoutingWhenNot(s, alwaysFalse, fun app ->
-                    app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                        markerMiddleware "conditional" next ctx)))
+          testTask "plugBeforeRoutingWhen skips middleware when condition is false" {
+              let alwaysFalse (_: IApplicationBuilder) = false
+              let builder = WebHostBuilder([||])
 
-            let client = createTestServer (fun _ -> spec)
-            let! (response : HttpResponseMessage) = client.GetAsync("/test")
-            let markers =
-                if response.Headers.Contains("X-Markers") then
-                    response.Headers.GetValues("X-Markers") |> Seq.head
-                else
-                    ""
+              let spec =
+                  WebHostSpec.Empty
+                  |> fun s ->
+                      builder.PlugBeforeRoutingWhen(
+                          s,
+                          alwaysFalse,
+                          fun app ->
+                              app.Use(
+                                  Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                      markerMiddleware "conditional" next ctx)
+                              )
+                      )
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
-            Expect.isTrue (markers.Contains("conditional,")) "Middleware should execute when condition is false (WhenNot)"
-        }
+              let client = createTestServer (fun _ -> spec)
+              let! (response: HttpResponseMessage) = client.GetAsync("/test")
 
-        testTask "plugBeforeRoutingWhenNot skips middleware when condition is true" {
-            let alwaysTrue (_: IApplicationBuilder) = true
-            let builder = WebHostBuilder([||])
-            let spec =
-                WebHostSpec.Empty
-                |> fun s -> builder.PlugBeforeRoutingWhenNot(s, alwaysTrue, fun app ->
-                    app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                        markerMiddleware "conditional" next ctx)))
+              let markers =
+                  if response.Headers.Contains("X-Markers") then
+                      response.Headers.GetValues("X-Markers") |> Seq.head
+                  else
+                      ""
 
-            let client = createTestServer (fun _ -> spec)
-            let! (response : HttpResponseMessage) = client.GetAsync("/test")
-            let markers =
-                if response.Headers.Contains("X-Markers") then
-                    response.Headers.GetValues("X-Markers") |> Seq.head
-                else
-                    ""
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
+              Expect.isFalse (markers.Contains("conditional,")) "Middleware should NOT execute when condition is false"
+          }
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
-            Expect.isFalse (markers.Contains("conditional,")) "Middleware should NOT execute when condition is true (WhenNot)"
-        }
+          // Tests for plugBeforeRoutingWhenNot (User Story 2)
+          testTask "plugBeforeRoutingWhenNot executes middleware when condition is false" {
+              let alwaysFalse (_: IApplicationBuilder) = false
+              let builder = WebHostBuilder([||])
 
-        // Tests for composition (User Story 3)
-        testTask "Multiple conditional before-routing middleware compose correctly" {
-            let alwaysTrue (_: IApplicationBuilder) = true
-            let alwaysFalse (_: IApplicationBuilder) = false
-            let builder = WebHostBuilder([||])
-            let spec =
-                WebHostSpec.Empty
-                |> fun s -> builder.PlugBeforeRoutingWhen(s, alwaysTrue, fun app ->
-                    app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                        markerMiddleware "first" next ctx)))
-                |> fun s -> builder.PlugBeforeRoutingWhen(s, alwaysFalse, fun app ->
-                    app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                        markerMiddleware "skipped" next ctx)))
-                |> fun s -> builder.PlugBeforeRoutingWhen(s, alwaysTrue, fun app ->
-                    app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                        markerMiddleware "second" next ctx)))
+              let spec =
+                  WebHostSpec.Empty
+                  |> fun s ->
+                      builder.PlugBeforeRoutingWhenNot(
+                          s,
+                          alwaysFalse,
+                          fun app ->
+                              app.Use(
+                                  Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                      markerMiddleware "conditional" next ctx)
+                              )
+                      )
 
-            let client = createTestServer (fun _ -> spec)
-            let! (response : HttpResponseMessage) = client.GetAsync("/test")
-            let markers =
-                if response.Headers.Contains("X-Markers") then
-                    response.Headers.GetValues("X-Markers") |> Seq.head
-                else
-                    ""
+              let client = createTestServer (fun _ -> spec)
+              let! (response: HttpResponseMessage) = client.GetAsync("/test")
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
-            Expect.isTrue (markers.Contains("first,")) "First middleware should execute"
-            Expect.isFalse (markers.Contains("skipped,")) "Skipped middleware should NOT execute"
-            Expect.isTrue (markers.Contains("second,")) "Second middleware should execute"
-        }
+              let markers =
+                  if response.Headers.Contains("X-Markers") then
+                      response.Headers.GetValues("X-Markers") |> Seq.head
+                  else
+                      ""
 
-        testTask "Conditional before-routing middleware works with regular plugBeforeRouting" {
-            let alwaysTrue (_: IApplicationBuilder) = true
-            let builder = WebHostBuilder([||])
-            let spec =
-                WebHostSpec.Empty
-                |> fun s -> builder.PlugBeforeRouting(s, fun app ->
-                    app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                        markerMiddleware "unconditional" next ctx)))
-                |> fun s -> builder.PlugBeforeRoutingWhen(s, alwaysTrue, fun app ->
-                    app.Use(Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
-                        markerMiddleware "conditional" next ctx)))
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
 
-            let client = createTestServer (fun _ -> spec)
-            let! (response : HttpResponseMessage) = client.GetAsync("/test")
-            let markers =
-                if response.Headers.Contains("X-Markers") then
-                    response.Headers.GetValues("X-Markers") |> Seq.head
-                else
-                    ""
+              Expect.isTrue
+                  (markers.Contains("conditional,"))
+                  "Middleware should execute when condition is false (WhenNot)"
+          }
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
-            Expect.isTrue (markers.Contains("unconditional,")) "Unconditional middleware should execute"
-            Expect.isTrue (markers.Contains("conditional,")) "Conditional middleware should execute"
-        }
-    ]
+          testTask "plugBeforeRoutingWhenNot skips middleware when condition is true" {
+              let alwaysTrue (_: IApplicationBuilder) = true
+              let builder = WebHostBuilder([||])
+
+              let spec =
+                  WebHostSpec.Empty
+                  |> fun s ->
+                      builder.PlugBeforeRoutingWhenNot(
+                          s,
+                          alwaysTrue,
+                          fun app ->
+                              app.Use(
+                                  Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                      markerMiddleware "conditional" next ctx)
+                              )
+                      )
+
+              let client = createTestServer (fun _ -> spec)
+              let! (response: HttpResponseMessage) = client.GetAsync("/test")
+
+              let markers =
+                  if response.Headers.Contains("X-Markers") then
+                      response.Headers.GetValues("X-Markers") |> Seq.head
+                  else
+                      ""
+
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
+
+              Expect.isFalse
+                  (markers.Contains("conditional,"))
+                  "Middleware should NOT execute when condition is true (WhenNot)"
+          }
+
+          // Tests for composition (User Story 3)
+          testTask "Multiple conditional before-routing middleware compose correctly" {
+              let alwaysTrue (_: IApplicationBuilder) = true
+              let alwaysFalse (_: IApplicationBuilder) = false
+              let builder = WebHostBuilder([||])
+
+              let spec =
+                  WebHostSpec.Empty
+                  |> fun s ->
+                      builder.PlugBeforeRoutingWhen(
+                          s,
+                          alwaysTrue,
+                          fun app ->
+                              app.Use(
+                                  Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                      markerMiddleware "first" next ctx)
+                              )
+                      )
+                  |> fun s ->
+                      builder.PlugBeforeRoutingWhen(
+                          s,
+                          alwaysFalse,
+                          fun app ->
+                              app.Use(
+                                  Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                      markerMiddleware "skipped" next ctx)
+                              )
+                      )
+                  |> fun s ->
+                      builder.PlugBeforeRoutingWhen(
+                          s,
+                          alwaysTrue,
+                          fun app ->
+                              app.Use(
+                                  Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                      markerMiddleware "second" next ctx)
+                              )
+                      )
+
+              let client = createTestServer (fun _ -> spec)
+              let! (response: HttpResponseMessage) = client.GetAsync("/test")
+
+              let markers =
+                  if response.Headers.Contains("X-Markers") then
+                      response.Headers.GetValues("X-Markers") |> Seq.head
+                  else
+                      ""
+
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
+              Expect.isTrue (markers.Contains("first,")) "First middleware should execute"
+              Expect.isFalse (markers.Contains("skipped,")) "Skipped middleware should NOT execute"
+              Expect.isTrue (markers.Contains("second,")) "Second middleware should execute"
+          }
+
+          testTask "Conditional before-routing middleware works with regular plugBeforeRouting" {
+              let alwaysTrue (_: IApplicationBuilder) = true
+              let builder = WebHostBuilder([||])
+
+              let spec =
+                  WebHostSpec.Empty
+                  |> fun s ->
+                      builder.PlugBeforeRouting(
+                          s,
+                          fun app ->
+                              app.Use(
+                                  Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                      markerMiddleware "unconditional" next ctx)
+                              )
+                      )
+                  |> fun s ->
+                      builder.PlugBeforeRoutingWhen(
+                          s,
+                          alwaysTrue,
+                          fun app ->
+                              app.Use(
+                                  Func<HttpContext, RequestDelegate, Task>(fun ctx next ->
+                                      markerMiddleware "conditional" next ctx)
+                              )
+                      )
+
+              let client = createTestServer (fun _ -> spec)
+              let! (response: HttpResponseMessage) = client.GetAsync("/test")
+
+              let markers =
+                  if response.Headers.Contains("X-Markers") then
+                      response.Headers.GetValues("X-Markers") |> Seq.head
+                  else
+                      ""
+
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200 OK"
+              Expect.isTrue (markers.Contains("unconditional,")) "Unconditional middleware should execute"
+              Expect.isTrue (markers.Contains("conditional,")) "Conditional middleware should execute"
+          } ]


### PR DESCRIPTION
## Summary

- Switch `WebHostBuilder.Run()` to use `WebApplication.CreateBuilder()` on net10.0+ via `#if NET10_0_OR_GREATER` compiler directive, eliminating deprecated `IWebHostBuilder.Configure()` warnings
- Use `WebApplication.CreateSlimBuilder()` when `useDefaults` is false to preserve the distinction between default and slim host configurations
- net8.0/net9.0 code paths are completely unchanged
- `WebHostSpec` type and all custom operations remain identical — no changes needed in extension libraries (Frank.Auth, Frank.LinkedData, Frank.OpenApi) or sample code
- Update test infrastructure to use `WebApplication.CreateBuilder()` since tests target net10.0 only

## Test plan

- [x] All 3 TFMs (net8.0, net9.0, net10.0) build with zero warnings
- [x] All 17 Frank.Tests pass on net10.0

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)