### PR TITLE
docs: Add design vision for semantic resources and spec pipeline

### DIFF
--- a/docs/SEMANTIC-RESOURCES.md
+++ b/docs/SEMANTIC-RESOURCES.md
@@ -1,0 +1,122 @@
+# Semantic Resources: Agent-Legible Applications
+
+Frank's semantic resource layer makes applications self-describing — not just "here are my routes" but a machine-interpretable model of what the application is, what it does, how it's structured, and how its state changes over time. An agent (LLM or otherwise) with access to this model has enough context to use the application, evaluate it, and propose changes to it.
+
+## The Core Idea
+
+A Frank application augmented with semantic metadata becomes a **reflective artifact** — one that participates in its own evolution. The application doesn't just serve data; it serves a queryable description of itself that enables a feedback loop: build → deploy → reflect → refine → rebuild.
+
+This is inspired by a proven pattern: extraction of structured data into an RDF graph, followed by agent-driven review and refinement of that graph, producing improved outputs. Applied to web applications, the same pattern means an application's data, metadata, and structure can be queried and used to reflect over current behavior and help refine future iterations.
+
+## What "Agent-Legible" Means
+
+An agent interacting with a Frank application over standard HTTP can:
+
+1. **Discover capabilities** — `OPTIONS /` returns supported media types; `Link` headers on any response point to the discovery endpoint
+2. **Retrieve the semantic model** — content negotiation on `GET /` yields RDF representations (`application/ld+json`, `text/turtle`, `application/rdf+xml`) describing the full resource graph
+3. **Inspect affordances** — `Accept: application/alps+json` on `GET /` returns the ALPS profile: semantic descriptors, transition types (`safe`/`unsafe`/`idempotent`), return types, and parameter schemas
+4. **Inspect statecharts** — `Accept: application/scxml+xml` or `Accept: application/vnd.xstate+json` returns the state machine definition for stateful resources
+5. **Query the graph** — the RDF model is structured for use with external SPARQL tools or any graph query mechanism
+
+No custom agent protocol is required. The interface is HTTP with content negotiation — durable standards that predate and will outlast any specific agent framework.
+
+## The Feedback Loop
+
+The semantic layer enables a cycle that operates at two levels:
+
+### Application-Level Reflection
+
+```
+Build Frank app
+    → App serves semantic model (RDF, ALPS, SCXML)
+    → Agent queries model, identifies gaps
+        (e.g., "resource X accepts POST but has no validation constraints")
+    → Agent proposes refinements
+    → Developer (or agent) implements changes
+    → Updated app serves updated model
+    → Cycle continues
+```
+
+### Design-Level Verification
+
+When combined with the [spec pipeline](SPEC-PIPELINE.md), the feedback loop extends to design artifacts:
+
+```
+Design spec (WSD, SCXML, ALPS)
+    → LLM-assisted implementation → Running Frank app
+    → Extract spec from running app
+    → Compare extracted spec against original design
+    → Identify drift, refine design or implementation
+    → Cycle continues
+```
+
+The extracted specs from a running application become verification artifacts for the design intent. See [SPEC-PIPELINE.md](SPEC-PIPELINE.md) for details on the bidirectional pipeline.
+
+## Architecture
+
+The semantic layer comprises four extensions built in dependency order:
+
+```
+Frank.LinkedData (#75)  ──────┬──────────────────┐
+  RDF model, content neg,     │                   │
+  OPTIONS + Link discovery    │                   │
+                              │                   │
+Frank.Statecharts (#87)  ─────┤                   │
+  Runtime state machines      │                   │
+  (see STATECHARTS.md)        │                   │
+                              │                   │
+          Frank.Validation (#76)                  │
+            SHACL constraints                     │
+                              │                   │
+          Frank.Provenance (#77) ─────────────────┤
+            PROV-O state change annotations       │
+                                                  │
+                    (External SPARQL tools) ───────┘
+```
+
+### Frank.LinkedData (#75) — Foundation
+
+Extends Frank resources with an RDF model and content negotiation for semantic media types. This is the foundation everything else builds on. Includes:
+
+- RDF model per resource derived from Frank's existing resource graph
+- Content negotiation for `application/ld+json`, `text/turtle`, `application/rdf+xml`
+- Spec media types via `useAppSpec`: ALPS, SCXML, XState, smcat, Mermaid, PlantUML
+- `OPTIONS` support returning available media types for discovery
+- `Link` headers pointing to the discovery endpoint
+
+### Frank.Validation (#76) — Constraints
+
+SHACL shapes as semantic request/response constraints. Complements F#'s structural type validation with business rule preconditions and cross-resource constraints. Does not need to be exhaustive — even partial SHACL coverage adds value for agent-driven analysis.
+
+### Frank.Provenance (#77) — State Change History
+
+PROV-O annotations for resource state changes, built on `Frank.Statecharts`' `onTransition` observable. Enables agents to reason about *how* the application reached its current state, not just what the state is.
+
+### External SPARQL
+
+Frank does not embed a SPARQL engine. The RDF model is structured so that external SPARQL tools can query it. This keeps Frank lightweight while enabling powerful graph queries for those who need them.
+
+## Design Principles
+
+**Build on durable standards.** HTTP, content negotiation, RDF, ALPS, SCXML — these are decades-old standards that will outlast any specific agent protocol or LLM framework.
+
+**The semantic surface is the interface.** No custom agent protocol, no framework-specific discovery mechanism. An agent that speaks HTTP can understand the application.
+
+**Opt-in, incremental.** A Frank application with zero semantic configuration works exactly as before. Each extension (`useLinkedData`, `useAppSpec`, `useValidation`, `useProvenance`) adds capability without requiring the others.
+
+**Let tooling evolve independently.** Frank provides the semantic model; how agents consume it is not Frank's concern. Today that might be an LLM with HTTP tool use; tomorrow it might be something else entirely.
+
+## Relationship to the Semantic Web
+
+This work draws on ideas from the early Semantic Web vision — a worldwide data graph where applications expose machine-interpretable descriptions of themselves. Frank's ambition is narrower: make individual applications self-describing enough that agents can reason about them. But in doing so, it contributes to the broader idea that applications can participate in a web of structured, queryable, semantically typed data — even if that web starts within a single organization's tools.
+
+## References
+
+- [RDF 1.2](https://www.w3.org/TR/rdf12-concepts/) — Resource Description Framework
+- [ALPS Specification](http://alps.io/spec/drafts/draft-01.html) — Application-Level Profile Semantics
+- [SHACL](https://www.w3.org/TR/shacl/) — Shapes Constraint Language
+- [PROV-O](https://www.w3.org/TR/prov-o/) — Provenance Ontology
+- [JSON-LD](https://www.w3.org/TR/json-ld11/) — JSON for Linking Data
+- [Frank.Statecharts](STATECHARTS.md) — Application-level state machines
+- [Spec Pipeline](SPEC-PIPELINE.md) — Bidirectional design spec pipeline
+- [Comparison with Webmachine and Freya](COMPARISON.md) — How Frank.Statecharts differs from protocol-level state machines

--- a/docs/SPEC-PIPELINE.md
+++ b/docs/SPEC-PIPELINE.md
@@ -1,0 +1,167 @@
+# Spec Pipeline: Bidirectional Design Specifications
+
+The spec pipeline enables a design-first development workflow for Frank applications. Start from a design document in any supported format, use LLM-assisted tooling to generate a working implementation, then extract specifications from the running application to verify and refine the design. The pipeline is bidirectional — every format works as both input and output.
+
+## The Workflow
+
+```
+Design Spec ──→ LLM-assisted codegen ──→ Running Frank app
+     ↑                                         │
+     │                                         │
+     └──── Compare / Refine ←── Extract spec ──┘
+```
+
+A developer sketches an API as a sequence diagram (WSD), a statechart (SCXML), or an affordance profile (ALPS). The LLM parses the spec into a typed AST and generates F# code — state DUs, transition functions, guard stubs, handler wiring. The developer fills in business logic, builds, and runs the application. The running application can then serve its current spec in any supported format via content negotiation, allowing comparison against the original design.
+
+This is a **verification loop**, not a one-shot generator. The extracted spec reflects the implementation as-built, including any refinements made during development. Comparing the extracted spec against the original design reveals intentional divergence (refinements) and unintentional drift (bugs or missed requirements). The comparison is not automated — an LLM or human reviews the two artifacts and judges what to do.
+
+## Format Roles
+
+Three formats form the core trio that together describe a complete application specification. Each models a complementary facet of the same system:
+
+| Format | Models | Intentionally Omits |
+|--------|--------|---------------------|
+| **WSD** | Workflow topology: states, transitions, ordering, parameters | Semantic meaning, HTTP types, data schemas |
+| **SCXML** | Executable statechart: states, transitions, guards, data model, history, invocation | Semantic meaning, HTTP types |
+| **ALPS** | Vocabulary: semantic descriptors, transition types (`safe`/`unsafe`/`idempotent`), return types | Workflow ordering (by design — [FAQ A.2](http://alps.io/spec/drafts/draft-01.html)) |
+
+WSD supplies the workflow constraints that ALPS intentionally omits. SCXML provides the executable state machine definition that WSD describes only topologically. ALPS provides the semantic meaning that both WSD and SCXML lack. Together they give a complete picture: what happens (WSD), how it executes (SCXML), and what it means (ALPS).
+
+Two additional formats add complementary value:
+
+| Format | Role |
+|--------|------|
+| **XState JSON** | JavaScript-ecosystem interop, Stately Studio visualization and simulation |
+| **smcat** | Lightweight text-based state machine notation with visualization |
+
+### Cross-Validation
+
+The formats describe overlapping aspects of the same system, which enables cross-validation:
+
+- Every XState/SCXML event name must exist as an ALPS transition descriptor
+- Every ALPS transition target must exist as an XState/SCXML state
+- WSD actor lifelines must correspond to ALPS state descriptors
+- Guard annotations in WSD must appear in SCXML/XState guard definitions
+
+A cross-format validator (#91) checks these invariants and reports inconsistencies.
+
+## Architecture
+
+```
+         Input Direction (Spec → Code)
+         ─────────────────────────────
+         WSD ──→ WSD AST ──→ ┐
+        SCXML ──→ SCXML AST ──→ ├──→ Typed representation ──→ LLM generates F# code
+         ALPS ──→ ALPS AST ──→ ┘
+        smcat ──→ smcat AST ──→ ┘
+  XState JSON ──→ (trivial) ──→ ┘
+
+         Output Direction (Code → Spec)
+         ──────────────────────────────
+         StateMachineMetadata ──→ WSD Generator ──→ WSD text
+                              ──→ SCXML Generator ──→ SCXML XML
+                              ──→ ALPS Generator ──→ ALPS JSON/XML
+                              ──→ XState Generator ──→ XState JSON
+                              ──→ smcat Generator ──→ smcat text
+```
+
+Each format has its own parser and generator. The parser produces a typed AST; the generator consumes `StateMachineMetadata` (the runtime's reflection type) and produces the format's text/XML/JSON representation.
+
+### Input Direction: LLM-Assisted Code Generation
+
+The "Spec → Code" direction is **intentionally LLM-assisted, not deterministic**. Each parser produces a typed representation that becomes structured context for an LLM prompt. The LLM generates F# code: state DUs, transition functions, guard stubs, handler wiring into Frank's `statefulResource` CE.
+
+This is a deliberate design choice:
+
+- **No template lock-in.** A deterministic generator embeds opinions about code structure that may not match the developer's preferences. An LLM adapts to the project's existing patterns.
+- **Typed ASTs are the public interface.** The parser output is stable; the code generation strategy can evolve independently. A developer who wants to build a different tool — a deterministic generator, a type provider, a VS Code extension — can consume the same typed ASTs.
+- **Correctness comes from the verification loop.** Rather than trying to guarantee correct generation, the pipeline extracts the spec back from the running code and compares. This is more robust than template-based guarantees.
+
+### Output Direction: Spec Extraction
+
+The output direction reads `StateMachineMetadata` from a running Frank application (or from compiled assemblies via reflection) and generates spec documents. This is deterministic — the generators produce canonical representations of the current implementation.
+
+The extracted specs serve multiple purposes:
+
+- **Verification**: compare against the original design spec
+- **Documentation**: serve via content negotiation (`GET /` with `Accept: application/scxml+xml`)
+- **Visualization**: feed into Stately Studio (XState), smcat renderer, app-state-diagram (ALPS)
+- **Interop**: export to tools in other ecosystems
+
+## WSD Guard Extension
+
+For per-user state discrimination (e.g., turn-based games), WSD is extended with guard annotations using existing `note` syntax. This preserves compatibility with websequencediagrams.com rendering:
+
+```
+note over WaitingForX: [guard: role=PlayerX]
+WaitingForX->+WaitingForO: makeMove(position)
+note over WaitingForO: [guard: role=PlayerO]
+WaitingForO->+WaitingForX: makeMove(position)
+```
+
+Guards flow into ALPS via `ext` elements (ALPS's designated extension point) and into SCXML/XState as native guard definitions.
+
+## WSD → ALPS Mapping
+
+Starting from [Amundsen's onboarding example](https://mamund.site44.com/talks/2018-09-restfest/2018-09-restfest-wsd.pdf):
+
+| WSD Arrow | WSD Meaning | ALPS Type | HTTP |
+|-----------|-------------|-----------|------|
+| `->` solid forward | Sync call, activates target | `unsafe` | POST |
+| `-->` dashed forward | Async/optional, activates target | `unsafe` | POST |
+| `->-` solid deactivates | Return from activation | `safe` | GET |
+| `-->-` dashed deactivates | Async return | `safe` | GET |
+
+WSD parameters become ALPS semantic descriptors. WSD actor lifelines become ALPS state descriptors with available transitions nested inside. WSD target states become ALPS `rt` (return type).
+
+## Implementation Phases
+
+The pipeline is tracked in [#57](https://github.com/frank-fs/frank/issues/57) with sub-issues per format.
+
+### Priority Order
+
+1. **WSD Parser (#90)** — critical path, already partially exists in [wsd-gen F# fork](https://github.com/panesofglass/wsd-gen/tree/fsharp)
+2. **WSD Generator + Cross-Validator (#91)** — depends on #90, enables the verification loop for WSD
+3. **ALPS (#97), SCXML (#98), smcat (#100)** — bidirectional, depend only on the core runtime (#87). Can proceed in parallel with each other and with #90
+4. **frank-cli commands (#94)** — depends on all format issues; provides `extract`, `generate`, `validate`, `import` subcommands
+5. **Automatic ETag from state (#93)** — parallel with everything; no pipeline dependency
+
+### Dependency Graph
+
+```
+#90 WSD Parser ──────────────→ #91 WSD Generator + Cross-Validator ┐
+(P0, critical path)            (P1)                                 │
+                                                                    ├──→ #94 frank-cli Commands
+#87 Core Runtime ────────┬───→ #97 ALPS Parser + Generator ────────┤    (P3)
+(prerequisite, done)     ├───→ #98 SCXML Parser + Generator ───────┤
+                         ├───→ #100 smcat Parser + Generator ──────┘
+                         └───→ #93 ETag Generation
+                               (P2, parallel)
+```
+
+## Round-Trip Expectations
+
+A design spec fed through the pipeline (spec → code → extract spec) will not produce an identical document. Implementation refines the design: states may be renamed, guards added, transitions adjusted. The extracted spec reflects the implementation as-built.
+
+What *should* be preserved is **structural equivalence** at the state machine level: the same states exist, the same transitions connect them, the same guards protect them. Surface differences (naming, ordering, comments, formatting) are expected and acceptable. The cross-validator checks structural invariants; an LLM or human judges semantic equivalence.
+
+## CLI Integration
+
+`frank-cli` (#94) provides commands that wrap the pipeline for common workflows:
+
+- `frank extract` — generate spec documents from a compiled Frank application
+- `frank generate` — generate F# scaffolding from a spec document (LLM-assisted)
+- `frank validate` — cross-validate spec documents against each other and/or a running app
+- `frank import` — parse a spec document and produce the typed AST (useful for tooling)
+
+## References
+
+- [Mike Amundsen: Using Web Sequence Diagrams with your APIs (RESTFest 2018)](https://mamund.site44.com/talks/2018-09-restfest/2018-09-restfest-wsd.pdf)
+- [State Transitions through Sequence Diagrams (F# Advent 2018)](https://wizardsofsmart.wordpress.com/2018/12/05/state-transitions-through-sequence-diagrams/)
+- [ALPS Specification](http://alps.io/spec/drafts/draft-01.html)
+- [SCXML W3C Recommendation](https://www.w3.org/TR/scxml/) — State Chart XML standard
+- [smcat (state machine cat)](https://github.com/sverweij/state-machine-cat) — lightweight state machine notation
+- [XState / Stately](https://stately.ai/) — state machine validation and visual editing
+- [app-state-diagram (ASD)](https://github.com/alps-asd/app-state-diagram) — generates state diagrams from ALPS
+- [Frank.Statecharts](STATECHARTS.md) — Runtime state machine library
+- [Semantic Resources](SEMANTIC-RESOURCES.md) — Agent-legible application architecture

--- a/docs/STATECHARTS.md
+++ b/docs/STATECHARTS.md
@@ -2,6 +2,8 @@
 
 Frank.Statecharts adds application-level state machines to Frank, enabling resources whose HTTP surface changes based on persisted domain state. Each resource instance has its own state, and the framework enforces which HTTP methods are available, evaluates guards, and manages transitions automatically.
 
+State machines can be defined directly in F# (as shown below) or generated from design specifications such as SCXML, WSD, or ALPS profiles. See [SPEC-PIPELINE.md](SPEC-PIPELINE.md) for the design-to-implementation workflow.
+
 For how this differs from Webmachine and Freya, see [COMPARISON.md](COMPARISON.md).
 
 ## Core Concepts
@@ -201,3 +203,9 @@ The integration test suite validates:
 - **Hierarchical statecharts** -- nested DU states, sub-state transitions, top-level transitions, cross-hierarchy guards, context-aware participant guards
 
 See [`test/Frank.Statecharts.Tests/`](../test/Frank.Statecharts.Tests/) for the full test suite.
+
+## See Also
+
+- [SPEC-PIPELINE.md](SPEC-PIPELINE.md) — Bidirectional design spec pipeline: how statecharts are designed from WSD/SCXML/ALPS and extracted from running applications for verification
+- [SEMANTIC-RESOURCES.md](SEMANTIC-RESOURCES.md) — How statecharts participate in the semantic layer, enabling agent-legible applications
+- [COMPARISON.md](COMPARISON.md) — How Frank.Statecharts differs from Webmachine and Freya


### PR DESCRIPTION
## Summary

- Adds `docs/SEMANTIC-RESOURCES.md` — captures the overarching vision for agent-legible applications: the reflection/refinement feedback loop, how #57 and #80 connect, and why Frank builds on durable standards (HTTP, RDF, ALPS) rather than agent-specific protocols
- Adds `docs/SPEC-PIPELINE.md` — documents the bidirectional design spec pipeline: WSD + SCXML + ALPS as the core trio, verification loop, LLM-assisted codegen philosophy, round-trip expectations, and CLI integration
- Updates `docs/STATECHARTS.md` — adds cross-references to the new design docs (one-liner in intro about external spec derivation + See Also section)

These design documents frame the vision that was previously implicit across #57 and #80 but never stated end-to-end. They are intended to guide future issue creation and planning.

Related: #57, #80, #87

## Test plan

- [x] Verify markdown renders correctly on GitHub
- [x] Verify all cross-references between the three docs resolve
- [x] Review content accuracy against #57 and #80 issue descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)