### PR TITLE
docs: rewrite README intro around four pillars

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![GitHub Release Date](https://img.shields.io/github/release-date/frank-fs/frank)
 ![Build status](https://github.com/frank-fs/frank/workflows/CI/badge.svg)
 
-A web framework for building applications where resources are the primary abstraction, invalid states are structurally impossible, and the application itself is the API documentation. Frank uses [F#](https://fsharp.org/) [computation expressions](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/computation-expressions) as a declarative, extensible layer over [ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/) — keeping the full power of the platform without hiding it behind abstractions.
+A web framework for building applications where resources are the primary abstraction, invalid states are structurally impossible, and the application itself is the API documentation. Frank uses [F#](https://fsharp.org/) [computation expressions](https://docs.microsoft.com/en-us/dotnet/fsharp/language-reference/computation-expressions) as a declarative, extensible layer over [ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/).
 
 Frank is built on four ideas:
 


### PR DESCRIPTION
## Summary
- Rewrite intro to lead with what Frank IS (resource-oriented CE wrapper over ASP.NET Core), not what it does for agents
- Express all four pillars up front: resources not routes, invalid states impossible, built for agents, discovery as first-class concern
- Restore approachable basic example before the statechart/affordance payoff
- Keep all existing package docs, middleware, auth, etc. unchanged

The previous README led with "navigable by AI agents," making Frank sound like an agent framework. The correct framing: Frank is a web framework with a vision — like Rails had a vision for Ruby — and F# is the language that makes it tractable.

## Test plan
- [x] Verify all four pillars present in intro
- [x] Basic example appears before TicTacToe statechart example
- [x] All package sections, code examples, and references unchanged
- [ ] Visual review of rendered markdown on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)