### PR TITLE
feat: auto-infer ResourceSpec.Name from route template

### DIFF
--- a/src/Frank/Builder.fs
+++ b/src/Frank/Builder.fs
@@ -12,6 +12,56 @@ module Builder =
     open Microsoft.Extensions.FileProviders
     open Microsoft.Extensions.Hosting
 
+    let private rootName = "Root"
+
+    let private isRouteParam (seg: string) =
+        seg.StartsWith('{') && seg.EndsWith('}')
+
+    let private titleCase (s: string) =
+        if String.IsNullOrEmpty s then
+            s
+        else
+            string (Char.ToUpperInvariant s[0]) + s.Substring(1).ToLowerInvariant()
+
+    let private singularize (s: string) =
+        if
+            s.Length > 1
+            && s.EndsWith("s", StringComparison.OrdinalIgnoreCase)
+            && not (s.EndsWith("ss", StringComparison.OrdinalIgnoreCase))
+        then
+            s.Substring(0, s.Length - 1)
+        else
+            s
+
+    let private inferNameFromRoute (routeTemplate: string) =
+        let trimmed = routeTemplate.TrimStart('/')
+
+        if String.IsNullOrEmpty trimmed then
+            rootName
+        else
+            let segments = trimmed.Split('/', StringSplitOptions.RemoveEmptyEntries)
+
+            // Singularize collection segments that precede a path parameter,
+            // so /users/{id} becomes "User" not "Users"
+            let processed =
+                segments
+                |> Array.indexed
+                |> Array.collect (fun (i, seg) ->
+                    if isRouteParam seg then
+                        Array.empty
+                    else
+                        let nextIsParam = i + 1 < segments.Length && isRouteParam segments[i + 1]
+
+                        let normalized = if nextIsParam then singularize seg else seg
+
+                        normalized.Split([| '-'; '_' |], StringSplitOptions.RemoveEmptyEntries)
+                        |> Array.map titleCase)
+
+            if Array.isEmpty processed then
+                rootName
+            else
+                String.Join(" ", processed)
+
     [<Struct>]
     type Resource = { Endpoints: Endpoint[] }
 
@@ -19,24 +69,28 @@ module Builder =
     /// Extensions add instances to endpoint metadata to advertise supported content types.
     [<Struct>]
     type DiscoveryMediaType =
-        { /// The content type string (e.g., "application/ld+json", "text/turtle").
-          MediaType: string
-          /// The link relation type for Link header generation (e.g., "describedby").
-          Rel: string }
+        {
+            /// The content type string (e.g., "application/ld+json", "text/turtle").
+            MediaType: string
+            /// The link relation type for Link header generation (e.g., "describedby").
+            Rel: string
+        }
 
     /// Metadata contributed by extension packages for JSON Home document generation.
     /// Register via DI; Frank.Discovery reads it at startup to build the home document.
     type JsonHomeMetadata =
-        { /// API title (e.g., from OpenAPI info)
-          Title: string option
-          /// URL for API documentation (e.g., Scalar UI at /scalar/v1)
-          DocsUrl: string option
-          /// Base URI for ALPS profiles (e.g., "http://example.com/alps/games").
-          /// Used to build link relation URIs: {AlpsBaseUri}#{resourceSlug}
-          AlpsBaseUri: string option
-          /// ALPS descriptor URIs keyed by (resourceSlug, descriptorId).
-          /// Enables semantic hrefVars in JSON Home.
-          AlpsDescriptors: Map<string, Map<string, string>> option }
+        {
+            /// API title (e.g., from OpenAPI info)
+            Title: string option
+            /// URL for API documentation (e.g., Scalar UI at /scalar/v1)
+            DocsUrl: string option
+            /// Base URI for ALPS profiles (e.g., "http://example.com/alps/games").
+            /// Used to build link relation URIs: {AlpsBaseUri}#{resourceSlug}
+            AlpsBaseUri: string option
+            /// ALPS descriptor URIs keyed by (resourceSlug, descriptorId).
+            /// Enables semantic hrefVars in JSON Home.
+            AlpsDescriptors: Map<string, Map<string, string>> option
+        }
 
         static member Empty =
             { Title = None
@@ -45,12 +99,12 @@ module Builder =
               AlpsDescriptors = None }
 
     type ResourceSpec =
-        { Name: string
+        { Name: string option
           Handlers: (string * RequestDelegate) list
           Metadata: (EndpointBuilder -> unit) list }
 
         static member Empty =
-            { Name = Unchecked.defaultof<_>
+            { Name = None
               Handlers = []
               Metadata = [] }
 
@@ -60,12 +114,16 @@ module Builder =
                   Metadata = metadata } =
                 spec
 
+            let resolvedName =
+                match name with
+                | Some n -> n
+                | None -> inferNameFromRoute routeTemplate
+
             let routePattern = Patterns.RoutePatternFactory.Parse routeTemplate
 
             let endpoints =
                 [| for httpMethod, handler in handlers ->
-                       let displayName =
-                           httpMethod + " " + (if String.IsNullOrEmpty name then routeTemplate else name)
+                       let displayName = httpMethod + " " + resolvedName
 
                        let builder = RouteEndpointBuilder(handler, routePattern, 0)
                        builder.DisplayName <- displayName
@@ -90,7 +148,7 @@ module Builder =
         member __.Yield(_) = ResourceSpec.Empty
 
         [<CustomOperation("name")>]
-        member __.Name(spec, name) = { spec with Name = name }
+        member __.Name(spec, name) = { spec with Name = Some name }
 
         static member AddMetadata(spec: ResourceSpec, convention: EndpointBuilder -> unit) : ResourceSpec =
             { spec with

--- a/test/Frank.OpenApi.Tests/OpenApiDocumentTests.fs
+++ b/test/Frank.OpenApi.Tests/OpenApiDocumentTests.fs
@@ -27,31 +27,41 @@ type TestEndpointDataSource(endpoints: Endpoint[]) =
 
 /// Creates a test server with Frank resources and OpenAPI enabled
 let createOpenApiTestServer (resources: Resource list) =
-    let allEndpoints = resources |> List.collect (fun r -> r.Endpoints |> Array.toList) |> List.toArray
+    let allEndpoints =
+        resources |> List.collect (fun r -> r.Endpoints |> Array.toList) |> List.toArray
+
     let builder =
-        Host.CreateDefaultBuilder([||])
+        Host
+            .CreateDefaultBuilder([||])
             .ConfigureWebHost(fun webBuilder ->
                 webBuilder
                     .UseTestServer()
                     .ConfigureServices(fun services ->
                         services.AddRouting() |> ignore
+
                         services.AddOpenApi(fun options ->
                             options.AddSchemaTransformer(FSharpSchemaTransformer()) |> ignore
+
                             options.AddOperationTransformer(fun operation context _ct ->
                                 if System.String.IsNullOrEmpty operation.OperationId then
                                     let hasExplicitName =
                                         context.Description.ActionDescriptor.EndpointMetadata
                                         |> Seq.exists (fun m -> m :? EndpointNameMetadata)
+
                                     if not hasExplicitName then
                                         let displayName = context.Description.ActionDescriptor.DisplayName
+
                                         if not (System.String.IsNullOrEmpty displayName) then
                                             let parts = displayName.Split(' ', 2)
+
                                             if parts.Length = 2 && not (parts[1].StartsWith("/")) then
                                                 let httpMethod = parts[0].ToLowerInvariant()
                                                 let resourceName = parts[1].Replace(" ", "")
                                                 operation.OperationId <- httpMethod + resourceName
-                                Task.CompletedTask) |> ignore
-                        ) |> ignore)
+
+                                Task.CompletedTask)
+                            |> ignore)
+                        |> ignore)
                     .Configure(fun app ->
                         app
                             .UseRouting()
@@ -68,14 +78,16 @@ let createOpenApiTestServer (resources: Resource list) =
 
 /// Creates a test server WITHOUT OpenAPI enabled
 let createPlainTestServer (resources: Resource list) =
-    let allEndpoints = resources |> List.collect (fun r -> r.Endpoints |> Array.toList) |> List.toArray
+    let allEndpoints =
+        resources |> List.collect (fun r -> r.Endpoints |> Array.toList) |> List.toArray
+
     let builder =
-        Host.CreateDefaultBuilder([||])
+        Host
+            .CreateDefaultBuilder([||])
             .ConfigureWebHost(fun webBuilder ->
                 webBuilder
                     .UseTestServer()
-                    .ConfigureServices(fun services ->
-                        services.AddRouting() |> ignore)
+                    .ConfigureServices(fun services -> services.AddRouting() |> ignore)
                     .Configure(fun app ->
                         app
                             .UseRouting()
@@ -88,7 +100,7 @@ let createPlainTestServer (resources: Resource list) =
     host.Start()
     host.GetTestClient()
 
-let simpleHandler : RequestDelegate =
+let simpleHandler: RequestDelegate =
     RequestDelegate(fun ctx -> ctx.Response.WriteAsync("OK"))
 
 /// Helper to check if a JSON element has a property
@@ -101,97 +113,130 @@ let getOpenApiDoc (client: HttpClient) =
     task {
         let! (response: HttpResponseMessage) = client.GetAsync("/openapi/v1.json")
         let! (body: string) = response.Content.ReadAsStringAsync()
-        return response, JsonDocument.Parse(body : string)
+        return response, JsonDocument.Parse(body: string)
     }
 
 // ===== US1: Serve OpenAPI Document =====
 
 [<Tests>]
 let us1Tests =
-    testList "US1 - Serve OpenAPI Document" [
-        testTask "GET /openapi/v1.json returns 200 with valid OpenAPI document" {
-            let products =
-                resource "/products" {
-                    name "Products"
-                    get simpleHandler
-                }
-            let client = createOpenApiTestServer [ products ]
-            let! (response: HttpResponseMessage) = client.GetAsync("/openapi/v1.json")
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+    testList
+        "US1 - Serve OpenAPI Document"
+        [ testTask "GET /openapi/v1.json returns 200 with valid OpenAPI document" {
+              let products =
+                  resource "/products" {
+                      name "Products"
+                      get simpleHandler
+                  }
 
-            let! (body: string) = response.Content.ReadAsStringAsync()
-            let doc = JsonDocument.Parse(body : string)
-            let root = doc.RootElement
+              let client = createOpenApiTestServer [ products ]
+              let! (response: HttpResponseMessage) = client.GetAsync("/openapi/v1.json")
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
 
-            // Verify it's a valid OpenAPI document
-            Expect.isTrue (hasProperty "openapi" root) "Should have openapi version field"
-            Expect.isTrue (hasProperty "paths" root) "Should have paths field"
+              let! (body: string) = response.Content.ReadAsStringAsync()
+              let doc = JsonDocument.Parse(body: string)
+              let root = doc.RootElement
 
-            // Verify the /products path exists
-            let paths = root.GetProperty("paths")
-            Expect.isTrue (hasProperty "/products" paths) "Should contain /products path"
+              // Verify it's a valid OpenAPI document
+              Expect.isTrue (hasProperty "openapi" root) "Should have openapi version field"
+              Expect.isTrue (hasProperty "paths" root) "Should have paths field"
 
-            // Verify GET method exists under /products
-            let productsPath = paths.GetProperty("/products")
-            Expect.isTrue (hasProperty "get" productsPath) "Should have GET operation for /products"
-        }
+              // Verify the /products path exists
+              let paths = root.GetProperty("paths")
+              Expect.isTrue (hasProperty "/products" paths) "Should contain /products path"
 
-        testTask "OpenAPI document contains auto-derived operationId from resource name" {
-            let products =
-                resource "/products" {
-                    name "Products"
-                    get simpleHandler
-                }
-            let client = createOpenApiTestServer [ products ]
-            let! result = getOpenApiDoc client
-            let (response: HttpResponseMessage), (doc: JsonDocument) = result
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
-            let getOp = doc.RootElement.GetProperty("paths").GetProperty("/products").GetProperty("get")
+              // Verify GET method exists under /products
+              let productsPath = paths.GetProperty("/products")
+              Expect.isTrue (hasProperty "get" productsPath) "Should have GET operation for /products"
+          }
 
-            // R8: operationId should be auto-derived from DisplayName "GET Products" -> "getProducts"
-            Expect.isTrue (hasProperty "operationId" getOp) "Should have operationId"
-            Expect.equal (getOp.GetProperty("operationId").GetString()) "getProducts" "operationId should be auto-derived from resource name"
-        }
+          testTask "OpenAPI document contains auto-derived operationId from resource name" {
+              let products =
+                  resource "/products" {
+                      name "Products"
+                      get simpleHandler
+                  }
 
-        testTask "OpenAPI document includes multiple endpoints from multiple resources" {
-            let products =
-                resource "/products" {
-                    name "Products"
-                    get simpleHandler
-                    post simpleHandler
-                }
-            let users =
-                resource "/users" {
-                    name "Users"
-                    get simpleHandler
-                }
-            let client = createOpenApiTestServer [ products; users ]
-            let! result = getOpenApiDoc client
-            let (_, (doc: JsonDocument)) = result
-            let paths = doc.RootElement.GetProperty("paths")
+              let client = createOpenApiTestServer [ products ]
+              let! result = getOpenApiDoc client
+              let (response: HttpResponseMessage), (doc: JsonDocument) = result
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
 
-            Expect.isTrue (hasProperty "/products" paths) "Should contain /products"
-            Expect.isTrue (hasProperty "/users" paths) "Should contain /users"
+              let getOp =
+                  doc.RootElement.GetProperty("paths").GetProperty("/products").GetProperty("get")
 
-            let productsPath = paths.GetProperty("/products")
-            Expect.isTrue (hasProperty "get" productsPath) "Should have GET /products"
-            Expect.isTrue (hasProperty "post" productsPath) "Should have POST /products"
+              // R8: operationId should be auto-derived from DisplayName "GET Products" -> "getProducts"
+              Expect.isTrue (hasProperty "operationId" getOp) "Should have operationId"
 
-            let usersPath = paths.GetProperty("/users")
-            Expect.isTrue (hasProperty "get" usersPath) "Should have GET /users"
-        }
+              Expect.equal
+                  (getOp.GetProperty("operationId").GetString())
+                  "getProducts"
+                  "operationId should be auto-derived from resource name"
+          }
 
-        testTask "App without OpenAPI does not expose /openapi/v1.json" {
-            let products =
-                resource "/products" {
-                    name "Products"
-                    get simpleHandler
-                }
-            let client = createPlainTestServer [ products ]
-            let! (response: HttpResponseMessage) = client.GetAsync("/openapi/v1.json")
-            Expect.equal response.StatusCode HttpStatusCode.NotFound "Should return 404 when OpenAPI is not configured"
-        }
-    ]
+          testTask "Multi-segment inferred name produces correct operationId" {
+              let adminUsers = resource "/admin/users" { get simpleHandler }
+              let client = createOpenApiTestServer [ adminUsers ]
+              let! result = getOpenApiDoc client
+              let (response: HttpResponseMessage), (doc: JsonDocument) = result
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+
+              let getOp =
+                  doc.RootElement.GetProperty("paths").GetProperty("/admin/users").GetProperty("get")
+
+              Expect.isTrue (hasProperty "operationId" getOp) "Should have operationId"
+
+              Expect.equal
+                  (getOp.GetProperty("operationId").GetString())
+                  "getAdminUsers"
+                  "Multi-word inferred name should collapse spaces for operationId"
+          }
+
+          testTask "OpenAPI document includes multiple endpoints from multiple resources" {
+              let products =
+                  resource "/products" {
+                      name "Products"
+                      get simpleHandler
+                      post simpleHandler
+                  }
+
+              let users =
+                  resource "/users" {
+                      name "Users"
+                      get simpleHandler
+                  }
+
+              let client = createOpenApiTestServer [ products; users ]
+              let! result = getOpenApiDoc client
+              let (_, (doc: JsonDocument)) = result
+              let paths = doc.RootElement.GetProperty("paths")
+
+              Expect.isTrue (hasProperty "/products" paths) "Should contain /products"
+              Expect.isTrue (hasProperty "/users" paths) "Should contain /users"
+
+              let productsPath = paths.GetProperty("/products")
+              Expect.isTrue (hasProperty "get" productsPath) "Should have GET /products"
+              Expect.isTrue (hasProperty "post" productsPath) "Should have POST /products"
+
+              let usersPath = paths.GetProperty("/users")
+              Expect.isTrue (hasProperty "get" usersPath) "Should have GET /users"
+          }
+
+          testTask "App without OpenAPI does not expose /openapi/v1.json" {
+              let products =
+                  resource "/products" {
+                      name "Products"
+                      get simpleHandler
+                  }
+
+              let client = createPlainTestServer [ products ]
+              let! (response: HttpResponseMessage) = client.GetAsync("/openapi/v1.json")
+
+              Expect.equal
+                  response.StatusCode
+                  HttpStatusCode.NotFound
+                  "Should return 404 when OpenAPI is not configured"
+          } ]
 
 // ===== US3: End-to-End Tests with HandlerDefinitions =====
 
@@ -200,223 +245,246 @@ type CreateProductRequest = { Name: string; Price: decimal }
 
 [<Tests>]
 let us3EndToEndTests =
-    testList "US3 - HandlerDefinitions End-to-End" [
-        testTask "HandlerDefinition with name and tags appears in OpenAPI document" {
-            let createProductHandler =
-                handler {
-                    name "createProduct"
-                    summary "Create a new product"
-                    description "Creates a new product in the catalog"
-                    tags [ "Products"; "Admin" ]
-                    produces typeof<Product> 201
-                    accepts typeof<CreateProductRequest>
-                    handle (fun (ctx: HttpContext) -> Task.CompletedTask)
-                }
+    testList
+        "US3 - HandlerDefinitions End-to-End"
+        [ testTask "HandlerDefinition with name and tags appears in OpenAPI document" {
+              let createProductHandler =
+                  handler {
+                      name "createProduct"
+                      summary "Create a new product"
+                      description "Creates a new product in the catalog"
+                      tags [ "Products"; "Admin" ]
+                      produces typeof<Product> 201
+                      accepts typeof<CreateProductRequest>
+                      handle (fun (ctx: HttpContext) -> Task.CompletedTask)
+                  }
 
-            let products =
-                resource "/products" {
-                    name "Products"
-                    post createProductHandler
-                }
+              let products =
+                  resource "/products" {
+                      name "Products"
+                      post createProductHandler
+                  }
 
-            let client = createOpenApiTestServer [ products ]
-            let! result = getOpenApiDoc client
-            let (response: HttpResponseMessage), (doc: JsonDocument) = result
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+              let client = createOpenApiTestServer [ products ]
+              let! result = getOpenApiDoc client
+              let (response: HttpResponseMessage), (doc: JsonDocument) = result
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
 
-            let postOp = doc.RootElement.GetProperty("paths").GetProperty("/products").GetProperty("post")
+              let postOp =
+                  doc.RootElement.GetProperty("paths").GetProperty("/products").GetProperty("post")
 
-            // Check operationId from HandlerDefinition name
-            Expect.equal (postOp.GetProperty("operationId").GetString()) "createProduct" "operationId should match handler name"
+              // Check operationId from HandlerDefinition name
+              Expect.equal
+                  (postOp.GetProperty("operationId").GetString())
+                  "createProduct"
+                  "operationId should match handler name"
 
-            // Check summary and description
-            Expect.equal (postOp.GetProperty("summary").GetString()) "Create a new product" "Summary should match"
-            Expect.equal (postOp.GetProperty("description").GetString()) "Creates a new product in the catalog" "Description should match"
+              // Check summary and description
+              Expect.equal (postOp.GetProperty("summary").GetString()) "Create a new product" "Summary should match"
 
-            // Check tags
-            let tags = postOp.GetProperty("tags")
-            Expect.equal (tags.GetArrayLength()) 2 "Should have 2 tags"
-            let tagsList = [ for i in 0 .. tags.GetArrayLength() - 1 -> tags[i].GetString() ]
-            Expect.containsAll tagsList [ "Products"; "Admin" ] "Tags should match"
-        }
+              Expect.equal
+                  (postOp.GetProperty("description").GetString())
+                  "Creates a new product in the catalog"
+                  "Description should match"
 
-        testTask "HandlerDefinition produces metadata appears as response in OpenAPI" {
-            let getProductHandler =
-                handler {
-                    name "getProduct"
-                    produces typeof<Product> 200
-                    produces typeof<Product> 201
-                    producesEmpty 404
-                    handle (fun (ctx: HttpContext) -> Task.CompletedTask)
-                }
+              // Check tags
+              let tags = postOp.GetProperty("tags")
+              Expect.equal (tags.GetArrayLength()) 2 "Should have 2 tags"
+              let tagsList = [ for i in 0 .. tags.GetArrayLength() - 1 -> tags[i].GetString() ]
+              Expect.containsAll tagsList [ "Products"; "Admin" ] "Tags should match"
+          }
 
-            let products =
-                resource "/products/{id}" {
-                    get getProductHandler
-                }
+          testTask "HandlerDefinition produces metadata appears as response in OpenAPI" {
+              let getProductHandler =
+                  handler {
+                      name "getProduct"
+                      produces typeof<Product> 200
+                      produces typeof<Product> 201
+                      producesEmpty 404
+                      handle (fun (ctx: HttpContext) -> Task.CompletedTask)
+                  }
 
-            let client = createOpenApiTestServer [ products ]
-            let! result = getOpenApiDoc client
-            let (response: HttpResponseMessage), (doc: JsonDocument) = result
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+              let products = resource "/products/{id}" { get getProductHandler }
 
-            let getOp = doc.RootElement.GetProperty("paths").GetProperty("/products/{id}").GetProperty("get")
-            let responses = getOp.GetProperty("responses")
+              let client = createOpenApiTestServer [ products ]
+              let! result = getOpenApiDoc client
+              let (response: HttpResponseMessage), (doc: JsonDocument) = result
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
 
-            // Check 200 response with Product schema
-            Expect.isTrue (hasProperty "200" responses) "Should have 200 response"
-            let resp200 = responses.GetProperty("200")
-            Expect.isTrue (hasProperty "content" resp200) "200 should have content"
+              let getOp =
+                  doc.RootElement.GetProperty("paths").GetProperty("/products/{id}").GetProperty("get")
 
-            // Check 201 response
-            Expect.isTrue (hasProperty "201" responses) "Should have 201 response"
+              let responses = getOp.GetProperty("responses")
 
-            // Check 404 empty response
-            Expect.isTrue (hasProperty "404" responses) "Should have 404 response"
-            let resp404 = responses.GetProperty("404")
-            // Empty responses typically don't have content or have empty content
-            let has404Content = hasProperty "content" resp404
-            if has404Content then
-                let content404 = resp404.GetProperty("content")
-                Expect.equal (content404.EnumerateObject() |> Seq.length) 0 "404 should have no content types"
-        }
+              // Check 200 response with Product schema
+              Expect.isTrue (hasProperty "200" responses) "Should have 200 response"
+              let resp200 = responses.GetProperty("200")
+              Expect.isTrue (hasProperty "content" resp200) "200 should have content"
 
-        testTask "HandlerDefinition accepts metadata appears as requestBody in OpenAPI" {
-            let createHandler =
-                handler {
-                    name "createProduct"
-                    accepts typeof<CreateProductRequest>
-                    produces typeof<Product> 201
-                    handle (fun (ctx: HttpContext) -> Task.CompletedTask)
-                }
+              // Check 201 response
+              Expect.isTrue (hasProperty "201" responses) "Should have 201 response"
 
-            let products =
-                resource "/products" {
-                    post createHandler
-                }
+              // Check 404 empty response
+              Expect.isTrue (hasProperty "404" responses) "Should have 404 response"
+              let resp404 = responses.GetProperty("404")
+              // Empty responses typically don't have content or have empty content
+              let has404Content = hasProperty "content" resp404
 
-            let client = createOpenApiTestServer [ products ]
-            let! result = getOpenApiDoc client
-            let (response: HttpResponseMessage), (doc: JsonDocument) = result
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+              if has404Content then
+                  let content404 = resp404.GetProperty("content")
+                  Expect.equal (content404.EnumerateObject() |> Seq.length) 0 "404 should have no content types"
+          }
 
-            let postOp = doc.RootElement.GetProperty("paths").GetProperty("/products").GetProperty("post")
+          testTask "HandlerDefinition accepts metadata appears as requestBody in OpenAPI" {
+              let createHandler =
+                  handler {
+                      name "createProduct"
+                      accepts typeof<CreateProductRequest>
+                      produces typeof<Product> 201
+                      handle (fun (ctx: HttpContext) -> Task.CompletedTask)
+                  }
 
-            // Check requestBody
-            Expect.isTrue (hasProperty "requestBody" postOp) "Should have requestBody"
-            let requestBody = postOp.GetProperty("requestBody")
-            Expect.isTrue (hasProperty "content" requestBody) "RequestBody should have content"
-            let content = requestBody.GetProperty("content")
-            Expect.isTrue (hasProperty "application/json" content) "Should accept application/json"
-        }
+              let products = resource "/products" { post createHandler }
 
-        testTask "Resource with mixed plain handlers and HandlerDefinitions" {
-            let plainGetHandler : RequestDelegate = RequestDelegate(fun ctx -> ctx.Response.WriteAsync("OK"))
+              let client = createOpenApiTestServer [ products ]
+              let! result = getOpenApiDoc client
+              let (response: HttpResponseMessage), (doc: JsonDocument) = result
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
 
-            let createHandler =
-                handler {
-                    name "createProduct"
-                    summary "Create product"
-                    produces typeof<Product> 201
-                    handle (fun (ctx: HttpContext) -> Task.CompletedTask)
-                }
+              let postOp =
+                  doc.RootElement.GetProperty("paths").GetProperty("/products").GetProperty("post")
 
-            let products =
-                resource "/products" {
-                    name "Products"
-                    get plainGetHandler
-                    post createHandler
-                }
+              // Check requestBody
+              Expect.isTrue (hasProperty "requestBody" postOp) "Should have requestBody"
+              let requestBody = postOp.GetProperty("requestBody")
+              Expect.isTrue (hasProperty "content" requestBody) "RequestBody should have content"
+              let content = requestBody.GetProperty("content")
+              Expect.isTrue (hasProperty "application/json" content) "Should accept application/json"
+          }
 
-            let client = createOpenApiTestServer [ products ]
-            let! result = getOpenApiDoc client
-            let (response: HttpResponseMessage), (doc: JsonDocument) = result
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+          testTask "Resource with mixed plain handlers and HandlerDefinitions" {
+              let plainGetHandler: RequestDelegate =
+                  RequestDelegate(fun ctx -> ctx.Response.WriteAsync("OK"))
 
-            let productsPath = doc.RootElement.GetProperty("paths").GetProperty("/products")
+              let createHandler =
+                  handler {
+                      name "createProduct"
+                      summary "Create product"
+                      produces typeof<Product> 201
+                      handle (fun (ctx: HttpContext) -> Task.CompletedTask)
+                  }
 
-            // Plain handler should use auto-derived operationId
-            let getOp = productsPath.GetProperty("get")
-            Expect.equal (getOp.GetProperty("operationId").GetString()) "getProducts" "GET should have auto-derived operationId"
-            Expect.isFalse (hasProperty "summary" getOp) "GET should not have summary"
+              let products =
+                  resource "/products" {
+                      name "Products"
+                      get plainGetHandler
+                      post createHandler
+                  }
 
-            // HandlerDefinition should have its metadata
-            let postOp = productsPath.GetProperty("post")
-            Expect.equal (postOp.GetProperty("operationId").GetString()) "createProduct" "POST should have handler-defined operationId"
-            Expect.equal (postOp.GetProperty("summary").GetString()) "Create product" "POST should have summary"
-        }
+              let client = createOpenApiTestServer [ products ]
+              let! result = getOpenApiDoc client
+              let (response: HttpResponseMessage), (doc: JsonDocument) = result
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
 
-        testTask "HandlerDefinition with custom content types for content negotiation" {
-            let getHandler =
-                handler {
-                    name "getProduct"
-                    produces typeof<Product> 200 ["application/xml"; "application/json"]
-                    handle (fun (ctx: HttpContext) -> Task.CompletedTask)
-                }
+              let productsPath = doc.RootElement.GetProperty("paths").GetProperty("/products")
 
-            let createHandler =
-                handler {
-                    name "createProduct"
-                    accepts typeof<CreateProductRequest> ["application/xml"]
-                    produces typeof<Product> 201
-                    handle (fun (ctx: HttpContext) -> Task.CompletedTask)
-                }
+              // Plain handler should use auto-derived operationId
+              let getOp = productsPath.GetProperty("get")
 
-            let products =
-                resource "/products" {
-                    get getHandler
-                    post createHandler
-                }
+              Expect.equal
+                  (getOp.GetProperty("operationId").GetString())
+                  "getProducts"
+                  "GET should have auto-derived operationId"
 
-            let client = createOpenApiTestServer [ products ]
-            let! result = getOpenApiDoc client
-            let (response: HttpResponseMessage), (doc: JsonDocument) = result
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+              Expect.isFalse (hasProperty "summary" getOp) "GET should not have summary"
 
-            let productsPath = doc.RootElement.GetProperty("paths").GetProperty("/products")
+              // HandlerDefinition should have its metadata
+              let postOp = productsPath.GetProperty("post")
 
-            // Check GET response supports both XML and JSON
-            let getOp = productsPath.GetProperty("get")
-            let getResp200 = getOp.GetProperty("responses").GetProperty("200")
-            let getContent = getResp200.GetProperty("content")
-            Expect.isTrue (hasProperty "application/xml" getContent) "GET 200 should support XML"
-            Expect.isTrue (hasProperty "application/json" getContent) "GET 200 should support JSON"
+              Expect.equal
+                  (postOp.GetProperty("operationId").GetString())
+                  "createProduct"
+                  "POST should have handler-defined operationId"
 
-            // Check POST requestBody accepts XML
-            let postOp = productsPath.GetProperty("post")
-            let postRequestBody = postOp.GetProperty("requestBody")
-            let postContent = postRequestBody.GetProperty("content")
-            Expect.isTrue (hasProperty "application/xml" postContent) "POST should accept XML"
-        }
-    ]
+              Expect.equal (postOp.GetProperty("summary").GetString()) "Create product" "POST should have summary"
+          }
+
+          testTask "HandlerDefinition with custom content types for content negotiation" {
+              let getHandler =
+                  handler {
+                      name "getProduct"
+                      produces typeof<Product> 200 [ "application/xml"; "application/json" ]
+                      handle (fun (ctx: HttpContext) -> Task.CompletedTask)
+                  }
+
+              let createHandler =
+                  handler {
+                      name "createProduct"
+                      accepts typeof<CreateProductRequest> [ "application/xml" ]
+                      produces typeof<Product> 201
+                      handle (fun (ctx: HttpContext) -> Task.CompletedTask)
+                  }
+
+              let products =
+                  resource "/products" {
+                      get getHandler
+                      post createHandler
+                  }
+
+              let client = createOpenApiTestServer [ products ]
+              let! result = getOpenApiDoc client
+              let (response: HttpResponseMessage), (doc: JsonDocument) = result
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+
+              let productsPath = doc.RootElement.GetProperty("paths").GetProperty("/products")
+
+              // Check GET response supports both XML and JSON
+              let getOp = productsPath.GetProperty("get")
+              let getResp200 = getOp.GetProperty("responses").GetProperty("200")
+              let getContent = getResp200.GetProperty("content")
+              Expect.isTrue (hasProperty "application/xml" getContent) "GET 200 should support XML"
+              Expect.isTrue (hasProperty "application/json" getContent) "GET 200 should support JSON"
+
+              // Check POST requestBody accepts XML
+              let postOp = productsPath.GetProperty("post")
+              let postRequestBody = postOp.GetProperty("requestBody")
+              let postContent = postRequestBody.GetProperty("content")
+              Expect.isTrue (hasProperty "application/xml" postContent) "POST should accept XML"
+          } ]
 
 // ===== Scalar UI Tests =====
 
 [<Tests>]
 let scalarTests =
-    testList "Scalar UI" [
-        testTask "GET /scalar/v1 returns Scalar UI when OpenAPI is enabled" {
-            let products =
-                resource "/products" {
-                    name "Products"
-                    get simpleHandler
-                }
-            let client = createOpenApiTestServer [ products ]
-            let! (response: HttpResponseMessage) = client.GetAsync("/scalar/v1")
-            Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+    testList
+        "Scalar UI"
+        [ testTask "GET /scalar/v1 returns Scalar UI when OpenAPI is enabled" {
+              let products =
+                  resource "/products" {
+                      name "Products"
+                      get simpleHandler
+                  }
 
-            let! (body: string) = response.Content.ReadAsStringAsync()
-            Expect.stringContains body "scalar" "Should contain Scalar UI content"
-        }
+              let client = createOpenApiTestServer [ products ]
+              let! (response: HttpResponseMessage) = client.GetAsync("/scalar/v1")
+              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
 
-        testTask "App without OpenAPI does not expose /scalar/v1" {
-            let products =
-                resource "/products" {
-                    name "Products"
-                    get simpleHandler
-                }
-            let client = createPlainTestServer [ products ]
-            let! (response: HttpResponseMessage) = client.GetAsync("/scalar/v1")
-            Expect.equal response.StatusCode HttpStatusCode.NotFound "Should return 404 when OpenAPI is not configured"
-        }
-    ]
+              let! (body: string) = response.Content.ReadAsStringAsync()
+              Expect.stringContains body "scalar" "Should contain Scalar UI content"
+          }
+
+          testTask "App without OpenAPI does not expose /scalar/v1" {
+              let products =
+                  resource "/products" {
+                      name "Products"
+                      get simpleHandler
+                  }
+
+              let client = createPlainTestServer [ products ]
+              let! (response: HttpResponseMessage) = client.GetAsync("/scalar/v1")
+
+              Expect.equal
+                  response.StatusCode
+                  HttpStatusCode.NotFound
+                  "Should return 404 when OpenAPI is not configured"
+          } ]

--- a/test/Frank.Tests/Frank.Tests.fsproj
+++ b/test/Frank.Tests/Frank.Tests.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="ETagCacheTests.fs" />
     <Compile Include="ConditionalRequestTests.fs" />
     <Compile Include="ConditionalRequestIntegrationTests.fs" />
+    <Compile Include="NameInferenceTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/test/Frank.Tests/MetadataTests.fs
+++ b/test/Frank.Tests/MetadataTests.fs
@@ -10,63 +10,74 @@ open Frank.Builder
 
 [<Tests>]
 let metadataTests =
-    testList "ResourceSpec Metadata" [
-        test "Empty ResourceSpec has empty metadata list" {
-            let spec = ResourceSpec.Empty
-            Expect.isEmpty spec.Metadata "Metadata should be empty by default"
-        }
+    testList
+        "ResourceSpec Metadata"
+        [ test "Empty ResourceSpec has empty metadata list" {
+              let spec = ResourceSpec.Empty
+              Expect.isEmpty spec.Metadata "Metadata should be empty by default"
+          }
 
-        test "AddMetadata appends convention functions" {
-            let convention1 : EndpointBuilder -> unit = fun _ -> ()
-            let convention2 : EndpointBuilder -> unit = fun _ -> ()
-            let spec =
-                ResourceSpec.Empty
-                |> fun s -> ResourceBuilder.AddMetadata(s, convention1)
-                |> fun s -> ResourceBuilder.AddMetadata(s, convention2)
-            Expect.equal spec.Metadata.Length 2 "Should have two metadata conventions"
-        }
+          test "AddMetadata appends convention functions" {
+              let convention1: EndpointBuilder -> unit = fun _ -> ()
+              let convention2: EndpointBuilder -> unit = fun _ -> ()
 
-        test "Build applies convention functions - metadata objects appear in endpoint" {
-            let marker = obj()
-            let convention : EndpointBuilder -> unit = fun b ->
-                b.Metadata.Add(marker)
-            let spec =
-                { ResourceSpec.Empty with
-                    Handlers = [ "GET", RequestDelegate(fun ctx -> Task.CompletedTask) ]
-                    Metadata = [ convention ] }
-            let resource = spec.Build("/test")
-            let endpoint = resource.Endpoints[0]
-            let found = endpoint.Metadata |> Seq.exists (fun m -> Object.ReferenceEquals(m, marker))
-            Expect.isTrue found "Marker metadata should be present in endpoint metadata"
-        }
+              let spec =
+                  ResourceSpec.Empty
+                  |> fun s -> ResourceBuilder.AddMetadata(s, convention1)
+                  |> fun s -> ResourceBuilder.AddMetadata(s, convention2)
 
-        test "Build without metadata produces endpoints with correct HTTP method and display name" {
-            let handler = RequestDelegate(fun ctx -> Task.CompletedTask)
-            let spec =
-                { ResourceSpec.Empty with
-                    Name = "TestResource"
-                    Handlers = [ "GET", handler ] }
-            let resource = spec.Build("/test")
-            let endpoint = resource.Endpoints[0] :?> RouteEndpoint
-            Expect.equal endpoint.DisplayName "GET TestResource" "Display name should match"
-            let httpMethodMetadata = endpoint.Metadata.GetMetadata<HttpMethodMetadata>()
-            Expect.isNotNull httpMethodMetadata "Should have HttpMethodMetadata"
-            Expect.contains (httpMethodMetadata.HttpMethods |> Seq.toList) "GET" "Should contain GET method"
-            Expect.equal endpoint.RoutePattern.RawText "/test" "Route pattern should match"
-        }
+              Expect.equal spec.Metadata.Length 2 "Should have two metadata conventions"
+          }
 
-        test "Build without metadata produces functionally identical endpoints to previous behavior" {
-            let handler = RequestDelegate(fun ctx -> Task.CompletedTask)
-            let spec =
-                { ResourceSpec.Empty with
-                    Name = "MyResource"
-                    Handlers = [ "POST", handler; "GET", handler ] }
-            let resource = spec.Build("/api/items")
-            Expect.equal resource.Endpoints.Length 2 "Should produce one endpoint per handler"
-            for endpoint in resource.Endpoints do
-                let re = endpoint :?> RouteEndpoint
-                Expect.equal re.RoutePattern.RawText "/api/items" "Route pattern should match"
-                let httpMethod = re.Metadata.GetMetadata<HttpMethodMetadata>()
-                Expect.isNotNull httpMethod "Should have HttpMethodMetadata"
-        }
-    ]
+          test "Build applies convention functions - metadata objects appear in endpoint" {
+              let marker = obj ()
+              let convention: EndpointBuilder -> unit = fun b -> b.Metadata.Add(marker)
+
+              let spec =
+                  { ResourceSpec.Empty with
+                      Handlers = [ "GET", RequestDelegate(fun ctx -> Task.CompletedTask) ]
+                      Metadata = [ convention ] }
+
+              let resource = spec.Build("/test")
+              let endpoint = resource.Endpoints[0]
+
+              let found =
+                  endpoint.Metadata |> Seq.exists (fun m -> Object.ReferenceEquals(m, marker))
+
+              Expect.isTrue found "Marker metadata should be present in endpoint metadata"
+          }
+
+          test "Build without metadata produces endpoints with correct HTTP method and display name" {
+              let handler = RequestDelegate(fun ctx -> Task.CompletedTask)
+
+              let spec =
+                  { ResourceSpec.Empty with
+                      Name = Some "TestResource"
+                      Handlers = [ "GET", handler ] }
+
+              let resource = spec.Build("/test")
+              let endpoint = resource.Endpoints[0] :?> RouteEndpoint
+              Expect.equal endpoint.DisplayName "GET TestResource" "Display name should match"
+              let httpMethodMetadata = endpoint.Metadata.GetMetadata<HttpMethodMetadata>()
+              Expect.isNotNull httpMethodMetadata "Should have HttpMethodMetadata"
+              Expect.contains (httpMethodMetadata.HttpMethods |> Seq.toList) "GET" "Should contain GET method"
+              Expect.equal endpoint.RoutePattern.RawText "/test" "Route pattern should match"
+          }
+
+          test "Build without metadata produces functionally identical endpoints to previous behavior" {
+              let handler = RequestDelegate(fun ctx -> Task.CompletedTask)
+
+              let spec =
+                  { ResourceSpec.Empty with
+                      Name = Some "MyResource"
+                      Handlers = [ "POST", handler; "GET", handler ] }
+
+              let resource = spec.Build("/api/items")
+              Expect.equal resource.Endpoints.Length 2 "Should produce one endpoint per handler"
+
+              for endpoint in resource.Endpoints do
+                  let re = endpoint :?> RouteEndpoint
+                  Expect.equal re.RoutePattern.RawText "/api/items" "Route pattern should match"
+                  let httpMethod = re.Metadata.GetMetadata<HttpMethodMetadata>()
+                  Expect.isNotNull httpMethod "Should have HttpMethodMetadata"
+          } ]

--- a/test/Frank.Tests/NameInferenceTests.fs
+++ b/test/Frank.Tests/NameInferenceTests.fs
@@ -1,0 +1,83 @@
+module Frank.Tests.NameInferenceTests
+
+open System.Threading.Tasks
+open Microsoft.AspNetCore.Http
+open Microsoft.AspNetCore.Routing
+open Expecto
+open Frank.Builder
+
+let private buildDisplayName routeTemplate (configure: ResourceSpec -> ResourceSpec) =
+    let handler = RequestDelegate(fun _ -> Task.CompletedTask)
+
+    let spec =
+        { ResourceSpec.Empty with
+            Handlers = [ "GET", handler ] }
+        |> configure
+
+    let resource = spec.Build(routeTemplate)
+    let endpoint = resource.Endpoints[0] :?> RouteEndpoint
+    endpoint.DisplayName
+
+let private buildWithRoute routeTemplate = buildDisplayName routeTemplate id
+
+let private buildWithExplicitName routeTemplate name =
+    buildDisplayName routeTemplate (fun spec -> { spec with Name = Some name })
+
+[<Tests>]
+let nameInferenceTests =
+    testList
+        "ResourceSpec Name Inference"
+        [ test "root path infers Root" { Expect.equal (buildWithRoute "/") "GET Root" "/ should infer Root" }
+
+          test "simple resource infers title-cased name" {
+              Expect.equal (buildWithRoute "/users") "GET Users" "/users should infer Users"
+          }
+
+          test "trailing path parameter singularizes preceding segment" {
+              Expect.equal (buildWithRoute "/users/{id}") "GET User" "/users/{id} should infer User"
+          }
+
+          test "multi-segment path joins with space" {
+              Expect.equal (buildWithRoute "/admin/users") "GET Admin Users" "/admin/users should infer Admin Users"
+          }
+
+          test "hyphenated segments split and title-case" {
+              Expect.equal (buildWithRoute "/not-for-sale") "GET Not For Sale" "/not-for-sale should infer Not For Sale"
+          }
+
+          test "underscored segments split and title-case" {
+              Expect.equal (buildWithRoute "/my_items") "GET My Items" "/my_items should infer My Items"
+          }
+
+          test "multiple path parameters strip all params" {
+              Expect.equal
+                  (buildWithRoute "/users/{userId}/posts/{postId}")
+                  "GET User Post"
+                  "Multiple trailing params singularize each preceding segment"
+          }
+
+          test "explicit name overrides inference" {
+              Expect.equal
+                  (buildWithExplicitName "/users" "People")
+                  "GET People"
+                  "Explicit name should override inference"
+          }
+
+          test "path with only parameter infers Root" {
+              Expect.equal (buildWithRoute "/{id}") "GET Root" "/{id} should infer Root"
+          }
+
+          test "trailing slash is ignored" {
+              Expect.equal (buildWithRoute "/users/") "GET Users" "/users/ should infer Users"
+          }
+
+          test "route constraints in parameters are treated as params" {
+              Expect.equal
+                  (buildWithRoute "/users/{id:int}")
+                  "GET User"
+                  "/users/{id:int} should treat constrained param as param"
+          }
+
+          test "empty string route infers Root" {
+              Expect.equal (buildWithRoute "") "GET Root" "empty string should infer Root"
+          } ]


### PR DESCRIPTION
## Summary

- Auto-infer `ResourceSpec.Name` from route template when not explicitly set via the `name` CE operation
- `/users` → "Users", `/users/{id}` → "User", `/admin/users` → "Admin Users", `/not-for-sale` → "Not For Sale", `/` → "Root"
- Changes `ResourceSpec.Name` from `string` (null sentinel via `Unchecked.defaultof`) to `string option` (`None` = infer, `Some` = explicit) — eliminates a latent null
- Inferred names flow into endpoint `DisplayName` and auto-generate OpenAPI `operationId` (e.g., `/admin/users` GET → `getAdminUsers`)

## Test plan

- [x] 12 unit tests in `NameInferenceTests.fs` covering: root, simple, singularization, multi-segment, hyphens, underscores, nested params, explicit override, param-only, trailing slash, route constraints, empty string
- [x] 1 new OpenAPI integration test verifying multi-word inferred name produces correct `operationId`
- [x] All 2016 tests pass across 16 test projects
- [x] `dotnet build Frank.sln` — 0 errors
- [x] `dotnet fantomas --check` — clean
- [x] Expert review by Fielding, @7sharp9, Don Syme, Wlaschin — all findings addressed

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)