### PR TITLE
feat: add role definition schema for statefulResource

### DIFF
--- a/src/Frank.Cli.Core/Statechart/StatechartExtractor.fs
+++ b/src/Frank.Cli.Core/Statechart/StatechartExtractor.fs
@@ -13,9 +13,11 @@ module StatechartExtractor =
         (initialStateKey: string)
         (guardNames: string list)
         (stateMetadata: Map<string, StateInfo>)
+        (roles: RoleInfo list)
         =
         { RouteTemplate = routeTemplate
           StateNames = stateNames
           InitialStateKey = initialStateKey
           GuardNames = guardNames
-          StateMetadata = stateMetadata }
+          StateMetadata = stateMetadata
+          Roles = roles }

--- a/src/Frank.Cli.Core/Statechart/StatechartSourceExtractor.fs
+++ b/src/Frank.Cli.Core/Statechart/StatechartSourceExtractor.fs
@@ -328,7 +328,7 @@ let private buildExtractedStatecharts
                   Description = None })
             |> Map.ofList
 
-        StatechartExtractor.toExtractedStatechart sr.RouteTemplate stateNames initialStateKey guardNames stateMetadata)
+        StatechartExtractor.toExtractedStatechart sr.RouteTemplate stateNames initialStateKey guardNames stateMetadata [])
 
 // ── Public API ──
 

--- a/src/Frank.Cli.Core/Unified/UnifiedExtractor.fs
+++ b/src/Frank.Cli.Core/Unified/UnifiedExtractor.fs
@@ -614,7 +614,7 @@ let private buildUnifiedResources
                 |> Map.ofList
 
             let statechart =
-                StatechartExtractor.toExtractedStatechart route stateNames initialStateKey guardNames stateMetadata
+                StatechartExtractor.toExtractedStatechart route stateNames initialStateKey guardNames stateMetadata []
 
             let capabilities =
                 stateHandlers

--- a/src/Frank.Resources.Model/ResourceTypes.fs
+++ b/src/Frank.Resources.Model/ResourceTypes.fs
@@ -33,6 +33,13 @@ module ProjectedProfiles =
         && Map.isEmpty profiles.ShaclShapes
         && Map.isEmpty profiles.JsonSchemas
 
+/// Portable, zero-dependency role representation for spec pipeline consumers.
+/// Hierarchy-neutral — does not assume flat or hierarchical state structures.
+[<Struct>]
+type RoleInfo =
+    { Name: string
+      Description: string option }
+
 /// Structured representation of a single stateful resource extracted from source.
 /// String keys (StateNames, InitialStateKey, GuardNames) are F# DU case names
 /// derived from the state type at compile time (e.g., "XTurn", "GameOver").
@@ -41,7 +48,8 @@ type ExtractedStatechart =
       StateNames: string list
       InitialStateKey: string
       GuardNames: string list
-      StateMetadata: Map<string, StateInfo> }
+      StateMetadata: Map<string, StateInfo>
+      Roles: RoleInfo list }
 
 /// HTTP capability for a resource, optionally scoped to a state.
 type HttpCapability =

--- a/src/Frank.Statecharts/Frank.Statecharts.fsproj
+++ b/src/Frank.Statecharts/Frank.Statecharts.fsproj
@@ -47,6 +47,7 @@
     <Compile Include="Validation/Pipeline.fs" />
     <!-- Builder and generators (depend on both core types and format types) -->
     <Compile Include="StatechartFeature.fs" />
+    <Compile Include="RoleFeature.fs" />
     <Compile Include="StatefulResourceBuilder.fs" />
     <Compile Include="Wsd/Generator.fs" />
     <Compile Include="Smcat/Generator.fs" />

--- a/src/Frank.Statecharts/Middleware.fs
+++ b/src/Frank.Statecharts/Middleware.fs
@@ -50,6 +50,11 @@ type StateMachineMiddleware(next: RequestDelegate) =
             // Step 1: Look up current state from store (caches typed state in HttpContext.Items)
             let! stateKey = meta.GetCurrentStateKey ctx.RequestServices ctx instanceId
 
+            // Step 1.5: Resolve roles for current user (skip if no roles declared)
+            if not (List.isEmpty meta.Roles) then
+                let resolvedRoles = meta.ResolveRoles ctx
+                ctx.SetRoles(resolvedRoles)
+
             // Step 2: Check if HTTP method is allowed in current state
             match Map.tryFind stateKey meta.StateHandlerMap with
             | None -> ctx.Response.StatusCode <- 405

--- a/src/Frank.Statecharts/RoleFeature.fs
+++ b/src/Frank.Statecharts/RoleFeature.fs
@@ -1,0 +1,24 @@
+namespace Frank.Statecharts
+
+open Microsoft.AspNetCore.Http
+
+/// Typed feature for resolved roles, registered on HttpContext.Features.
+/// Non-generic — roles are always Set<string>.
+type IRoleFeature =
+    abstract Roles: Set<string>
+
+/// Extension methods for reading/writing resolved roles via HttpContext.Features.
+[<AutoOpen>]
+module HttpContextRoleExtensions =
+    type HttpContext with
+
+        member ctx.GetRoles() : Set<string> =
+            let f = ctx.Features.Get<IRoleFeature>()
+            if obj.ReferenceEquals(f, null) then Set.empty else f.Roles
+
+        member ctx.SetRoles(roles: Set<string>) =
+            let feature =
+                { new IRoleFeature with
+                    member _.Roles = roles }
+
+            ctx.Features.Set<IRoleFeature>(feature)

--- a/src/Frank.Statecharts/StatefulResourceBuilder.fs
+++ b/src/Frank.Statecharts/StatefulResourceBuilder.fs
@@ -8,6 +8,7 @@ open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Http
 open Microsoft.AspNetCore.Routing
 open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Logging
 open Frank.Resources.Model
 open Frank.Builder
 
@@ -81,6 +82,10 @@ type StateMachineMetadata =
         EvaluateEventGuards: HttpContext -> GuardResult
         /// Post-handler: get event from HttpContext.Items, read state/context from IStatechartFeature, run transition, persist, return result.
         ExecuteTransition: IServiceProvider -> HttpContext -> string -> Task<TransitionAttemptResult>
+        /// Role definitions for this resource (for spec pipeline extraction).
+        Roles: RoleDefinition list
+        /// Closure: evaluates role predicates against ctx.User, returns Set<string> of matching role names.
+        ResolveRoles: HttpContext -> Set<string>
     }
 
 /// Per-state handler accumulator used during CE evaluation.
@@ -105,7 +110,8 @@ type StatefulResourceSpec<'State, 'Event, 'Context when 'State: equality and 'St
       StateHandlerMap: Map<string, (string * RequestDelegate) list>
       TransitionObservers: (TransitionEvent<'State, 'Event, 'Context> -> unit) list
       ResolveInstanceId: (HttpContext -> string) option
-      Metadata: (EndpointBuilder -> unit) list }
+      Metadata: (EndpointBuilder -> unit) list
+      Roles: RoleDefinition list }
 
 /// Helper functions for building per-state handler lists.
 [<RequireQualifiedAccess>]
@@ -141,7 +147,8 @@ type StatefulResourceBuilder(routeTemplate: string) =
           StateHandlerMap = Map.empty
           TransitionObservers = []
           ResolveInstanceId = None
-          Metadata = [] }
+          Metadata = []
+          Roles = [] }
 
     /// Register a pre-built state machine definition.
     [<CustomOperation("machine")>]
@@ -171,6 +178,12 @@ type StatefulResourceBuilder(routeTemplate: string) =
         { spec with
             ResolveInstanceId = Some resolver }
 
+    /// Declare a named role with an identity-matching predicate.
+    [<CustomOperation("role")>]
+    member _.Role(spec: StatefulResourceSpec<'S, 'E, 'C>, name: string, predicate: ClaimsPrincipal -> bool) =
+        { spec with
+            Roles = { Name = name; ClaimsPredicate = predicate } :: spec.Roles }
+
     member _.Run(spec: StatefulResourceSpec<'S, 'E, 'C>) : Resource =
         let machine =
             spec.Machine
@@ -182,6 +195,49 @@ type StatefulResourceBuilder(routeTemplate: string) =
                 fun (ctx: HttpContext) ->
                     let routeData = ctx.GetRouteData()
                     routeData.Values.Values |> Seq.head |> string)
+
+        // Validate role definitions — fail fast on duplicates or empty names
+        let emptyNames = spec.Roles |> List.filter (fun r -> String.IsNullOrWhiteSpace r.Name)
+
+        if not (List.isEmpty emptyNames) then
+            failwithf "Empty role name on resource '%s'" routeTemplate
+
+        let roleNames = spec.Roles |> List.map (fun r -> r.Name)
+
+        let duplicates =
+            roleNames
+            |> List.groupBy id
+            |> List.filter (fun (_, g) -> g.Length > 1)
+            |> List.map fst
+
+        if not (List.isEmpty duplicates) then
+            failwithf "Duplicate role names on resource '%s': %s" routeTemplate (String.concat ", " duplicates)
+
+        // Closure: evaluate role predicates against ctx.User, catch exceptions per-role
+        let resolveRoles (ctx: HttpContext) : Set<string> =
+            if List.isEmpty spec.Roles then
+                Set.empty
+            else
+                let logger =
+                    ctx.RequestServices.GetRequiredService<ILoggerFactory>().CreateLogger("Frank.Statecharts.RoleResolution")
+
+                spec.Roles
+                |> List.choose (fun role ->
+                    try
+                        if role.ClaimsPredicate ctx.User then
+                            Some role.Name
+                        else
+                            None
+                    with ex ->
+                        logger.LogWarning(
+                            ex,
+                            "Role predicate '{RoleName}' threw an exception for resource '{RouteTemplate}'",
+                            role.Name,
+                            routeTemplate
+                        )
+
+                        None)
+                |> Set.ofList
 
         // Precomputed state key extractor: DU case name for unions, ToString() for others.
         let stateKey (state: 'S) = StateKeyExtractor.keyOf state
@@ -226,7 +282,8 @@ type StatefulResourceBuilder(routeTemplate: string) =
             let guardCtx: AccessControlContext<'S, 'C> =
                 { User = ctx.User
                   CurrentState = state
-                  Context = context }
+                  Context = context
+                  Roles = ctx.GetRoles() }
 
             accessGuards
             |> List.tryPick (fun (_, pred) ->
@@ -248,7 +305,8 @@ type StatefulResourceBuilder(routeTemplate: string) =
                     { User = ctx.User
                       CurrentState = state
                       Event = event
-                      Context = context }
+                      Context = context
+                      Roles = ctx.GetRoles() }
 
                 eventGuards
                 |> List.tryPick (fun (_, pred) ->
@@ -316,7 +374,9 @@ type StatefulResourceBuilder(routeTemplate: string) =
               GetCurrentStateKey = getCurrentStateKey
               EvaluateGuards = evaluateGuards
               EvaluateEventGuards = evaluateEventGuards
-              ExecuteTransition = executeTransition }
+              ExecuteTransition = executeTransition
+              Roles = spec.Roles
+              ResolveRoles = resolveRoles }
 
         // Collect distinct HTTP methods across all states.
         // Middleware dispatches the real state-specific handler; endpoints just need routing targets.

--- a/src/Frank.Statecharts/Types.fs
+++ b/src/Frank.Statecharts/Types.fs
@@ -19,17 +19,32 @@ type GuardResult =
     | Blocked of reason: BlockReason
 
 /// Context for access-control guards (pre-handler). No event available.
+[<NoEquality; NoComparison>]
 type AccessControlContext<'State, 'Context> =
     { User: ClaimsPrincipal
       CurrentState: 'State
-      Context: 'Context }
+      Context: 'Context
+      Roles: Set<string> }
+
+    member this.HasRole(roleName: string) = this.Roles.Contains(roleName)
 
 /// Context for event-validation guards (post-handler). Event is the actual value set by the handler.
+[<NoEquality; NoComparison>]
 type EventValidationContext<'State, 'Event, 'Context> =
     { User: ClaimsPrincipal
       CurrentState: 'State
       Event: 'Event
-      Context: 'Context }
+      Context: 'Context
+      Roles: Set<string> }
+
+    member this.HasRole(roleName: string) = this.Roles.Contains(roleName)
+
+/// Named role with identity-matching predicate.
+/// Per-resource, not global. The predicate is the source of truth for runtime evaluation.
+[<NoEquality; NoComparison>]
+type RoleDefinition =
+    { Name: string
+      ClaimsPredicate: ClaimsPrincipal -> bool }
 
 /// A guard that controls access to state transitions.
 /// The DU case determines both execution phase and type signature.

--- a/test/Frank.Cli.Core.Tests/Unified/AffordanceMapGeneratorTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/AffordanceMapGeneratorTests.fs
@@ -41,7 +41,8 @@ let private ticTacToeResource: UnifiedResource =
               { IsFinal = true
                 AllowedMethods = [ "GET" ]
                 Description = None } ]
-            |> Map.ofList }
+            |> Map.ofList
+          Roles = [] }
 
     { RouteTemplate = "/games/{gameId}"
       ResourceSlug = "games"

--- a/test/Frank.Cli.Core.Tests/Unified/UnifiedAlpsGeneratorTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/UnifiedAlpsGeneratorTests.fs
@@ -72,7 +72,8 @@ let private ticTacToeStatechart: ExtractedStatechart =
           { IsFinal = true
             AllowedMethods = [ "GET" ]
             Description = None } ]
-        |> Map.ofList }
+        |> Map.ofList
+      Roles = [] }
 
 let private ticTacToeResource: UnifiedResource =
     { RouteTemplate = "/games/{gameId}"

--- a/test/Frank.Cli.Core.Tests/Unified/UnifiedExtractorTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/UnifiedExtractorTests.fs
@@ -208,7 +208,8 @@ let game = statefulResource "/games/{gameId}" {
                               "OTurn", { IsFinal = false; AllowedMethods = [ "GET"; "POST" ]; Description = None }
                               "Won", { IsFinal = true; AllowedMethods = [ "GET" ]; Description = None }
                               "Draw", { IsFinal = true; AllowedMethods = [ "GET" ]; Description = None } ]
-                            |> Map.ofList }
+                            |> Map.ofList
+                          Roles = [] }
 
                     let resource =
                         { RouteTemplate = "/games/{gameId}"
@@ -239,7 +240,8 @@ let game = statefulResource "/games/{gameId}" {
                           StateNames = [ "XTurn"; "OTurn" ]
                           InitialStateKey = "XTurn"
                           GuardNames = []
-                          StateMetadata = Map.empty }
+                          StateMetadata = Map.empty
+                          Roles = [] }
 
                     let stateType =
                         { FullName = "Test.GameState"
@@ -273,7 +275,8 @@ let game = statefulResource "/games/{gameId}" {
                           StateNames = [ "Playing"; "Won" ]
                           InitialStateKey = "Playing"
                           GuardNames = []
-                          StateMetadata = Map.empty }
+                          StateMetadata = Map.empty
+                          Roles = [] }
 
                     let stateType =
                         { FullName = "Test.GameState"
@@ -325,7 +328,8 @@ let game = statefulResource "/games/{gameId}" {
                           StateNames = [ "A"; "B" ]
                           InitialStateKey = "A"
                           GuardNames = []
-                          StateMetadata = Map.empty }
+                          StateMetadata = Map.empty
+                          Roles = [] }
 
                     let stateType =
                         { FullName = "Test.State"

--- a/test/Frank.Statecharts.Tests/Smcat/GeneratorTests.fs
+++ b/test/Frank.Statecharts.Tests/Smcat/GeneratorTests.fs
@@ -50,7 +50,9 @@ let private makeMetadata
       GetCurrentStateKey = fun _ _ _ -> Task.FromResult(initialKey)
       EvaluateGuards = fun _ -> Allowed
       EvaluateEventGuards = fun _ -> Allowed
-      ExecuteTransition = fun _ _ _ -> Task.FromResult(TransitionAttemptResult.NoEvent) }
+      ExecuteTransition = fun _ _ _ -> Task.FromResult(TransitionAttemptResult.NoEvent)
+      Roles = []
+      ResolveRoles = fun _ -> Set.empty }
 
 let private simpleMachine guards stateMetadata : StateMachine<TestState, TestEvent, unit> =
     { Initial = Idle

--- a/test/Frank.Statecharts.Tests/StatechartETagProviderTests.fs
+++ b/test/Frank.Statecharts.Tests/StatechartETagProviderTests.fs
@@ -210,7 +210,9 @@ let factoryTests =
                     EvaluateGuards = fun _ -> Allowed
                     EvaluateEventGuards = fun _ -> Allowed
                     ExecuteTransition =
-                      fun _ _ _ -> System.Threading.Tasks.Task.FromResult(TransitionAttemptResult.NoEvent) }
+                      fun _ _ _ -> System.Threading.Tasks.Task.FromResult(TransitionAttemptResult.NoEvent)
+                    Roles = []
+                    ResolveRoles = fun _ -> Set.empty }
 
               let endpoint =
                   Endpoint(null, EndpointMetadataCollection(metadata :> obj), "test-endpoint")

--- a/test/Frank.Statecharts.Tests/StatefulResourceTests.fs
+++ b/test/Frank.Statecharts.Tests/StatefulResourceTests.fs
@@ -1511,3 +1511,389 @@ let simpleDuBackwardCompatibilityTests =
                   "Playing (Won X) -> Playing"
 
               Expect.equal (stateKeyOf Disposed) "Disposed" "Disposed -> Disposed" ]
+
+// === Role Definition Tests ===
+
+let private getRolesHandler (ctx: HttpContext) : Task =
+    let roles = ctx.GetRoles()
+    ctx.Response.WriteAsync(String.Join(",", roles |> Set.toList |> List.sort))
+
+let private addRoleTestStore (services: IServiceCollection) =
+    services.AddStateMachineStore<MiddlewareTests.TestState, int>() |> ignore
+
+let private withRoleServer (resource: Resource) configUser (f: HttpClient -> Task) =
+    task {
+        let server = MiddlewareTests.buildTestServer resource addRoleTestStore configUser
+        let client = server.CreateClient()
+
+        try
+            do! f client
+        finally
+            client.Dispose()
+            server.Dispose()
+    }
+    :> Task
+
+[<Tests>]
+let roleDefinitionTests =
+    testList
+        "Role definitions"
+        [ testCase "T019: role declarations appear in endpoint metadata"
+          <| fun () ->
+              let resource =
+                  statefulResource "/test/{id}" {
+                      machine MiddlewareTests.testMachine
+                      resolveInstanceId (fun ctx -> "1")
+                      role "RoleA" (fun claims -> claims.HasClaim("role", "a"))
+                      role "RoleB" (fun claims -> claims.HasClaim("role", "b"))
+
+                      inState (
+                          forState MiddlewareTests.Active [ StateHandlerBuilder.get (fun _ -> Task.CompletedTask) ]
+                      )
+                  }
+
+              let endpoint = resource.Endpoints[0]
+              let metadata = endpoint.Metadata.GetMetadata<StateMachineMetadata>()
+              Expect.isNotNull (box metadata) "should have StateMachineMetadata"
+              let roleNames = metadata.Roles |> List.map (fun r -> r.Name) |> List.sort
+              Expect.equal roleNames [ "RoleA"; "RoleB" ] "should have both roles"
+
+          testCase "T020: duplicate role names rejected at startup"
+          <| fun () ->
+              try
+                  statefulResource "/test/{id}" {
+                      machine MiddlewareTests.testMachine
+                      resolveInstanceId (fun ctx -> "1")
+                      role "Same" (fun _ -> true)
+                      role "Same" (fun _ -> false)
+
+                      inState (
+                          forState MiddlewareTests.Active [ StateHandlerBuilder.get (fun _ -> Task.CompletedTask) ]
+                      )
+                  }
+                  |> ignore
+
+                  failtest "should have thrown on duplicate role names"
+              with ex ->
+                  Expect.stringContains ex.Message "Duplicate role names" "error should mention duplicate names"
+
+          testCase "T021: role resolution with different identities"
+          <| fun () ->
+              let resource =
+                  statefulResource "/roles/{id}" {
+                      machine MiddlewareTests.testMachine
+                      resolveInstanceId (fun _ -> "1")
+                      role "RoleA" (fun claims -> claims.HasClaim("role", "a"))
+                      role "RoleB" (fun claims -> claims.HasClaim("role", "b"))
+                      role "Observer" (fun _ -> true)
+
+                      inState (
+                          forState MiddlewareTests.Active [ StateHandlerBuilder.get getRolesHandler ]
+                      )
+                  }
+
+              // User with role=a should get RoleA and Observer
+              let userA =
+                  ClaimsPrincipal(ClaimsIdentity([| Claim("role", "a") |], "test"))
+
+              (withRoleServer resource (Some userA) (fun client ->
+                  task {
+                      let! (resp: HttpResponseMessage) = client.GetAsync("/roles/1")
+                      Expect.equal resp.StatusCode HttpStatusCode.OK "should be 200 for role=a user"
+                      let! body = resp.Content.ReadAsStringAsync()
+                      let parts = body.Split(',') |> Set.ofArray
+                      Expect.isTrue (parts.Contains "RoleA") "RoleA should be resolved for role=a"
+                      Expect.isTrue (parts.Contains "Observer") "Observer should always resolve"
+                      Expect.isFalse (parts.Contains "RoleB") "RoleB should not resolve for role=a"
+                  }))
+                  .GetAwaiter()
+                  .GetResult()
+
+              // User with role=b should get RoleB and Observer
+              let userB =
+                  ClaimsPrincipal(ClaimsIdentity([| Claim("role", "b") |], "test"))
+
+              (withRoleServer resource (Some userB) (fun client ->
+                  task {
+                      let! (resp: HttpResponseMessage) = client.GetAsync("/roles/1")
+                      Expect.equal resp.StatusCode HttpStatusCode.OK "should be 200 for role=b user"
+                      let! body = resp.Content.ReadAsStringAsync()
+                      let parts = body.Split(',') |> Set.ofArray
+                      Expect.isTrue (parts.Contains "RoleB") "RoleB should be resolved for role=b"
+                      Expect.isTrue (parts.Contains "Observer") "Observer should always resolve"
+                      Expect.isFalse (parts.Contains "RoleA") "RoleA should not resolve for role=b"
+                  }))
+                  .GetAwaiter()
+                  .GetResult()
+
+          testCase "T021B: anonymous user matches only predicate-based roles"
+          <| fun () ->
+              let resource =
+                  statefulResource "/roles/{id}" {
+                      machine MiddlewareTests.testMachine
+                      resolveInstanceId (fun _ -> "1")
+                      role "RoleA" (fun claims -> claims.HasClaim("role", "a"))
+                      role "RoleB" (fun claims -> claims.HasClaim("role", "b"))
+                      role "Observer" (fun _ -> true)
+
+                      inState (
+                          forState MiddlewareTests.Active [ StateHandlerBuilder.get getRolesHandler ]
+                      )
+                  }
+
+              // Anonymous user (no auth type) should match only Observer
+              let anonymous = ClaimsPrincipal(ClaimsIdentity())
+
+              (withRoleServer resource (Some anonymous) (fun client ->
+                  task {
+                      let! (resp: HttpResponseMessage) = client.GetAsync("/roles/1")
+                      Expect.equal resp.StatusCode HttpStatusCode.OK "should be 200 for anonymous user"
+                      let! body = resp.Content.ReadAsStringAsync()
+                      let parts = body.Split(',') |> Array.filter (fun s -> s <> "") |> Set.ofArray
+                      Expect.isTrue (parts.Contains "Observer") "Observer should resolve for anonymous user"
+                      Expect.isFalse (parts.Contains "RoleA") "RoleA should not resolve for anonymous user"
+                      Expect.isFalse (parts.Contains "RoleB") "RoleB should not resolve for anonymous user"
+                  }))
+                  .GetAwaiter()
+                  .GetResult()
+
+          testCase "T021C: user with all claims matches all roles"
+          <| fun () ->
+              let resource =
+                  statefulResource "/roles/{id}" {
+                      machine MiddlewareTests.testMachine
+                      resolveInstanceId (fun _ -> "1")
+                      role "RoleA" (fun claims -> claims.HasClaim("role", "a"))
+                      role "RoleB" (fun claims -> claims.HasClaim("role", "b"))
+                      role "Observer" (fun _ -> true)
+
+                      inState (
+                          forState MiddlewareTests.Active [ StateHandlerBuilder.get getRolesHandler ]
+                      )
+                  }
+
+              // User with both claims should match all three roles
+              let superUser =
+                  ClaimsPrincipal(ClaimsIdentity([| Claim("role", "a"); Claim("role", "b") |], "test"))
+
+              (withRoleServer resource (Some superUser) (fun client ->
+                  task {
+                      let! (resp: HttpResponseMessage) = client.GetAsync("/roles/1")
+                      Expect.equal resp.StatusCode HttpStatusCode.OK "should be 200 for user with all claims"
+                      let! body = resp.Content.ReadAsStringAsync()
+                      Expect.equal body "Observer,RoleA,RoleB" "all three roles should be resolved and sorted"
+                  }))
+                  .GetAwaiter()
+                  .GetResult()
+
+          testCase "T022: HasRole in guards allows matching role and blocks others"
+          <| fun () ->
+              let roleGuardMachine: StateMachine<MiddlewareTests.TestState, MiddlewareTests.TestEvent, int> =
+                  { MiddlewareTests.testMachine with
+                      Guards =
+                          [ AccessControl(
+                                "RequireAllowed",
+                                fun ctx ->
+                                    if ctx.HasRole "Allowed" then
+                                        Allowed
+                                    else
+                                        Blocked NotAllowed
+                            ) ] }
+
+              let resource =
+                  statefulResource "/guarded-role/{id}" {
+                      machine roleGuardMachine
+                      resolveInstanceId (fun _ -> "1")
+                      role "Allowed" (fun claims -> claims.HasClaim("access", "granted"))
+
+                      inState (
+                          forState
+                              MiddlewareTests.Active
+                              [ StateHandlerBuilder.get (fun ctx -> ctx.Response.WriteAsync("ok")) ]
+                      )
+                  }
+
+              // User with access=granted should get Allowed role -> 200
+              let allowedUser =
+                  ClaimsPrincipal(ClaimsIdentity([| Claim("access", "granted") |], "test"))
+
+              (withRoleServer resource (Some allowedUser) (fun client ->
+                  task {
+                      let! (resp: HttpResponseMessage) = client.GetAsync("/guarded-role/1")
+                      Expect.equal resp.StatusCode HttpStatusCode.OK "allowed user should get 200"
+                  }))
+                  .GetAwaiter()
+                  .GetResult()
+
+              // User without access=granted should not get Allowed role -> 403
+              let deniedUser =
+                  ClaimsPrincipal(ClaimsIdentity([| Claim("access", "denied") |], "test"))
+
+              (withRoleServer resource (Some deniedUser) (fun client ->
+                  task {
+                      let! (resp: HttpResponseMessage) = client.GetAsync("/guarded-role/1")
+                      Expect.equal resp.StatusCode HttpStatusCode.Forbidden "denied user should get 403"
+                  }))
+                  .GetAwaiter()
+                  .GetResult()
+
+          testCase "T022C: HasRole with undeclared role name always blocks"
+          <| fun () ->
+              let undeclaredRoleGuardMachine: StateMachine<MiddlewareTests.TestState, MiddlewareTests.TestEvent, int> =
+                  { MiddlewareTests.testMachine with
+                      Guards =
+                          [ AccessControl(
+                                "RequireNonexistent",
+                                fun ctx ->
+                                    if ctx.HasRole "NonexistentRole" then
+                                        Allowed
+                                    else
+                                        Blocked NotAllowed
+                            ) ] }
+
+              let resource =
+                  statefulResource "/undeclared-role/{id}" {
+                      machine undeclaredRoleGuardMachine
+                      resolveInstanceId (fun _ -> "1")
+                      role "Allowed" (fun claims -> claims.HasClaim("access", "granted"))
+
+                      inState (
+                          forState
+                              MiddlewareTests.Active
+                              [ StateHandlerBuilder.get (fun ctx -> ctx.Response.WriteAsync("ok")) ]
+                      )
+                  }
+
+              // Even a user with access=granted should get 403 because NonexistentRole is never declared
+              let allowedUser =
+                  ClaimsPrincipal(ClaimsIdentity([| Claim("access", "granted") |], "test"))
+
+              (withRoleServer resource (Some allowedUser) (fun client ->
+                  task {
+                      let! (resp: HttpResponseMessage) = client.GetAsync("/undeclared-role/1")
+                      Expect.equal resp.StatusCode HttpStatusCode.Forbidden "undeclared role should never match -> 403"
+                  }))
+                  .GetAwaiter()
+                  .GetResult()
+
+          testCase "T023: backward compatibility — resource without roles"
+          <| fun () ->
+              let resource =
+                  statefulResource "/noRoles/{id}" {
+                      machine MiddlewareTests.testMachine
+                      resolveInstanceId (fun _ -> "1")
+
+                      inState (
+                          forState MiddlewareTests.Active [ StateHandlerBuilder.get getRolesHandler ]
+                      )
+                  }
+
+              (withRoleServer resource None (fun client ->
+                  task {
+                      let! (resp: HttpResponseMessage) = client.GetAsync("/noRoles/1")
+                      Expect.equal resp.StatusCode HttpStatusCode.OK "no-role resource should be 200"
+                      let! body = resp.Content.ReadAsStringAsync()
+                      Expect.equal body "" "GetRoles() should return empty set when no roles declared"
+                  }))
+                  .GetAwaiter()
+                  .GetResult()
+
+              // Also verify HasRole returns false
+              let metadata =
+                  resource.Endpoints[0].Metadata.GetMetadata<StateMachineMetadata>()
+
+              Expect.isEmpty metadata.Roles "Roles list should be empty"
+
+          testCase "T024: predicate exception handling — bad predicate skipped, good role still resolves"
+          <| fun () ->
+              let resource =
+                  statefulResource "/exception-role/{id}" {
+                      machine MiddlewareTests.testMachine
+                      resolveInstanceId (fun _ -> "1")
+                      role "BadRole" (fun _ -> failwith "boom")
+                      role "GoodRole" (fun _ -> true)
+
+                      inState (
+                          forState MiddlewareTests.Active [ StateHandlerBuilder.get getRolesHandler ]
+                      )
+                  }
+
+              let user = ClaimsPrincipal(ClaimsIdentity([||], "test"))
+
+              (withRoleServer resource (Some user) (fun client ->
+                  task {
+                      let! (resp: HttpResponseMessage) = client.GetAsync("/exception-role/1")
+                      // Request should still succeed — bad predicate is logged and skipped
+                      Expect.equal resp.StatusCode HttpStatusCode.OK "request should succeed despite bad predicate"
+                      let! body = resp.Content.ReadAsStringAsync()
+                      // GoodRole should resolve; BadRole should be absent
+                      let parts = body.Split(',') |> Array.filter (fun s -> s <> "") |> Set.ofArray
+                      Expect.isTrue (parts.Contains "GoodRole") "GoodRole should still resolve"
+                      Expect.isFalse (parts.Contains "BadRole") "BadRole should be skipped on exception"
+                  }))
+                  .GetAwaiter()
+                  .GetResult()
+
+          testCase "GAP-1: EventValidation guard context receives resolved roles"
+          <| fun () ->
+              let guardCalled = ref false
+              let receivedRoles = ref Set.empty
+
+              let evGuard: Guard<MiddlewareTests.TestState, MiddlewareTests.TestEvent, int> =
+                  EventValidation(
+                      "CheckRoles",
+                      fun ctx ->
+                          guardCalled.Value <- true
+                          receivedRoles.Value <- ctx.Roles
+                          Allowed
+                  )
+
+              let evGuardMachine =
+                  { MiddlewareTests.testMachine with
+                      Guards = [ evGuard ] }
+
+              let resource =
+                  statefulResource "/ev-guard/{id}" {
+                      machine evGuardMachine
+                      resolveInstanceId (fun _ -> "1")
+                      role "TestRole" (fun _ -> true)
+
+                      inState (
+                          forState
+                              MiddlewareTests.Active
+                              [ StateHandlerBuilder.get (fun _ -> Task.CompletedTask)
+                                StateHandlerBuilder.post (fun ctx ->
+                                    StateMachineContext.setEvent ctx MiddlewareTests.DoAction
+                                    Task.CompletedTask) ]
+                      )
+                  }
+
+              (withRoleServer resource None (fun client ->
+                  task {
+                      let! (_: HttpResponseMessage) = client.PostAsync("/ev-guard/1", new StringContent(""))
+                      Expect.isTrue guardCalled.Value "EventValidation guard should have been called"
+
+                      Expect.isTrue
+                          (receivedRoles.Value.Contains("TestRole"))
+                          "EventValidation guard ctx.Roles should contain resolved roles"
+                  }))
+                  .GetAwaiter()
+                  .GetResult()
+
+          testCase "GAP-3: empty role name rejected at startup"
+          <| fun () ->
+              try
+                  statefulResource "/test/{id}" {
+                      machine MiddlewareTests.testMachine
+                      resolveInstanceId (fun _ -> "1")
+                      role "" (fun _ -> true)
+
+                      inState (
+                          forState MiddlewareTests.Active [ StateHandlerBuilder.get (fun _ -> Task.CompletedTask) ]
+                      )
+                  }
+                  |> ignore
+
+                  failtest "should have thrown for empty role name"
+              with ex ->
+                  Expect.stringContains ex.Message "Empty role name" "error should mention empty name" ]

--- a/test/Frank.Statecharts.Tests/TypeTests.fs
+++ b/test/Frank.Statecharts.Tests/TypeTests.fs
@@ -173,7 +173,8 @@ let guardTests =
               let ctx: AccessControlContext<TurnstileState, unit> =
                   { User = adminPrincipal
                     CurrentState = Locked
-                    Context = () }
+                    Context = ()
+                    Roles = Set.empty }
 
               match adminGuard with
               | AccessControl(_, pred) -> Expect.equal (pred ctx) Allowed "admin should be allowed"
@@ -197,7 +198,8 @@ let guardTests =
               let ctx: AccessControlContext<TurnstileState, unit> =
                   { User = userPrincipal
                     CurrentState = Locked
-                    Context = () }
+                    Context = ()
+                    Roles = Set.empty }
 
               match adminGuard with
               | AccessControl(_, pred) -> Expect.equal (pred ctx) (Blocked(NotAllowed)) "non-admin should be blocked"
@@ -221,7 +223,8 @@ let guardTests =
                   { User = principal
                     CurrentState = Locked
                     Event = Coin
-                    Context = () }
+                    Context = ()
+                    Roles = Set.empty }
 
               match eventGuard with
               | EventValidation(_, pred) -> Expect.equal (pred ctx) Allowed "Coin should be allowed"

--- a/test/Frank.Statecharts.Tests/Wsd/GeneratorRoundTripTests.fs
+++ b/test/Frank.Statecharts.Tests/Wsd/GeneratorRoundTripTests.fs
@@ -46,7 +46,9 @@ let private makeMetadata
       GetCurrentStateKey = fun _ _ _ -> Task.FromResult(initialKey)
       EvaluateGuards = fun _ -> Allowed
       EvaluateEventGuards = fun _ -> Allowed
-      ExecuteTransition = fun _ _ _ -> Task.FromResult(TransitionAttemptResult.NoEvent) }
+      ExecuteTransition = fun _ _ _ -> Task.FromResult(TransitionAttemptResult.NoEvent)
+      Roles = []
+      ResolveRoles = fun _ -> Set.empty }
 
 let private dummyHandler = RequestDelegate(fun _ -> Task.CompletedTask)
 

--- a/test/Frank.Statecharts.Tests/Wsd/GeneratorTests.fs
+++ b/test/Frank.Statecharts.Tests/Wsd/GeneratorTests.fs
@@ -48,7 +48,9 @@ let private makeMetadata
       GetCurrentStateKey = fun _ _ _ -> Task.FromResult(initialKey)
       EvaluateGuards = fun _ -> Allowed
       EvaluateEventGuards = fun _ -> Allowed
-      ExecuteTransition = fun _ _ _ -> Task.FromResult(TransitionAttemptResult.NoEvent) }
+      ExecuteTransition = fun _ _ _ -> Task.FromResult(TransitionAttemptResult.NoEvent)
+      Roles = []
+      ResolveRoles = fun _ -> Set.empty }
 
 // --- Test state machines ---
 
@@ -335,7 +337,9 @@ let generatorTests =
                     GetCurrentStateKey = fun _ _ _ -> Task.FromResult("test")
                     EvaluateGuards = fun _ -> Allowed
                     EvaluateEventGuards = fun _ -> Allowed
-                    ExecuteTransition = fun _ _ _ -> Task.FromResult(TransitionAttemptResult.NoEvent) }
+                    ExecuteTransition = fun _ _ _ -> Task.FromResult(TransitionAttemptResult.NoEvent)
+                    Roles = []
+                    ResolveRoles = fun _ -> Set.empty }
 
               let result = generate { ResourceName = "bad" } metadata
 


### PR DESCRIPTION
## Summary

- Adds declarative `role` CE operation to `statefulResource` that maps authentication claims to named protocol roles
- Foundation for projection operator (#107), projected content negotiation (#75), and progress analysis (#108)
- Two-tier type design: portable `RoleInfo` in `Frank.Resources.Model`, platform `RoleDefinition` in `Frank.Statecharts`
- Eager per-request role resolution via separate `IRoleFeature` typed feature interface
- Guards check roles via `ctx.HasRole "RoleName"` on both `AccessControlContext` and `EventValidationContext`
- 11 integration tests covering all 10 functional requirements, 5 success criteria, 5 edge cases

## Design decisions (expert-informed)

| Decision | Choice | Expert rationale |
|----------|--------|-----------------|
| Typed feature | Separate `IRoleFeature` | Fowler: one feature per concern |
| Guard context | `Roles: Set<string>` + `HasRole` member | Wadler: value semantics; Harel: inspectable for projection |
| Spec pipeline | `Roles` on `ExtractedStatechart` | Syme: illegal states unrepresentable |
| File location | `RoleDefinition` in `Types.fs`, `IRoleFeature` in `RoleFeature.fs` | Seemann: domain types together; Fowler: separate concerns |
| Portable type | `RoleInfo` hierarchy-neutral | Harel: future-proof for hierarchical runtime |

## Test plan

- [x] Role declarations appear in endpoint metadata (T019)
- [x] Duplicate role names rejected at startup with descriptive error (T020)
- [x] Role resolution with multiple identities: matching, anonymous, all-match (T021/B/C)
- [x] `HasRole` in AccessControl guards: allowed, blocked, undeclared role (T022/C)
- [x] Backward compatibility: no roles = empty set (T023)
- [x] Predicate exception handling: graceful degradation (T024)
- [x] EventValidation guards receive resolved roles (GAP-1)
- [x] Empty role name rejected at startup (GAP-3)
- [x] Build succeeds, 1041 tests pass

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)