### PR TITLE
feat: typed ALPS extension vocabulary

### DIFF
--- a/src/Frank.Cli.Core/Unified/UnifiedAlpsGenerator.fs
+++ b/src/Frank.Cli.Core/Unified/UnifiedAlpsGenerator.fs
@@ -6,6 +6,7 @@ open System.Text.Json
 open System.Text.RegularExpressions
 open Frank.Cli.Core.Analysis
 open Frank.Resources.Model
+open Frank.Statecharts.Alps.Classification
 
 // ============================================================================
 // Schema.org Vocabulary Alignment (T027)
@@ -306,6 +307,21 @@ let generate (resource: UnifiedResource) (baseUri: string) : Result<string, stri
                 writeTransitionDescriptor writer descriptorId transType semanticIds rel
 
         writer.WriteEndArray()
+
+    // ── Role extensions from statechart ──
+    match resource.Statechart with
+    | Some sc when not sc.Roles.IsEmpty ->
+        writer.WritePropertyName("ext")
+        writer.WriteStartArray()
+
+        for role in sc.Roles do
+            writer.WriteStartObject()
+            writer.WriteString("id", ProjectedRoleExtId)
+            writer.WriteString("value", role.Name)
+            writer.WriteEndObject()
+
+        writer.WriteEndArray()
+    | _ -> ()
 
     writer.WriteEndObject()
     writer.WriteEndObject()

--- a/src/Frank.Statecharts.Core/Types.fs
+++ b/src/Frank.Statecharts.Core/Types.fs
@@ -82,6 +82,13 @@ type AlpsMeta =
     | AlpsLink of rel: string * href: string
     | AlpsDataDescriptor of id: string * doc: (string option * string) option
     | AlpsVersion of string
+    | AlpsRole of id: string * value: string
+    /// Guard annotation for state/document-level ext elements only.
+    /// Invariant: never appears on TransitionEdge.Annotations (guards are
+    /// extracted to TransitionEdge.Guard during classification).
+    | AlpsGuardExt of value: string
+    | AlpsDuality of id: string * value: string
+    | AlpsAvailableInStates of states: string list
 
 // -- SCXML annotation types --
 

--- a/src/Frank.Statecharts/Alps/Classification.fs
+++ b/src/Frank.Statecharts/Alps/Classification.fs
@@ -82,6 +82,34 @@ let buildDescriptorIndex (descriptors: ParsedDescriptor list) : Map<string, Pars
     collectAll Map.empty descriptors
 
 // ---------------------------------------------------------------------------
+// ALPS extension vocabulary IDs (T008)
+// ---------------------------------------------------------------------------
+
+[<Literal>]
+let GuardExtId = "guard"
+
+[<Literal>]
+let ProjectedRoleExtId = "projectedRole"
+
+[<Literal>]
+let ProtocolStateExtId = "protocolState"
+
+[<Literal>]
+let AvailableInStatesExtId = "availableInStates"
+
+[<Literal>]
+let ClientObligationExtId = "clientObligation"
+
+[<Literal>]
+let AdvancesProtocolExtId = "advancesProtocol"
+
+[<Literal>]
+let DualOfExtId = "dualOf"
+
+[<Literal>]
+let CutPointExtId = "cutPoint"
+
+// ---------------------------------------------------------------------------
 // Transition extraction (T006, ported from Mapper.fs)
 // ---------------------------------------------------------------------------
 
@@ -92,7 +120,7 @@ let resolveRt (rt: string option) : string option =
 /// Extract a guard label from ext elements (first ext with id="guard").
 let extractGuard (exts: ParsedExtension list) : string option =
     exts
-    |> List.tryFind (fun e -> e.Id = "guard")
+    |> List.tryFind (fun e -> e.Id = GuardExtId)
     |> Option.bind (fun e -> e.Value)
 
 /// Extract parameter descriptor ids from a descriptor's children.
@@ -112,6 +140,30 @@ let toTransitionKind (typeStr: string option) : AlpsTransitionKind =
     | _ -> AlpsTransitionKind.Unsafe // default
 
 // ---------------------------------------------------------------------------
+// Extension classification (T008)
+// ---------------------------------------------------------------------------
+
+/// Classify a parsed extension into a typed AlpsMeta DU case.
+/// Known extension ids get typed cases; unknown fall back to AlpsExtension.
+/// Note: these extension types do not carry href in the ALPS extension vocabulary;
+/// href is preserved only for unknown extensions via AlpsExtension fallback.
+let classifyExtension (ext: ParsedExtension) : Annotation =
+    let value = ext.Value |> Option.defaultValue ""
+
+    match ext.Id with
+    | GuardExtId -> AlpsAnnotation(AlpsGuardExt value)
+    | ProjectedRoleExtId | ProtocolStateExtId -> AlpsAnnotation(AlpsRole(ext.Id, value))
+    | AvailableInStatesExtId ->
+        let states =
+            value.Split(',', System.StringSplitOptions.RemoveEmptyEntries ||| System.StringSplitOptions.TrimEntries)
+            |> Array.toList
+
+        AlpsAnnotation(AlpsAvailableInStates states)
+    | ClientObligationExtId | AdvancesProtocolExtId | DualOfExtId | CutPointExtId ->
+        AlpsAnnotation(AlpsDuality(ext.Id, value))
+    | _ -> AlpsAnnotation(AlpsExtension(ext.Id, ext.Href, ext.Value))
+
+// ---------------------------------------------------------------------------
 // Annotation extraction (T007)
 // ---------------------------------------------------------------------------
 
@@ -123,8 +175,7 @@ let buildStateAnnotations (d: ParsedDescriptor) : Annotation list =
         | None -> []
 
     let extAnnotations =
-        d.Extensions
-        |> List.map (fun e -> AlpsAnnotation(AlpsExtension(e.Id, e.Href, e.Value)))
+        d.Extensions |> List.map classifyExtension
 
     let linkAnnotations =
         d.Links
@@ -153,11 +204,12 @@ let buildTransitionAnnotations
         | Some value -> [ AlpsAnnotation(AlpsDocumentation(resolved.DocFormat, value)) ]
         | None -> []
 
-    // 4. AlpsExtension -- in document order, excluding guards
+    // 4. Typed extensions -- in document order, excluding guards
+    //    (guards flow through TransitionEdge.Guard; AlpsGuardExt is for state/doc-level only)
     let extAnnotations =
         resolved.Extensions
-        |> List.filter (fun e -> e.Id <> "guard")
-        |> List.map (fun e -> AlpsAnnotation(AlpsExtension(e.Id, e.Href, e.Value)))
+        |> List.filter (fun e -> e.Id <> GuardExtId)
+        |> List.map classifyExtension
 
     typeAnnotation @ hrefAnnotation @ docAnnotation @ extAnnotations
 
@@ -263,8 +315,7 @@ let classifyDescriptors
         |> List.map (fun l -> AlpsAnnotation(AlpsLink(l.Rel, l.Href)))
 
     let extAnnotations =
-        rootExtensions
-        |> List.map (fun e -> AlpsAnnotation(AlpsExtension(e.Id, e.Href, e.Value)))
+        rootExtensions |> List.map classifyExtension
 
     let dataDescriptorAnnotations =
         nonStateDescriptors

--- a/src/Frank.Statecharts/Alps/GeneratorCommon.fs
+++ b/src/Frank.Statecharts/Alps/GeneratorCommon.fs
@@ -64,12 +64,28 @@ let tryGetDocAnnotation (annotations: Annotation list) : (string option * string
         | AlpsAnnotation(AlpsDocumentation(fmt, value)) -> Some(fmt, value)
         | _ -> None)
 
-/// Extract non-guard extension annotations from an annotation list.
+/// Extract extension annotations from an annotation list as (id, href, value) triples.
+/// Typed AlpsMeta cases are emitted back as triples for round-trip fidelity.
+/// Uses exhaustive match on AlpsMeta so the compiler flags unhandled cases when new ones are added.
 let getExtAnnotations (annotations: Annotation list) : (string * string option * string option) list =
     annotations
     |> List.choose (fun a ->
         match a with
-        | AlpsAnnotation(AlpsExtension(id, href, value)) -> Some(id, href, value)
+        | AlpsAnnotation meta ->
+            match meta with
+            | AlpsExtension(id, href, value) -> Some(id, href, value)
+            | AlpsRole(id, value) -> Some(id, None, Some value)
+            | AlpsGuardExt value -> Some(Classification.GuardExtId, None, Some value)
+            | AlpsDuality(id, value) -> Some(id, None, Some value)
+            | AlpsAvailableInStates states ->
+                // Normalized: no spaces (classifyExtension trims on parse)
+                Some(Classification.AvailableInStatesExtId, None, Some(states |> String.concat ","))
+            | AlpsTransitionType _
+            | AlpsDescriptorHref _
+            | AlpsDocumentation _
+            | AlpsLink _
+            | AlpsDataDescriptor _
+            | AlpsVersion _ -> None
         | _ -> None)
 
 /// Extract link annotations from an annotation list.

--- a/test/Frank.Statecharts.Tests/Alps/ExtensionClassificationTests.fs
+++ b/test/Frank.Statecharts.Tests/Alps/ExtensionClassificationTests.fs
@@ -1,0 +1,298 @@
+module Frank.Statecharts.Tests.Alps.ExtensionClassificationTests
+
+open Expecto
+open Frank.Statecharts.Ast
+open Frank.Statecharts.Alps.Classification
+
+// ---------------------------------------------------------------------------
+// classifyExtension: maps ParsedExtension → typed AlpsMeta DU cases
+// ---------------------------------------------------------------------------
+
+[<Tests>]
+let classifyExtensionTests =
+    testList
+        "ALPS extension classification"
+        [
+          // Guard extensions
+          testCase "guard extension → AlpsGuardExt"
+          <| fun () ->
+              let ext =
+                  { Id = "guard"
+                    Href = None
+                    Value = Some "emailValid" }
+
+              let result = classifyExtension ext
+              Expect.equal result (AlpsAnnotation(AlpsGuardExt "emailValid")) "guard → AlpsGuardExt"
+
+          testCase "guard extension without value → AlpsGuardExt empty"
+          <| fun () ->
+              let ext =
+                  { Id = "guard"
+                    Href = None
+                    Value = None }
+
+              let result = classifyExtension ext
+              Expect.equal result (AlpsAnnotation(AlpsGuardExt "")) "guard with no value → AlpsGuardExt \"\""
+
+          // Role extensions
+          testCase "projectedRole → AlpsRole"
+          <| fun () ->
+              let ext =
+                  { Id = "projectedRole"
+                    Href = None
+                    Value = Some "admin" }
+
+              let result = classifyExtension ext
+              Expect.equal result (AlpsAnnotation(AlpsRole("projectedRole", "admin"))) "projectedRole → AlpsRole"
+
+          testCase "protocolState → AlpsRole"
+          <| fun () ->
+              let ext =
+                  { Id = "protocolState"
+                    Href = None
+                    Value = Some "authenticated" }
+
+              let result = classifyExtension ext
+
+              Expect.equal
+                  result
+                  (AlpsAnnotation(AlpsRole("protocolState", "authenticated")))
+                  "protocolState → AlpsRole"
+
+          // Duality extensions
+          testCase "clientObligation → AlpsDuality"
+          <| fun () ->
+              let ext =
+                  { Id = "clientObligation"
+                    Href = None
+                    Value = Some "must-ack" }
+
+              let result = classifyExtension ext
+
+              Expect.equal
+                  result
+                  (AlpsAnnotation(AlpsDuality("clientObligation", "must-ack")))
+                  "clientObligation → AlpsDuality"
+
+          testCase "advancesProtocol → AlpsDuality"
+          <| fun () ->
+              let ext =
+                  { Id = "advancesProtocol"
+                    Href = None
+                    Value = Some "true" }
+
+              let result = classifyExtension ext
+
+              Expect.equal
+                  result
+                  (AlpsAnnotation(AlpsDuality("advancesProtocol", "true")))
+                  "advancesProtocol → AlpsDuality"
+
+          testCase "dualOf → AlpsDuality"
+          <| fun () ->
+              let ext =
+                  { Id = "dualOf"
+                    Href = None
+                    Value = Some "serverAction" }
+
+              let result = classifyExtension ext
+              Expect.equal result (AlpsAnnotation(AlpsDuality("dualOf", "serverAction"))) "dualOf → AlpsDuality"
+
+          testCase "cutPoint → AlpsDuality"
+          <| fun () ->
+              let ext =
+                  { Id = "cutPoint"
+                    Href = None
+                    Value = Some "true" }
+
+              let result = classifyExtension ext
+              Expect.equal result (AlpsAnnotation(AlpsDuality("cutPoint", "true"))) "cutPoint → AlpsDuality"
+
+          // AvailableInStates extension
+          testCase "availableInStates → AlpsAvailableInStates"
+          <| fun () ->
+              let ext =
+                  { Id = "availableInStates"
+                    Href = None
+                    Value = Some "XTurn,OTurn" }
+
+              let result = classifyExtension ext
+
+              Expect.equal
+                  result
+                  (AlpsAnnotation(AlpsAvailableInStates [ "XTurn"; "OTurn" ]))
+                  "availableInStates → AlpsAvailableInStates"
+
+          testCase "availableInStates single state"
+          <| fun () ->
+              let ext =
+                  { Id = "availableInStates"
+                    Href = None
+                    Value = Some "Won" }
+
+              let result = classifyExtension ext
+              Expect.equal result (AlpsAnnotation(AlpsAvailableInStates [ "Won" ])) "single state"
+
+          testCase "availableInStates trims whitespace around entries"
+          <| fun () ->
+              let ext =
+                  { Id = "availableInStates"
+                    Href = None
+                    Value = Some "XTurn, OTurn , Won" }
+
+              let result = classifyExtension ext
+
+              Expect.equal
+                  result
+                  (AlpsAnnotation(AlpsAvailableInStates [ "XTurn"; "OTurn"; "Won" ]))
+                  "whitespace trimmed"
+
+          testCase "availableInStates ignores empty entries from double commas"
+          <| fun () ->
+              let ext =
+                  { Id = "availableInStates"
+                    Href = None
+                    Value = Some "XTurn,,OTurn" }
+
+              let result = classifyExtension ext
+
+              Expect.equal
+                  result
+                  (AlpsAnnotation(AlpsAvailableInStates [ "XTurn"; "OTurn" ]))
+                  "empty entries removed"
+
+          // Fallback: unknown extension → AlpsExtension (backward compat)
+          testCase "unknown extension → AlpsExtension fallback"
+          <| fun () ->
+              let ext =
+                  { Id = "author"
+                    Href = Some "http://example.com"
+                    Value = Some "amundsen" }
+
+              let result = classifyExtension ext
+
+              Expect.equal
+                  result
+                  (AlpsAnnotation(AlpsExtension("author", Some "http://example.com", Some "amundsen")))
+                  "unknown → AlpsExtension" ]
+
+// ---------------------------------------------------------------------------
+// buildStateAnnotations uses classifyExtension for typed extensions
+// ---------------------------------------------------------------------------
+
+[<Tests>]
+let buildStateAnnotationsTypedTests =
+    testList
+        "buildStateAnnotations with typed extensions"
+        [ testCase "state with role extension gets AlpsRole annotation"
+          <| fun () ->
+              let descriptor =
+                  { Id = Some "XTurn"
+                    Type = Some "semantic"
+                    Href = None
+                    ReturnType = None
+                    DocFormat = None
+                    DocValue = None
+                    Children = []
+                    Extensions =
+                      [ { Id = "projectedRole"
+                          Href = None
+                          Value = Some "PlayerX" } ]
+                    Links = [] }
+
+              let annotations = buildStateAnnotations descriptor
+
+              let hasRole =
+                  annotations
+                  |> List.exists (fun a ->
+                      match a with
+                      | AlpsAnnotation(AlpsRole("projectedRole", "PlayerX")) -> true
+                      | _ -> false)
+
+              Expect.isTrue hasRole "should contain AlpsRole annotation"
+
+          testCase "state with unknown extension gets AlpsExtension annotation"
+          <| fun () ->
+              let descriptor =
+                  { Id = Some "home"
+                    Type = Some "semantic"
+                    Href = None
+                    ReturnType = None
+                    DocFormat = None
+                    DocValue = None
+                    Children = []
+                    Extensions =
+                      [ { Id = "author"
+                          Href = None
+                          Value = Some "test" } ]
+                    Links = [] }
+
+              let annotations = buildStateAnnotations descriptor
+
+              let hasExt =
+                  annotations
+                  |> List.exists (fun a ->
+                      match a with
+                      | AlpsAnnotation(AlpsExtension("author", None, Some "test")) -> true
+                      | _ -> false)
+
+              Expect.isTrue hasExt "should contain AlpsExtension annotation" ]
+
+// ---------------------------------------------------------------------------
+// buildTransitionAnnotations uses classifyExtension for typed extensions
+// ---------------------------------------------------------------------------
+
+[<Tests>]
+let buildTransitionAnnotationsTypedTests =
+    testList
+        "buildTransitionAnnotations with typed extensions"
+        [ testCase "transition with duality extension gets AlpsDuality annotation"
+          <| fun () ->
+              let resolved =
+                  { Id = Some "makeMove"
+                    Type = Some "unsafe"
+                    Href = None
+                    ReturnType = Some "#OTurn"
+                    DocFormat = None
+                    DocValue = None
+                    Children = []
+                    Extensions =
+                      [ { Id = "guard"
+                          Href = None
+                          Value = Some "role=PlayerX" }
+                        { Id = "clientObligation"
+                          Href = None
+                          Value = Some "must-ack" } ]
+                    Links = [] }
+
+              let originalChild =
+                  { Id = Some "makeMove"
+                    Type = Some "unsafe"
+                    Href = None
+                    ReturnType = Some "#OTurn"
+                    DocFormat = None
+                    DocValue = None
+                    Children = []
+                    Extensions = resolved.Extensions
+                    Links = [] }
+
+              let annotations =
+                  buildTransitionAnnotations AlpsTransitionKind.Unsafe originalChild resolved
+
+              // Guard should be excluded (handled by extractGuard)
+              let hasDuality =
+                  annotations
+                  |> List.exists (fun a ->
+                      match a with
+                      | AlpsAnnotation(AlpsDuality("clientObligation", "must-ack")) -> true
+                      | _ -> false)
+
+              let hasGuard =
+                  annotations
+                  |> List.exists (fun a ->
+                      match a with
+                      | AlpsAnnotation(AlpsGuardExt _) -> true
+                      | _ -> false)
+
+              Expect.isTrue hasDuality "should contain AlpsDuality annotation"
+              Expect.isFalse hasGuard "guard should be excluded from transition annotations" ]

--- a/test/Frank.Statecharts.Tests/Alps/GoldenFiles.fs
+++ b/test/Frank.Statecharts.Tests/Alps/GoldenFiles.fs
@@ -402,6 +402,72 @@ let amundsenOnboardingAlpsJson = """{
   }
 }"""
 
+/// Golden file exercising all typed ALPS extension vocabulary terms:
+/// guard, projectedRole, protocolState, clientObligation, advancesProtocol,
+/// dualOf, cutPoint, availableInStates.
+[<Literal>]
+let roleExtensionsAlpsJson = """{
+  "alps": {
+    "version": "1.0",
+    "doc": { "format": "text", "value": "Protocol with role extensions" },
+    "descriptor": [
+      {
+        "id": "payload",
+        "type": "semantic"
+      },
+      {
+        "id": "Idle",
+        "type": "semantic",
+        "ext": [
+          { "id": "projectedRole", "value": "server" },
+          { "id": "availableInStates", "value": "Idle" }
+        ],
+        "descriptor": [
+          {
+            "id": "start",
+            "type": "unsafe",
+            "rt": "#Active",
+            "ext": [
+              { "id": "guard", "value": "isReady" },
+              { "id": "clientObligation", "value": "must-ack" },
+              { "id": "advancesProtocol", "value": "true" }
+            ],
+            "descriptor": [
+              { "href": "#payload" }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "Active",
+        "type": "semantic",
+        "ext": [
+          { "id": "projectedRole", "value": "client" },
+          { "id": "protocolState", "value": "running" }
+        ],
+        "descriptor": [
+          {
+            "id": "complete",
+            "type": "safe",
+            "rt": "#Done",
+            "ext": [
+              { "id": "dualOf", "value": "start" },
+              { "id": "cutPoint", "value": "true" }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "Done",
+        "type": "semantic",
+        "ext": [
+          { "id": "availableInStates", "value": "Done" }
+        ]
+      }
+    ]
+  }
+}"""
+
 [<Literal>]
 let onboardingAlpsXml = """<?xml version="1.0" encoding="UTF-8"?>
 <alps version="1.0">

--- a/test/Frank.Statecharts.Tests/Alps/JsonParserTests.fs
+++ b/test/Frank.Statecharts.Tests/Alps/JsonParserTests.fs
@@ -348,7 +348,7 @@ let jsonParserEdgeCaseTests =
               // href-only descriptor with no id won't become a state or data descriptor
               Expect.isEmpty (getStates doc) "no states"
 
-          testCase "multiple ext elements on a single descriptor produce extension annotations"
+          testCase "multiple ext elements on a single descriptor produce typed annotations"
           <| fun _ ->
               // Build a state with two ext elements and a transition child so it's classified as a state
               let json =
@@ -359,15 +359,24 @@ let jsonParserEdgeCaseTests =
 
               let stateA = states |> List.find (fun s -> s.Identifier = Some "StateA")
 
-              // State annotations should include the extensions
-              let extAnnotations =
+              // guard ext should be classified as AlpsGuardExt
+              let hasGuard =
                   stateA.Annotations
-                  |> List.choose (fun a ->
+                  |> List.exists (fun a ->
                       match a with
-                      | AlpsAnnotation(AlpsExtension(id, _, _)) -> Some id
-                      | _ -> None)
+                      | AlpsAnnotation(AlpsGuardExt "role=X") -> true
+                      | _ -> false)
 
-              Expect.containsAll (Set.ofList extAnnotations) (Set.ofList [ "guard"; "meta" ]) "both extensions present"
+              // unknown ext should remain as AlpsExtension
+              let hasMeta =
+                  stateA.Annotations
+                  |> List.exists (fun a ->
+                      match a with
+                      | AlpsAnnotation(AlpsExtension("meta", _, Some "info")) -> true
+                      | _ -> false)
+
+              Expect.isTrue hasGuard "guard classified as AlpsGuardExt"
+              Expect.isTrue hasMeta "meta remains AlpsExtension"
 
           testCase "unicode characters in descriptor ids"
           <| fun _ ->

--- a/test/Frank.Statecharts.Tests/Alps/RoundTripTests.fs
+++ b/test/Frank.Statecharts.Tests/Alps/RoundTripTests.fs
@@ -533,4 +533,11 @@ let amundsenRoundTripTests =
               let generated = generateAlpsJson result1.Document
               let result2 = parseAlpsJson generated
               Expect.isEmpty result2.Errors "re-parse succeeds"
-              Expect.equal result1.Document result2.Document "idempotent transition roundtrips" ]
+              Expect.equal result1.Document result2.Document "idempotent transition roundtrips"
+
+          testCase "role extensions golden file roundtrips"
+          <| fun _ ->
+              let original = parseOk roleExtensionsAlpsJson "parse failed"
+              let generated = generateAlpsJson original
+              let roundTripped = parseOk generated "re-parse failed"
+              Expect.equal roundTripped original "role extensions round-trip preserves AST" ]

--- a/test/Frank.Statecharts.Tests/Frank.Statecharts.Tests.fsproj
+++ b/test/Frank.Statecharts.Tests/Frank.Statecharts.Tests.fsproj
@@ -42,6 +42,7 @@
     <Compile Include="Alps/XmlParserTests.fs" />
     <Compile Include="Alps/JsonGeneratorTests.fs" />
     <Compile Include="Alps/RoundTripTests.fs" />
+    <Compile Include="Alps/ExtensionClassificationTests.fs" />
     <Compile Include="Alps/XmlGeneratorTests.fs" />
     <!-- Validation tests -->
     <Compile Include="Validation/StringDistanceTests.fs" />


### PR DESCRIPTION
## Summary

- Adds 4 new `AlpsMeta` DU cases (`AlpsRole`, `AlpsGuardExt`, `AlpsDuality`, `AlpsAvailableInStates`) for typed classification of known ALPS `ext` elements
- Introduces `classifyExtension` function with `[<Literal>]` constants for all 8 vocabulary IDs
- Updates generators with exhaustive `AlpsMeta` match for compile-time safety on future additions
- Wires `ExtractedStatechart.Roles` → `projectedRole` ext emission in `UnifiedAlpsGenerator`
- Unknown extensions fall back to `AlpsExtension` (backward compatible)

## Deferred items (filed as issues)

- #165 — Namespaced URIs for extension IDs before external publication
- #166 — Preserve `href` on typed extension DU cases for round-trip fidelity
- #167 — Sub-DUs for `AlpsRole`/`AlpsDuality` id fields

## Test plan

- [x] 15 new tests: classifyExtension (11), buildStateAnnotations (2), buildTransitionAnnotations (1), round-trip (1)
- [x] 2 edge case tests for availableInStates whitespace/double-comma handling
- [x] Golden file exercises all 8 extension vocabulary terms
- [x] All 2020 tests pass across 16 test projects
- [x] `dotnet build Frank.sln` — 0 errors
- [x] Expert review by Miller, Amundsen, Syme, @7sharp9 — all findings addressed or deferred with issues

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)