### PR TITLE
fix: adopt withServer callback pattern for proper test host disposal

### DIFF
--- a/test/Frank.Discovery.Tests/CombinationTests.fs
+++ b/test/Frank.Discovery.Tests/CombinationTests.fs
@@ -3,6 +3,7 @@ module Frank.Discovery.Tests.CombinationTests
 open System.Net
 open System.Net.Http
 open System.Net.Http.Headers
+open System.Threading.Tasks
 open Microsoft.AspNetCore.Http
 open Expecto
 open Frank.Builder
@@ -31,13 +32,18 @@ let private rootResource () =
         get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("root handler")))
     }
 
-/// Build a spec with specific CE operations applied, then create a test server.
-let private buildSpec (configure: WebHostBuilder -> WebHostSpec -> WebHostSpec) (res: Resource) =
+/// Build a spec with specific CE operations applied, then run a test against that server.
+let private withSpec
+    (configure: WebHostBuilder -> WebHostSpec -> WebHostSpec)
+    (res: Resource)
+    (f: HttpClient -> Task)
+    =
     let ceBuilder = WebHostBuilder([||])
-    ceBuilder.Yield()
-    |> configure ceBuilder
-    |> fun s -> ceBuilder.Resource(s, res)
-    |> buildCeTestServer
+    let spec =
+        ceBuilder.Yield()
+        |> configure ceBuilder
+        |> fun s -> ceBuilder.Resource(s, res)
+    withCeServer spec f
 
 // -- A. Individual isolation --
 
@@ -45,40 +51,45 @@ let private buildSpec (configure: WebHostBuilder -> WebHostSpec -> WebHostSpec) 
 let isolationTests =
     testList "A. Individual isolation" [
         testTask "useOptionsDiscovery alone handles OPTIONS" {
-            let client = buildSpec (fun b s -> b.UseOptionsDiscovery(s)) (itemsResourceWithMedia ())
-            let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
-            Expect.equal resp.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
-            Expect.isGreaterThan (resp.Content.Headers.Allow.Count) 0 "should have Allow header"
+            do! withSpec (fun b s -> b.UseOptionsDiscovery(s)) (itemsResourceWithMedia ()) (fun client -> task {
+                let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
+                Expect.equal resp.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
+                Expect.isGreaterThan (resp.Content.Headers.Allow.Count) 0 "should have Allow header"
+            })
         }
 
         testTask "useOptionsDiscovery alone does not add Link headers" {
-            let client = buildSpec (fun b s -> b.UseOptionsDiscovery(s)) (itemsResourceWithMedia ())
-            let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
-            Expect.isFalse (resp.Headers.Contains("Link")) "should not have Link header from OPTIONS-only middleware"
+            do! withSpec (fun b s -> b.UseOptionsDiscovery(s)) (itemsResourceWithMedia ()) (fun client -> task {
+                let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
+                Expect.isFalse (resp.Headers.Contains("Link")) "should not have Link header from OPTIONS-only middleware"
+            })
         }
 
         testTask "useLinkHeaders alone adds Link headers to GET" {
-            let client = buildSpec (fun b s -> b.UseLinkHeaders(s)) (itemsResourceWithMedia ())
-            let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
-            Expect.equal resp.StatusCode HttpStatusCode.OK "GET should return 200"
-            Expect.isTrue (resp.Headers.Contains("Link")) "should have Link header"
+            do! withSpec (fun b s -> b.UseLinkHeaders(s)) (itemsResourceWithMedia ()) (fun client -> task {
+                let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
+                Expect.equal resp.StatusCode HttpStatusCode.OK "GET should return 200"
+                Expect.isTrue (resp.Headers.Contains("Link")) "should have Link header"
+            })
         }
 
         testTask "useLinkHeaders alone does not handle OPTIONS" {
-            let client = buildSpec (fun b s -> b.UseLinkHeaders(s)) (itemsResourceWithMedia ())
-            let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
-            // Without OptionsDiscoveryMiddleware, OPTIONS goes to the routing layer
-            Expect.notEqual resp.StatusCode HttpStatusCode.OK "should not get 200 from discovery"
+            do! withSpec (fun b s -> b.UseLinkHeaders(s)) (itemsResourceWithMedia ()) (fun client -> task {
+                let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
+                // Without OptionsDiscoveryMiddleware, OPTIONS goes to the routing layer
+                Expect.notEqual resp.StatusCode HttpStatusCode.OK "should not get 200 from discovery"
+            })
         }
 
         testTask "useJsonHome alone serves home document" {
-            let client = buildSpec (fun b s -> b.UseJsonHome(s)) (itemsResourcePlain ())
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            Expect.equal resp.StatusCode HttpStatusCode.OK "should serve home document"
-            Expect.equal (resp.Content.Headers.ContentType.MediaType) "application/json-home" "content type"
-            Expect.isTrue (resp.Headers.Contains("Vary")) "should have Vary header"
+            do! withSpec (fun b s -> b.UseJsonHome(s)) (itemsResourcePlain ()) (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp.StatusCode HttpStatusCode.OK "should serve home document"
+                Expect.equal (resp.Content.Headers.ContentType.MediaType) "application/json-home" "content type"
+                Expect.isTrue (resp.Headers.Contains("Vary")) "should have Vary header"
+            })
         }
     ]
 
@@ -90,65 +101,59 @@ let pairwiseTests =
         testTask "useOptionsDiscovery + useLinkHeaders = useDiscoveryHeaders behavior" {
             let res = itemsResourceWithMedia ()
 
-            // Build individual-ops server
-            let clientIndiv =
-                buildSpec (fun b s -> s |> b.UseOptionsDiscovery |> b.UseLinkHeaders) res
-
-            // Build useDiscoveryHeaders server
-            let clientBundle =
-                buildSpec (fun b s -> b.UseDiscoveryHeaders(s)) res
-
             // Axis 1: Allow on OPTIONS
-            let! (r1: HttpResponseMessage) = clientIndiv.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
-            let! (r2: HttpResponseMessage) = clientBundle.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
-            let allow1 = r1.Content.Headers.Allow |> Set.ofSeq
-            let allow2 = r2.Content.Headers.Allow |> Set.ofSeq
-            Expect.equal allow1 allow2 "Allow headers should match"
+            do! withSpec (fun b s -> s |> b.UseOptionsDiscovery |> b.UseLinkHeaders) res (fun clientIndiv -> task {
+                do! withSpec (fun b s -> b.UseDiscoveryHeaders(s)) res (fun clientBundle -> task {
+                    let! (r1: HttpResponseMessage) = clientIndiv.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
+                    let! (r2: HttpResponseMessage) = clientBundle.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
+                    let allow1 = r1.Content.Headers.Allow |> Set.ofSeq
+                    let allow2 = r2.Content.Headers.Allow |> Set.ofSeq
+                    Expect.equal allow1 allow2 "Allow headers should match"
 
-            // Axis 2: Link on GET
-            let! (r3: HttpResponseMessage) = clientIndiv.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
-            let! (r4: HttpResponseMessage) = clientBundle.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
-            Expect.equal (r3.Headers.Contains("Link")) (r4.Headers.Contains("Link")) "Link header presence should match"
+                    // Axis 2: Link on GET
+                    let! (r3: HttpResponseMessage) = clientIndiv.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
+                    let! (r4: HttpResponseMessage) = clientBundle.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
+                    Expect.equal (r3.Headers.Contains("Link")) (r4.Headers.Contains("Link")) "Link header presence should match"
 
-            // Axis 3: pass-through on unmatched
-            let! (r5: HttpResponseMessage) = clientIndiv.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/nonexistent"))
-            let! (r6: HttpResponseMessage) = clientBundle.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/nonexistent"))
-            Expect.equal r5.StatusCode r6.StatusCode "unmatched status should match"
+                    // Axis 3: pass-through on unmatched
+                    let! (r5: HttpResponseMessage) = clientIndiv.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/nonexistent"))
+                    let! (r6: HttpResponseMessage) = clientBundle.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/nonexistent"))
+                    Expect.equal r5.StatusCode r6.StatusCode "unmatched status should match"
+                })
+            })
         }
 
         testTask "useOptionsDiscovery + useJsonHome work together" {
-            let client =
-                buildSpec (fun b s -> s |> b.UseJsonHome |> b.UseOptionsDiscovery) (itemsResourceWithMedia ())
+            do! withSpec (fun b s -> s |> b.UseJsonHome |> b.UseOptionsDiscovery) (itemsResourceWithMedia ()) (fun client -> task {
+                // OPTIONS works
+                let! (resp1: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
+                Expect.equal resp1.StatusCode HttpStatusCode.OK "OPTIONS should work"
+                Expect.isGreaterThan (resp1.Content.Headers.Allow.Count) 0 "should have Allow"
 
-            // OPTIONS works
-            let! (resp1: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
-            Expect.equal resp1.StatusCode HttpStatusCode.OK "OPTIONS should work"
-            Expect.isGreaterThan (resp1.Content.Headers.Allow.Count) 0 "should have Allow"
+                // JSON Home works
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp2: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp2.StatusCode HttpStatusCode.OK "JSON Home should work"
 
-            // JSON Home works
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
-            let! (resp2: HttpResponseMessage) = client.SendAsync(req)
-            Expect.equal resp2.StatusCode HttpStatusCode.OK "JSON Home should work"
-
-            // Link headers absent (no LinkHeaderMiddleware)
-            let! (resp3: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
-            Expect.isFalse (resp3.Headers.Contains("Link")) "Link headers should be absent"
+                // Link headers absent (no LinkHeaderMiddleware)
+                let! (resp3: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
+                Expect.isFalse (resp3.Headers.Contains("Link")) "Link headers should be absent"
+            })
         }
 
         testTask "useLinkHeaders + useJsonHome work together" {
-            let client =
-                buildSpec (fun b s -> s |> b.UseJsonHome |> b.UseLinkHeaders) (itemsResourceWithMedia ())
+            do! withSpec (fun b s -> s |> b.UseJsonHome |> b.UseLinkHeaders) (itemsResourceWithMedia ()) (fun client -> task {
+                // Link headers on GET
+                let! (resp1: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
+                Expect.isTrue (resp1.Headers.Contains("Link")) "should have Link header"
 
-            // Link headers on GET
-            let! (resp1: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
-            Expect.isTrue (resp1.Headers.Contains("Link")) "should have Link header"
-
-            // JSON Home works
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
-            let! (resp2: HttpResponseMessage) = client.SendAsync(req)
-            Expect.equal resp2.StatusCode HttpStatusCode.OK "JSON Home should work"
+                // JSON Home works
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp2: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp2.StatusCode HttpStatusCode.OK "JSON Home should work"
+            })
         }
     ]
 
@@ -158,41 +163,41 @@ let pairwiseTests =
 let bundleTests =
     testList "C. Full bundle" [
         testTask "useDiscoveryHeaders provides OPTIONS and Link but not JSON Home" {
-            let client = buildSpec (fun b s -> b.UseDiscoveryHeaders(s)) (itemsResourceWithMedia ())
+            do! withSpec (fun b s -> b.UseDiscoveryHeaders(s)) (itemsResourceWithMedia ()) (fun client -> task {
+                // OPTIONS works
+                let! (resp1: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
+                Expect.equal resp1.StatusCode HttpStatusCode.OK "OPTIONS should work"
 
-            // OPTIONS works
-            let! (resp1: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
-            Expect.equal resp1.StatusCode HttpStatusCode.OK "OPTIONS should work"
+                // Link works
+                let! (resp2: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
+                Expect.isTrue (resp2.Headers.Contains("Link")) "should have Link header"
 
-            // Link works
-            let! (resp2: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
-            Expect.isTrue (resp2.Headers.Contains("Link")) "should have Link header"
-
-            // JSON Home NOT available
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
-            let! (resp3: HttpResponseMessage) = client.SendAsync(req)
-            Expect.notEqual resp3.StatusCode HttpStatusCode.OK "should not serve JSON Home"
+                // JSON Home NOT available
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp3: HttpResponseMessage) = client.SendAsync(req)
+                Expect.notEqual resp3.StatusCode HttpStatusCode.OK "should not serve JSON Home"
+            })
         }
 
         testTask "useDiscovery provides OPTIONS, Link headers, and JSON Home" {
-            let client = buildSpec (fun b s -> b.UseDiscovery(s)) (itemsResourceWithMedia ())
+            do! withSpec (fun b s -> b.UseDiscovery(s)) (itemsResourceWithMedia ()) (fun client -> task {
+                // OPTIONS works
+                let! (resp1: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
+                Expect.equal resp1.StatusCode HttpStatusCode.OK "OPTIONS should work"
+                Expect.isGreaterThan (resp1.Content.Headers.Allow.Count) 0 "should have Allow"
 
-            // OPTIONS works
-            let! (resp1: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
-            Expect.equal resp1.StatusCode HttpStatusCode.OK "OPTIONS should work"
-            Expect.isGreaterThan (resp1.Content.Headers.Allow.Count) 0 "should have Allow"
+                // Link headers work
+                let! (resp2: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
+                Expect.isTrue (resp2.Headers.Contains("Link")) "should have Link header"
 
-            // Link headers work
-            let! (resp2: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
-            Expect.isTrue (resp2.Headers.Contains("Link")) "should have Link header"
-
-            // JSON Home works
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
-            let! (resp3: HttpResponseMessage) = client.SendAsync(req)
-            Expect.equal resp3.StatusCode HttpStatusCode.OK "JSON Home should work"
-            Expect.isTrue (resp3.Headers.Contains("Vary")) "should have Vary header"
+                // JSON Home works
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp3: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp3.StatusCode HttpStatusCode.OK "JSON Home should work"
+                Expect.isTrue (resp3.Headers.Contains("Vary")) "should have Vary header"
+            })
         }
     ]
 
@@ -204,23 +209,20 @@ let orderingTests =
         testTask "useLinkHeaders before useOptionsDiscovery same as after" {
             let res = itemsResourceWithMedia ()
 
-            // Order 1: Link then Options
-            let client1 =
-                buildSpec (fun b s -> s |> b.UseLinkHeaders |> b.UseOptionsDiscovery) res
+            // Order 1: Link then Options; Order 2: Options then Link — test both in nested servers
+            do! withSpec (fun b s -> s |> b.UseLinkHeaders |> b.UseOptionsDiscovery) res (fun client1 -> task {
+                do! withSpec (fun b s -> s |> b.UseOptionsDiscovery |> b.UseLinkHeaders) res (fun client2 -> task {
+                    // Axis 1: Allow on OPTIONS
+                    let! (r1: HttpResponseMessage) = client1.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
+                    let! (r2: HttpResponseMessage) = client2.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
+                    Expect.equal (r1.Content.Headers.Allow |> Set.ofSeq) (r2.Content.Headers.Allow |> Set.ofSeq) "Allow headers should match"
 
-            // Order 2: Options then Link
-            let client2 =
-                buildSpec (fun b s -> s |> b.UseOptionsDiscovery |> b.UseLinkHeaders) res
-
-            // Axis 1: Allow on OPTIONS
-            let! (r1: HttpResponseMessage) = client1.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
-            let! (r2: HttpResponseMessage) = client2.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
-            Expect.equal (r1.Content.Headers.Allow |> Set.ofSeq) (r2.Content.Headers.Allow |> Set.ofSeq) "Allow headers should match"
-
-            // Axis 2: Link on GET
-            let! (r3: HttpResponseMessage) = client1.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
-            let! (r4: HttpResponseMessage) = client2.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
-            Expect.equal (r3.Headers.Contains("Link")) (r4.Headers.Contains("Link")) "Link header presence should match"
+                    // Axis 2: Link on GET
+                    let! (r3: HttpResponseMessage) = client1.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
+                    let! (r4: HttpResponseMessage) = client2.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
+                    Expect.equal (r3.Headers.Contains("Link")) (r4.Headers.Contains("Link")) "Link header presence should match"
+                })
+            })
         }
     ]
 
@@ -236,17 +238,18 @@ let degradationTests =
                 ceBuilder.Yield()
                 |> fun s -> ceBuilder.UseOptionsDiscovery(s)
 
-            let client = buildCeTestServer spec
-
-            let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/anything"))
-            Expect.notEqual resp.StatusCode HttpStatusCode.OK "should pass through (404)"
+            do! withCeServer spec (fun client -> task {
+                let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/anything"))
+                Expect.notEqual resp.StatusCode HttpStatusCode.OK "should pass through (404)"
+            })
         }
 
         testTask "Link headers with no DiscoveryMediaType metadata adds nothing" {
-            let client = buildSpec (fun b s -> b.UseLinkHeaders(s)) (itemsResourcePlain ())
-            let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
-            Expect.equal resp.StatusCode HttpStatusCode.OK "GET should return 200"
-            Expect.isFalse (resp.Headers.Contains("Link")) "should not have Link header without metadata"
+            do! withSpec (fun b s -> b.UseLinkHeaders(s)) (itemsResourcePlain ()) (fun client -> task {
+                let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
+                Expect.equal resp.StatusCode HttpStatusCode.OK "GET should return 200"
+                Expect.isFalse (resp.Headers.Contains("Link")) "should not have Link header without metadata"
+            })
         }
 
         testTask "JSON Home with no resources returns valid empty document" {
@@ -255,16 +258,16 @@ let degradationTests =
                 ceBuilder.Yield()
                 |> fun s -> ceBuilder.UseJsonHome(s)
 
-            let client = buildCeTestServer spec
-
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            Expect.equal resp.StatusCode HttpStatusCode.OK "should return 200"
-            Expect.equal (resp.Content.Headers.ContentType.MediaType) "application/json-home" "content type"
-            Expect.isTrue (resp.Headers.Contains("Vary")) "should have Vary header"
-            let! (body: string) = resp.Content.ReadAsStringAsync()
-            Expect.isTrue (body.Contains("\"resources\"")) "should have resources key"
+            do! withCeServer spec (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp.StatusCode HttpStatusCode.OK "should return 200"
+                Expect.equal (resp.Content.Headers.ContentType.MediaType) "application/json-home" "content type"
+                Expect.isTrue (resp.Headers.Contains("Vary")) "should have Vary header"
+                let! (body: string) = resp.Content.ReadAsStringAsync()
+                Expect.isTrue (body.Contains("\"resources\"")) "should have resources key"
+            })
         }
     ]
 
@@ -274,24 +277,26 @@ let degradationTests =
 let interactionTests =
     testList "F. Accept header interaction" [
         testTask "JSON Home at root with wrong Accept passes through" {
-            let client = buildSpec (fun b s -> b.UseDiscovery(s)) (itemsResourcePlain ())
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("text/html"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            // Middleware should not intercept — wrong Accept type
-            let contentType =
-                if isNull resp.Content.Headers.ContentType then ""
-                else resp.Content.Headers.ContentType.MediaType
-            Expect.notEqual contentType "application/json-home" "should not be json-home"
-            Expect.isFalse (resp.Headers.Contains("Vary")) "should not have Vary from json-home middleware"
+            do! withSpec (fun b s -> b.UseDiscovery(s)) (itemsResourcePlain ()) (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("text/html"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                // Middleware should not intercept — wrong Accept type
+                let contentType =
+                    if isNull resp.Content.Headers.ContentType then ""
+                    else resp.Content.Headers.ContentType.MediaType
+                Expect.notEqual contentType "application/json-home" "should not be json-home"
+                Expect.isFalse (resp.Headers.Contains("Vary")) "should not have Vary from json-home middleware"
+            })
         }
 
         testTask "OPTIONS at root passes through when no user endpoint at root" {
-            let client = buildSpec (fun b s -> b.UseDiscovery(s)) (itemsResourceWithMedia ())
-            // No user-defined resource at /, JSON Home only intercepts GET/HEAD
-            let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/"))
-            // OptionsDiscoveryMiddleware scans EndpointDataSource — no endpoint at /
-            Expect.notEqual resp.StatusCode HttpStatusCode.OK "OPTIONS at root should pass through"
+            do! withSpec (fun b s -> b.UseDiscovery(s)) (itemsResourceWithMedia ()) (fun client -> task {
+                // No user-defined resource at /, JSON Home only intercepts GET/HEAD
+                let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/"))
+                // OptionsDiscoveryMiddleware scans EndpointDataSource — no endpoint at /
+                Expect.notEqual resp.StatusCode HttpStatusCode.OK "OPTIONS at root should pass through"
+            })
         }
 
         testTask "user-defined GET / handler responds normally under useDiscovery" {
@@ -302,13 +307,13 @@ let interactionTests =
                 |> fun s -> ceBuilder.UseDiscovery(s)
                 |> fun s -> ceBuilder.Resource(s, rootResource ())
 
-            let client = buildCeTestServer spec
-
-            // GET / without json-home Accept should get user handler, not JSON Home
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("text/html"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            let! (body: string) = resp.Content.ReadAsStringAsync()
-            Expect.equal body "root handler" "should get user handler response"
+            do! withCeServer spec (fun client -> task {
+                // GET / without json-home Accept should get user handler, not JSON Home
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("text/html"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                let! (body: string) = resp.Content.ReadAsStringAsync()
+                Expect.equal body "root handler" "should get user handler response"
+            })
         }
     ]

--- a/test/Frank.Discovery.Tests/EdgeCaseTests.fs
+++ b/test/Frank.Discovery.Tests/EdgeCaseTests.fs
@@ -2,6 +2,7 @@ module Frank.Discovery.Tests.EdgeCaseTests
 
 open System.Net
 open System.Net.Http
+open System.Threading.Tasks
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
 open Microsoft.AspNetCore.Http
@@ -28,22 +29,23 @@ let edgeCaseTests =
                     discoveryMediaType "application/ld+json" "describedby"
                 }
 
-            let client = createDiscoveryTestServer [ itemsResource ]
-            let request = new HttpRequestMessage(HttpMethod.Options, "/items")
-            request.Headers.Add("Origin", "http://example.com")
-            request.Headers.Add("Access-Control-Request-Method", "GET")
-            let! (response: HttpResponseMessage) = client.SendAsync(request)
+            do! withDiscoveryServer [ itemsResource ] (fun client -> task {
+                let request = new HttpRequestMessage(HttpMethod.Options, "/items")
+                request.Headers.Add("Origin", "http://example.com")
+                request.Headers.Add("Access-Control-Request-Method", "GET")
+                let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-            // The discovery middleware should pass through for CORS preflights.
-            // Our middleware always returns 200; if it passed through, ASP.NET Core
-            // routing handles the request (typically 405 for method not allowed).
-            Expect.notEqual response.StatusCode HttpStatusCode.OK
-                "CORS preflight should not be handled by discovery middleware (not 200)"
+                // The discovery middleware should pass through for CORS preflights.
+                // Our middleware always returns 200; if it passed through, ASP.NET Core
+                // routing handles the request (typically 405 for method not allowed).
+                Expect.notEqual response.StatusCode HttpStatusCode.OK
+                    "CORS preflight should not be handled by discovery middleware (not 200)"
 
-            // No Link header should be present from the discovery middleware
-            let hasLink = response.Headers.Contains("Link")
-            Expect.isFalse hasLink
-                "CORS preflight should not produce Link headers from discovery middleware"
+                // No Link header should be present from the discovery middleware
+                let hasLink = response.Headers.Contains("Link")
+                Expect.isFalse hasLink
+                    "CORS preflight should not produce Link headers from discovery middleware"
+            })
         }
 
         testTask "explicit OPTIONS handler takes precedence over discovery middleware" {
@@ -57,13 +59,14 @@ let edgeCaseTests =
                     discoveryMediaType "application/ld+json" "describedby"
                 }
 
-            let client = createDiscoveryTestServer [ itemsResource ]
-            let request = new HttpRequestMessage(HttpMethod.Options, "/items")
-            let! (response: HttpResponseMessage) = client.SendAsync(request)
+            do! withDiscoveryServer [ itemsResource ] (fun client -> task {
+                let request = new HttpRequestMessage(HttpMethod.Options, "/items")
+                let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-            let! body = response.Content.ReadAsStringAsync()
-            Expect.equal body "custom OPTIONS"
-                "Explicit OPTIONS handler should take precedence over discovery middleware"
+                let! body = response.Content.ReadAsStringAsync()
+                Expect.equal body "custom OPTIONS"
+                    "Explicit OPTIONS handler should take precedence over discovery middleware"
+            })
         }
 
         testTask "duplicate DiscoveryMediaType entries are deduplicated in OPTIONS response" {
@@ -76,26 +79,27 @@ let edgeCaseTests =
                     discoveryMediaType "text/turtle" "describedby"
                 }
 
-            let client = createDiscoveryTestServer [ itemsResource ]
-            let request = new HttpRequestMessage(HttpMethod.Options, "/items")
-            let! (response: HttpResponseMessage) = client.SendAsync(request)
+            do! withDiscoveryServer [ itemsResource ] (fun client -> task {
+                let request = new HttpRequestMessage(HttpMethod.Options, "/items")
+                let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
+                Expect.equal response.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
 
-            // Verify deduplication: application/ld+json should appear only once
-            let linkHeaders = response.Headers.GetValues("Link") |> Seq.toList
-            let jsonLdLinks =
-                linkHeaders
-                |> List.filter (fun h -> h.Contains("application/ld+json"))
-            Expect.equal (List.length jsonLdLinks) 1
-                "application/ld+json should appear only once after deduplication"
+                // Verify deduplication: application/ld+json should appear only once
+                let linkHeaders = response.Headers.GetValues("Link") |> Seq.toList
+                let jsonLdLinks =
+                    linkHeaders
+                    |> List.filter (fun h -> h.Contains("application/ld+json"))
+                Expect.equal (List.length jsonLdLinks) 1
+                    "application/ld+json should appear only once after deduplication"
 
-            // text/turtle should still be present
-            let turtleLinks =
-                linkHeaders
-                |> List.filter (fun h -> h.Contains("text/turtle"))
-            Expect.equal (List.length turtleLinks) 1
-                "text/turtle should be present"
+                // text/turtle should still be present
+                let turtleLinks =
+                    linkHeaders
+                    |> List.filter (fun h -> h.Contains("text/turtle"))
+                Expect.equal (List.length turtleLinks) 1
+                    "text/turtle should be present"
+            })
         }
 
         testTask "HEAD request does not trigger OPTIONS discovery middleware" {
@@ -108,20 +112,21 @@ let edgeCaseTests =
                     discoveryMediaType "application/ld+json" "describedby"
                 }
 
-            let client = createDiscoveryTestServer [ itemsResource ]
-            let request = new HttpRequestMessage(HttpMethod.Head, "/items")
-            let! (response: HttpResponseMessage) = client.SendAsync(request)
+            do! withDiscoveryServer [ itemsResource ] (fun client -> task {
+                let request = new HttpRequestMessage(HttpMethod.Head, "/items")
+                let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-            // HEAD request should not trigger the OPTIONS discovery middleware.
-            // No Link header from the discovery middleware should be present.
-            let hasLink = response.Headers.Contains("Link")
-            Expect.isFalse hasLink
-                "HEAD request should not produce Link headers from OPTIONS discovery middleware"
+                // HEAD request should not trigger the OPTIONS discovery middleware.
+                // No Link header from the discovery middleware should be present.
+                let hasLink = response.Headers.Contains("Link")
+                Expect.isFalse hasLink
+                    "HEAD request should not produce Link headers from OPTIONS discovery middleware"
 
-            // Response body should be empty (HEAD semantics)
-            let! body = response.Content.ReadAsStringAsync()
-            Expect.equal body ""
-                "HEAD response body should be empty"
+                // Response body should be empty (HEAD semantics)
+                let! body = response.Content.ReadAsStringAsync()
+                Expect.equal body ""
+                    "HEAD response body should be empty"
+            })
         }
 
         testTask "no Link headers on error responses from OPTIONS discovery" {
@@ -138,23 +143,23 @@ let edgeCaseTests =
                     discoveryMediaType "application/ld+json" "describedby"
                 }
 
-            let client = createDiscoveryTestServer [ itemsResource ]
+            do! withDiscoveryServer [ itemsResource ] (fun client -> task {
+                // First, verify GET returns 404
+                let getRequest = new HttpRequestMessage(HttpMethod.Get, "/items")
+                let! (getResponse: HttpResponseMessage) = client.SendAsync(getRequest)
+                Expect.equal getResponse.StatusCode HttpStatusCode.NotFound
+                    "GET should return 404"
 
-            // First, verify GET returns 404
-            let getRequest = new HttpRequestMessage(HttpMethod.Get, "/items")
-            let! (getResponse: HttpResponseMessage) = client.SendAsync(getRequest)
-            Expect.equal getResponse.StatusCode HttpStatusCode.NotFound
-                "GET should return 404"
+                // OPTIONS should still return 200 with Link headers (it's middleware-generated)
+                let optionsRequest = new HttpRequestMessage(HttpMethod.Options, "/items")
+                let! (optionsResponse: HttpResponseMessage) = client.SendAsync(optionsRequest)
+                Expect.equal optionsResponse.StatusCode HttpStatusCode.OK
+                    "OPTIONS should return 200 regardless of handler behavior"
 
-            // OPTIONS should still return 200 with Link headers (it's middleware-generated)
-            let optionsRequest = new HttpRequestMessage(HttpMethod.Options, "/items")
-            let! (optionsResponse: HttpResponseMessage) = client.SendAsync(optionsRequest)
-            Expect.equal optionsResponse.StatusCode HttpStatusCode.OK
-                "OPTIONS should return 200 regardless of handler behavior"
-
-            let linkHeaders = optionsResponse.Headers.GetValues("Link") |> Seq.toList
-            Expect.isNonEmpty linkHeaders
-                "OPTIONS should include Link headers even when GET handler returns errors"
+                let linkHeaders = optionsResponse.Headers.GetValues("Link") |> Seq.toList
+                Expect.isNonEmpty linkHeaders
+                    "OPTIONS should include Link headers even when GET handler returns errors"
+            })
         }
 
         testTask "multiple extensions contributing media types all appear in OPTIONS response" {
@@ -169,29 +174,30 @@ let edgeCaseTests =
                     discoveryMediaType "application/scxml+xml" "describedby"
                 }
 
-            let client = createDiscoveryTestServer [ workflowResource ]
-            let request = new HttpRequestMessage(HttpMethod.Options, "/workflow")
-            let! (response: HttpResponseMessage) = client.SendAsync(request)
+            do! withDiscoveryServer [ workflowResource ] (fun client -> task {
+                let request = new HttpRequestMessage(HttpMethod.Options, "/workflow")
+                let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
+                Expect.equal response.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
 
-            let linkHeaders = response.Headers.GetValues("Link") |> Seq.toList
+                let linkHeaders = response.Headers.GetValues("Link") |> Seq.toList
 
-            // All four media types should appear
-            let linkValue = linkHeaders |> String.concat " "
-            Expect.stringContains linkValue "application/ld+json"
-                "Should include LinkedData JSON-LD media type"
-            Expect.stringContains linkValue "text/turtle"
-                "Should include LinkedData Turtle media type"
-            Expect.stringContains linkValue "application/rdf+xml"
-                "Should include LinkedData RDF/XML media type"
-            Expect.stringContains linkValue "application/scxml+xml"
-                "Should include Statecharts SCXML media type"
+                // All four media types should appear
+                let linkValue = linkHeaders |> String.concat " "
+                Expect.stringContains linkValue "application/ld+json"
+                    "Should include LinkedData JSON-LD media type"
+                Expect.stringContains linkValue "text/turtle"
+                    "Should include LinkedData Turtle media type"
+                Expect.stringContains linkValue "application/rdf+xml"
+                    "Should include LinkedData RDF/XML media type"
+                Expect.stringContains linkValue "application/scxml+xml"
+                    "Should include Statecharts SCXML media type"
 
-            // All should have rel=describedby
-            for link in linkHeaders do
-                Expect.stringContains link "rel=\"describedby\""
-                    "Each Link header should have rel=describedby"
+                // All should have rel=describedby
+                for link in linkHeaders do
+                    Expect.stringContains link "rel=\"describedby\""
+                        "Each Link header should have rel=describedby"
+            })
         }
 
         testTask "resource with no DiscoveryMediaType returns OPTIONS with Allow but no Link headers" {
@@ -202,19 +208,20 @@ let edgeCaseTests =
                     post (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("created")))
                 }
 
-            let client = createDiscoveryTestServer [ plainResource ]
-            let request = new HttpRequestMessage(HttpMethod.Options, "/plain")
-            let! (response: HttpResponseMessage) = client.SendAsync(request)
+            do! withDiscoveryServer [ plainResource ] (fun client -> task {
+                let request = new HttpRequestMessage(HttpMethod.Options, "/plain")
+                let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
+                Expect.equal response.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
 
-            let allowHeader = response.Content.Headers.Allow |> Set.ofSeq
-            Expect.contains allowHeader "GET" "Allow should contain GET"
-            Expect.contains allowHeader "POST" "Allow should contain POST"
-            Expect.contains allowHeader "OPTIONS" "Allow should contain OPTIONS"
+                let allowHeader = response.Content.Headers.Allow |> Set.ofSeq
+                Expect.contains allowHeader "GET" "Allow should contain GET"
+                Expect.contains allowHeader "POST" "Allow should contain POST"
+                Expect.contains allowHeader "OPTIONS" "Allow should contain OPTIONS"
 
-            // No Link headers since no DiscoveryMediaType metadata
-            let hasLink = response.Headers.Contains("Link")
-            Expect.isFalse hasLink "No Link headers without DiscoveryMediaType metadata"
+                // No Link headers since no DiscoveryMediaType metadata
+                let hasLink = response.Headers.Contains("Link")
+                Expect.isFalse hasLink "No Link headers without DiscoveryMediaType metadata"
+            })
         }
     ]

--- a/test/Frank.Discovery.Tests/JsonHomeMiddlewareTests.fs
+++ b/test/Frank.Discovery.Tests/JsonHomeMiddlewareTests.fs
@@ -3,6 +3,7 @@ module Frank.Discovery.Tests.JsonHomeMiddlewareTests
 open System.Net
 open System.Net.Http
 open System.Net.Http.Headers
+open System.Threading.Tasks
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
 open Microsoft.AspNetCore.Http
@@ -17,137 +18,168 @@ open Frank.Builder
 open Frank.Discovery
 open Frank.Discovery.Tests.OptionsDiscoveryTests
 
-let private buildTestServer () =
-    let itemsRes = resource "/items" { get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("items list"))) }
-    let dataSource = TestEndpointDataSource(itemsRes.Endpoints)
+let private withServer (f: HttpClient -> Task) =
+    task {
+        let itemsRes = resource "/items" { get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("items list"))) }
+        let dataSource = TestEndpointDataSource(itemsRes.Endpoints)
 
-    let host =
-        Host.CreateDefaultBuilder([||])
-            .ConfigureWebHost(fun webBuilder ->
-                webBuilder
-                    .UseTestServer()
-                    .ConfigureServices(fun services ->
-                        services.AddRouting() |> ignore
-                        services.AddSingleton<EndpointDataSource>(dataSource) |> ignore)
-                    .Configure(fun app ->
-                        app.UseMiddleware<JsonHomeMiddleware>() |> ignore
-                        app.UseRouting() |> ignore
-                        app.UseEndpoints(fun endpoints ->
-                            endpoints.DataSources.Add(dataSource)
-                            endpoints.MapGet("/", fun ctx ->
-                                ctx.Response.WriteAsync("Hello World")) |> ignore) |> ignore)
-                |> ignore)
-            .Build()
+        let host =
+            Host.CreateDefaultBuilder([||])
+                .ConfigureWebHost(fun webBuilder ->
+                    webBuilder
+                        .UseTestServer()
+                        .ConfigureServices(fun services ->
+                            services.AddRouting() |> ignore
+                            services.AddSingleton<EndpointDataSource>(dataSource) |> ignore)
+                        .Configure(fun app ->
+                            app.UseMiddleware<JsonHomeMiddleware>() |> ignore
+                            app.UseRouting() |> ignore
+                            app.UseEndpoints(fun endpoints ->
+                                endpoints.DataSources.Add(dataSource)
+                                endpoints.MapGet("/", fun ctx ->
+                                    ctx.Response.WriteAsync("Hello World")) |> ignore) |> ignore)
+                    |> ignore)
+                .Build()
 
-    host.Start()
-    host.GetTestClient()
+        host.Start()
+
+        try
+            let client = host.GetTestClient()
+
+            try
+                do! f client
+            finally
+                client.Dispose()
+        finally
+            (host :> System.IDisposable).Dispose()
+    }
+    :> Task
 
 [<Tests>]
 let tests =
     testList "JsonHomeMiddleware" [
         testTask "GET / with Accept: application/json-home returns home document" {
-            let client = buildTestServer ()
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            Expect.equal resp.StatusCode HttpStatusCode.OK "should be 200"
-            Expect.equal (resp.Content.Headers.ContentType.MediaType) "application/json-home" "content type"
-            Expect.isTrue (resp.Headers.Contains("Vary")) "should have Vary header"
-            Expect.isTrue (resp.Headers.Contains("Cache-Control")) "should have Cache-Control"
-            let! (body: string) = resp.Content.ReadAsStringAsync()
-            Expect.isTrue (body.Contains("\"resources\"")) "should have resources"
-            Expect.isTrue (body.Contains("/items")) "should contain items resource"
+            do! withServer (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp.StatusCode HttpStatusCode.OK "should be 200"
+                Expect.equal (resp.Content.Headers.ContentType.MediaType) "application/json-home" "content type"
+                Expect.isTrue (resp.Headers.Contains("Vary")) "should have Vary header"
+                Expect.isTrue (resp.Headers.Contains("Cache-Control")) "should have Cache-Control"
+                let! (body: string) = resp.Content.ReadAsStringAsync()
+                Expect.isTrue (body.Contains("\"resources\"")) "should have resources"
+                Expect.isTrue (body.Contains("/items")) "should contain items resource"
+            })
         }
 
         testTask "GET / with Accept: text/html passes through" {
-            let client = buildTestServer ()
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("text/html"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            let! (body: string) = resp.Content.ReadAsStringAsync()
-            Expect.equal body "Hello World" "should pass through to user handler"
+            do! withServer (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("text/html"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                let! (body: string) = resp.Content.ReadAsStringAsync()
+                Expect.equal body "Hello World" "should pass through to user handler"
+            })
         }
 
         testTask "GET / with Accept: */* passes through" {
-            let client = buildTestServer ()
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("*/*"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            let! (body: string) = resp.Content.ReadAsStringAsync()
-            Expect.equal body "Hello World" "should pass through"
+            do! withServer (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("*/*"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                let! (body: string) = resp.Content.ReadAsStringAsync()
+                Expect.equal body "Hello World" "should pass through"
+            })
         }
 
         testTask "GET / with Accept: application/json passes through" {
-            let client = buildTestServer ()
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            let! (body: string) = resp.Content.ReadAsStringAsync()
-            Expect.equal body "Hello World" "should pass through"
+            do! withServer (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                let! (body: string) = resp.Content.ReadAsStringAsync()
+                Expect.equal body "Hello World" "should pass through"
+            })
         }
 
         testTask "POST / passes through" {
-            let client = buildTestServer ()
-            let req = new HttpRequestMessage(HttpMethod.Post, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            Expect.notEqual resp.StatusCode HttpStatusCode.OK "should not serve home doc on POST"
+            do! withServer (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Post, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                Expect.notEqual resp.StatusCode HttpStatusCode.OK "should not serve home doc on POST"
+            })
         }
 
         testTask "GET /other passes through" {
-            let client = buildTestServer ()
-            let req = new HttpRequestMessage(HttpMethod.Get, "/other")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            Expect.equal resp.StatusCode HttpStatusCode.NotFound "non-root path passes through"
+            do! withServer (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/other")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp.StatusCode HttpStatusCode.NotFound "non-root path passes through"
+            })
         }
 
         testTask "Accept with parameters still matches" {
-            let client = buildTestServer ()
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.TryAddWithoutValidation("Accept", "application/json-home; charset=utf-8") |> ignore
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            Expect.equal resp.StatusCode HttpStatusCode.OK "should match ignoring parameters"
+            do! withServer (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.TryAddWithoutValidation("Accept", "application/json-home; charset=utf-8") |> ignore
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp.StatusCode HttpStatusCode.OK "should match ignoring parameters"
+            })
         }
 
         testTask "Accept with multiple types and quality values selects json-home" {
-            let client = buildTestServer ()
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.TryAddWithoutValidation("Accept", "application/json-home, text/html;q=0.9") |> ignore
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            Expect.equal resp.StatusCode HttpStatusCode.OK "should match json-home in multi-value Accept"
-            Expect.equal (resp.Content.Headers.ContentType.MediaType) "application/json-home" "content type"
+            do! withServer (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.TryAddWithoutValidation("Accept", "application/json-home, text/html;q=0.9") |> ignore
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp.StatusCode HttpStatusCode.OK "should match json-home in multi-value Accept"
+                Expect.equal (resp.Content.Headers.ContentType.MediaType) "application/json-home" "content type"
+            })
         }
 
         testTask "HEAD / with Accept: application/json-home returns headers with no body" {
-            let client = buildTestServer ()
-            let req = new HttpRequestMessage(HttpMethod.Head, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            Expect.equal resp.StatusCode HttpStatusCode.OK "should be 200"
-            Expect.equal (resp.Content.Headers.ContentType.MediaType) "application/json-home" "content type"
-            Expect.isTrue (resp.Headers.Contains("Vary")) "should have Vary header"
-            Expect.isTrue (resp.Headers.Contains("Cache-Control")) "should have Cache-Control"
-            let! (body: string) = resp.Content.ReadAsStringAsync()
-            Expect.equal body "" "HEAD should have empty body"
+            do! withServer (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Head, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp.StatusCode HttpStatusCode.OK "should be 200"
+                Expect.equal (resp.Content.Headers.ContentType.MediaType) "application/json-home" "content type"
+                Expect.isTrue (resp.Headers.Contains("Vary")) "should have Vary header"
+                Expect.isTrue (resp.Headers.Contains("Cache-Control")) "should have Cache-Control"
+                let! (body: string) = resp.Content.ReadAsStringAsync()
+                Expect.equal body "" "HEAD should have empty body"
+            })
         }
     ]
 
 /// Build a test server from a WebHostSpec, replicating the CE Run pipeline with TestServer.
-let buildCeTestServer (spec: WebHostSpec) =
-    let builder = WebApplication.CreateBuilder([||])
-    builder.WebHost.UseTestServer() |> ignore
-    spec.Services(builder.Services) |> ignore
-    let app = builder.Build()
-    let dataSource = TestEndpointDataSource(spec.Endpoints)
-    (app :> IApplicationBuilder)
-    |> spec.BeforeRoutingMiddleware
-    |> fun app -> app.UseRouting()
-    |> spec.Middleware
-    |> ignore
-    (app :> IEndpointRouteBuilder).DataSources.Add(dataSource)
-    app.Start()
-    app.GetTestClient()
+let withCeServer (spec: WebHostSpec) (f: HttpClient -> Task) =
+    task {
+        let builder = WebApplication.CreateBuilder([||])
+        builder.WebHost.UseTestServer() |> ignore
+        spec.Services(builder.Services) |> ignore
+        let app = builder.Build()
+        let dataSource = TestEndpointDataSource(spec.Endpoints)
+        (app :> IApplicationBuilder)
+        |> spec.BeforeRoutingMiddleware
+        |> fun app -> app.UseRouting()
+        |> spec.Middleware
+        |> ignore
+        (app :> IEndpointRouteBuilder).DataSources.Add(dataSource)
+        app.Start()
+
+        let client = app.GetTestClient()
+
+        try
+            do! f client
+        finally
+            client.Dispose()
+            (app :> System.IDisposable).Dispose()
+    }
+    :> Task
 
 [<Tests>]
 let ceTests =
@@ -165,15 +197,15 @@ let ceTests =
                 |> fun s -> ceBuilder.UseJsonHome(s)
                 |> fun s -> ceBuilder.Resource(s, testResource)
 
-            let client = buildCeTestServer spec
-
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            Expect.equal resp.StatusCode HttpStatusCode.OK "should serve home document"
-            let! (body: string) = resp.Content.ReadAsStringAsync()
-            Expect.isTrue (body.Contains("/items")) "should contain items resource"
-            Expect.isTrue (body.Contains("urn:frank:")) "should have URN relation"
+            do! withCeServer spec (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp.StatusCode HttpStatusCode.OK "should serve home document"
+                let! (body: string) = resp.Content.ReadAsStringAsync()
+                Expect.isTrue (body.Contains("/items")) "should contain items resource"
+                Expect.isTrue (body.Contains("urn:frank:")) "should have URN relation"
+            })
         }
 
         testTask "useJsonHome passes through non-json-home Accept at root" {
@@ -188,15 +220,15 @@ let ceTests =
                 |> fun s -> ceBuilder.UseJsonHome(s)
                 |> fun s -> ceBuilder.Resource(s, testResource)
 
-            let client = buildCeTestServer spec
-
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("text/html"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            // Should pass through — Accept is text/html, not application/json-home
-            let contentType =
-                if isNull resp.Content.Headers.ContentType then "" else resp.Content.Headers.ContentType.MediaType
-            Expect.notEqual contentType "application/json-home" "should not be json-home"
+            do! withCeServer spec (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("text/html"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                // Should pass through — Accept is text/html, not application/json-home
+                let contentType =
+                    if isNull resp.Content.Headers.ContentType then "" else resp.Content.Headers.ContentType.MediaType
+                Expect.notEqual contentType "application/json-home" "should not be json-home"
+            })
         }
     ]
 
@@ -215,15 +247,15 @@ let useDiscoveryTests =
                 |> fun s -> ceBuilder.UseDiscovery(s)
                 |> fun s -> ceBuilder.Resource(s, testResource)
 
-            let client = buildCeTestServer spec
-
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            Expect.equal resp.StatusCode HttpStatusCode.OK "should serve home document"
-            Expect.isTrue (resp.Headers.Contains("Vary")) "should have Vary header"
-            let! (body: string) = resp.Content.ReadAsStringAsync()
-            Expect.isTrue (body.Contains("/items")) "should contain items resource"
+            do! withCeServer spec (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp.StatusCode HttpStatusCode.OK "should serve home document"
+                Expect.isTrue (resp.Headers.Contains("Vary")) "should have Vary header"
+                let! (body: string) = resp.Content.ReadAsStringAsync()
+                Expect.isTrue (body.Contains("/items")) "should contain items resource"
+            })
         }
 
         testTask "useDiscovery returns Allow header on OPTIONS" {
@@ -239,11 +271,11 @@ let useDiscoveryTests =
                 |> fun s -> ceBuilder.UseDiscovery(s)
                 |> fun s -> ceBuilder.Resource(s, testResource)
 
-            let client = buildCeTestServer spec
-
-            let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
-            Expect.equal resp.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
-            Expect.isGreaterThan (resp.Content.Headers.Allow.Count) 0 "should have Allow header"
+            do! withCeServer spec (fun client -> task {
+                let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Options, "/items"))
+                Expect.equal resp.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
+                Expect.isGreaterThan (resp.Content.Headers.Allow.Count) 0 "should have Allow header"
+            })
         }
 
         testTask "useDiscovery returns Link headers on GET" {
@@ -259,11 +291,11 @@ let useDiscoveryTests =
                 |> fun s -> ceBuilder.UseDiscovery(s)
                 |> fun s -> ceBuilder.Resource(s, testResource)
 
-            let client = buildCeTestServer spec
-
-            let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
-            Expect.equal resp.StatusCode HttpStatusCode.OK "GET should return 200"
-            Expect.isTrue (resp.Headers.Contains("Link")) "should have Link header"
+            do! withCeServer spec (fun client -> task {
+                let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
+                Expect.equal resp.StatusCode HttpStatusCode.OK "GET should return 200"
+                Expect.isTrue (resp.Headers.Contains("Link")) "should have Link header"
+            })
         }
     ]
 
@@ -282,13 +314,13 @@ let useDiscoveryHeadersTests =
                 |> fun s -> ceBuilder.UseDiscoveryHeaders(s)
                 |> fun s -> ceBuilder.Resource(s, testResource)
 
-            let client = buildCeTestServer spec
-
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            // Should NOT serve JSON Home — useDiscoveryHeaders only provides OPTIONS + Link
-            Expect.notEqual resp.StatusCode HttpStatusCode.OK "should not serve home document"
+            do! withCeServer spec (fun client -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                // Should NOT serve JSON Home — useDiscoveryHeaders only provides OPTIONS + Link
+                Expect.notEqual resp.StatusCode HttpStatusCode.OK "should not serve home document"
+            })
         }
     ]
 
@@ -322,15 +354,22 @@ let metadataTests =
                         |> ignore)
                     .Build()
             host.Start()
-            let client = host.GetTestClient()
 
-            let req = new HttpRequestMessage(HttpMethod.Get, "/")
-            req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
-            let! (resp: HttpResponseMessage) = client.SendAsync(req)
-            let! (body: string) = resp.Content.ReadAsStringAsync()
-            Expect.isTrue (body.Contains("Game API")) "should use metadata title"
-            Expect.isTrue (body.Contains("http://example.com/alps/games#games")) "should have ALPS relation"
-            Expect.isTrue (body.Contains("http://example.com/alps/games#gameId")) "should have ALPS hrefVar"
-            Expect.isTrue (body.Contains("/scalar/v1")) "should have docs URL"
+            try
+                let client = host.GetTestClient()
+
+                try
+                    let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                    req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                    let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                    let! (body: string) = resp.Content.ReadAsStringAsync()
+                    Expect.isTrue (body.Contains("Game API")) "should use metadata title"
+                    Expect.isTrue (body.Contains("http://example.com/alps/games#games")) "should have ALPS relation"
+                    Expect.isTrue (body.Contains("http://example.com/alps/games#gameId")) "should have ALPS hrefVar"
+                    Expect.isTrue (body.Contains("/scalar/v1")) "should have docs URL"
+                finally
+                    client.Dispose()
+            finally
+                (host :> System.IDisposable).Dispose()
         }
     ]

--- a/test/Frank.Discovery.Tests/LinkHeaderTests.fs
+++ b/test/Frank.Discovery.Tests/LinkHeaderTests.fs
@@ -15,66 +15,9 @@ open Frank.Builder
 open Frank.Discovery
 open Frank.Discovery.Tests.OptionsDiscoveryTests
 
-/// Creates a test server with the Link header middleware enabled.
-let createLinkTestServer (resources: Resource list) =
-    let allEndpoints =
-        resources
-        |> List.collect (fun r -> r.Endpoints |> Array.toList)
-        |> List.toArray
-
-    let dataSource = TestEndpointDataSource(allEndpoints)
-
-    let builder =
-        Host.CreateDefaultBuilder([||])
-            .ConfigureWebHost(fun webBuilder ->
-                webBuilder
-                    .UseTestServer()
-                    .ConfigureServices(fun services ->
-                        services.AddRouting() |> ignore
-                        services.AddSingleton<EndpointDataSource>(dataSource) |> ignore)
-                    .Configure(fun app ->
-                        app
-                            .UseRouting()
-                            .UseMiddleware<LinkHeaderMiddleware>()
-                            .UseEndpoints(fun endpoints ->
-                                endpoints.DataSources.Add(dataSource))
-                        |> ignore)
-                |> ignore)
-
-    let host = builder.Build()
-    host.Start()
-    host.GetTestClient()
-
-/// Creates a test server with both OPTIONS discovery and Link header middlewares.
-let createFullDiscoveryTestServer (resources: Resource list) =
-    let allEndpoints =
-        resources
-        |> List.collect (fun r -> r.Endpoints |> Array.toList)
-        |> List.toArray
-
-    let dataSource = TestEndpointDataSource(allEndpoints)
-
-    let builder =
-        Host.CreateDefaultBuilder([||])
-            .ConfigureWebHost(fun webBuilder ->
-                webBuilder
-                    .UseTestServer()
-                    .ConfigureServices(fun services ->
-                        services.AddRouting() |> ignore
-                        services.AddSingleton<EndpointDataSource>(dataSource) |> ignore)
-                    .Configure(fun app ->
-                        app
-                            .UseRouting()
-                            .UseMiddleware<OptionsDiscoveryMiddleware>()
-                            .UseMiddleware<LinkHeaderMiddleware>()
-                            .UseEndpoints(fun endpoints ->
-                                endpoints.DataSources.Add(dataSource))
-                        |> ignore)
-                |> ignore)
-
-    let host = builder.Build()
-    host.Start()
-    host.GetTestClient()
+/// Runs a test against a server with the Link header middleware enabled.
+let withLinkServer resources f =
+    withTestHost (fun app -> app.UseMiddleware<LinkHeaderMiddleware>() |> ignore) resources f
 
 // ===== US2: Link Headers on GET Responses =====
 
@@ -91,24 +34,25 @@ let us2Tests =
                     discoveryMediaType "application/rdf+xml" "describedby"
                 }
 
-            let client = createLinkTestServer [ itemsResource ]
-            let! (response: HttpResponseMessage) = client.GetAsync("/items")
+            do! withLinkServer [ itemsResource ] (fun client -> task {
+                let! (response: HttpResponseMessage) = client.GetAsync("/items")
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "GET should return 200"
+                Expect.equal response.StatusCode HttpStatusCode.OK "GET should return 200"
 
-            let linkHeaders = response.Headers.GetValues("Link") |> Seq.toList
-            Expect.hasLength linkHeaders 3 "Should have 3 Link headers"
+                let linkHeaders = response.Headers.GetValues("Link") |> Seq.toList
+                Expect.hasLength linkHeaders 3 "Should have 3 Link headers"
 
-            let allLinks = linkHeaders |> String.concat " "
-            Expect.stringContains allLinks "</items>; rel=\"describedby\"; type=\"application/ld+json\""
-                "Link header should contain application/ld+json"
-            Expect.stringContains allLinks "</items>; rel=\"describedby\"; type=\"text/turtle\""
-                "Link header should contain text/turtle"
-            Expect.stringContains allLinks "</items>; rel=\"describedby\"; type=\"application/rdf+xml\""
-                "Link header should contain application/rdf+xml"
+                let allLinks = linkHeaders |> String.concat " "
+                Expect.stringContains allLinks "</items>; rel=\"describedby\"; type=\"application/ld+json\""
+                    "Link header should contain application/ld+json"
+                Expect.stringContains allLinks "</items>; rel=\"describedby\"; type=\"text/turtle\""
+                    "Link header should contain text/turtle"
+                Expect.stringContains allLinks "</items>; rel=\"describedby\"; type=\"application/rdf+xml\""
+                    "Link header should contain application/rdf+xml"
 
-            let! body = response.Content.ReadAsStringAsync()
-            Expect.equal body "items" "Normal response body should be present"
+                let! body = response.Content.ReadAsStringAsync()
+                Expect.equal body "items" "Normal response body should be present"
+            })
         }
 
         testTask "GET request to resource with no semantic markers returns no Link headers" {
@@ -118,11 +62,12 @@ let us2Tests =
                     get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("healthy")))
                 }
 
-            let client = createLinkTestServer [ healthResource ]
-            let! (response: HttpResponseMessage) = client.GetAsync("/health")
+            do! withLinkServer [ healthResource ] (fun client -> task {
+                let! (response: HttpResponseMessage) = client.GetAsync("/health")
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "GET should return 200"
-            Expect.isFalse (response.Headers.Contains("Link")) "No Link headers should be present"
+                Expect.equal response.StatusCode HttpStatusCode.OK "GET should return 200"
+                Expect.isFalse (response.Headers.Contains("Link")) "No Link headers should be present"
+            })
         }
     ]
 
@@ -145,17 +90,17 @@ let us3Tests =
                     get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("healthy")))
                 }
 
-            let client = createLinkTestServer [ itemsResource; healthResource ]
+            do! withLinkServer [ itemsResource; healthResource ] (fun client -> task {
+                // GET /items should have Link headers
+                let! (itemsResponse: HttpResponseMessage) = client.GetAsync("/items")
+                Expect.equal itemsResponse.StatusCode HttpStatusCode.OK "/items should return 200"
+                Expect.isTrue (itemsResponse.Headers.Contains("Link")) "/items should have Link headers"
 
-            // GET /items should have Link headers
-            let! (itemsResponse: HttpResponseMessage) = client.GetAsync("/items")
-            Expect.equal itemsResponse.StatusCode HttpStatusCode.OK "/items should return 200"
-            Expect.isTrue (itemsResponse.Headers.Contains("Link")) "/items should have Link headers"
-
-            // GET /health should NOT have Link headers
-            let! (healthResponse: HttpResponseMessage) = client.GetAsync("/health")
-            Expect.equal healthResponse.StatusCode HttpStatusCode.OK "/health should return 200"
-            Expect.isFalse (healthResponse.Headers.Contains("Link")) "/health should not have Link headers"
+                // GET /health should NOT have Link headers
+                let! (healthResponse: HttpResponseMessage) = client.GetAsync("/health")
+                Expect.equal healthResponse.StatusCode HttpStatusCode.OK "/health should return 200"
+                Expect.isFalse (healthResponse.Headers.Contains("Link")) "/health should not have Link headers"
+            })
         }
     ]
 
@@ -186,24 +131,24 @@ let us4Tests =
                     get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("plain")))
                 }
 
-            let client = createLinkTestServer [ linkedDataResource; statechartsResource; plainResource ]
+            do! withLinkServer [ linkedDataResource; statechartsResource; plainResource ] (fun client -> task {
+                // /data should have 2 Link headers
+                let! (dataResponse: HttpResponseMessage) = client.GetAsync("/data")
+                Expect.equal dataResponse.StatusCode HttpStatusCode.OK "/data should return 200"
+                let dataLinks = dataResponse.Headers.GetValues("Link") |> Seq.toList
+                Expect.hasLength dataLinks 2 "/data should have 2 Link headers"
 
-            // /data should have 2 Link headers
-            let! (dataResponse: HttpResponseMessage) = client.GetAsync("/data")
-            Expect.equal dataResponse.StatusCode HttpStatusCode.OK "/data should return 200"
-            let dataLinks = dataResponse.Headers.GetValues("Link") |> Seq.toList
-            Expect.hasLength dataLinks 2 "/data should have 2 Link headers"
+                // /machines should have 1 Link header
+                let! (machinesResponse: HttpResponseMessage) = client.GetAsync("/machines")
+                Expect.equal machinesResponse.StatusCode HttpStatusCode.OK "/machines should return 200"
+                let machinesLinks = machinesResponse.Headers.GetValues("Link") |> Seq.toList
+                Expect.hasLength machinesLinks 1 "/machines should have 1 Link header"
 
-            // /machines should have 1 Link header
-            let! (machinesResponse: HttpResponseMessage) = client.GetAsync("/machines")
-            Expect.equal machinesResponse.StatusCode HttpStatusCode.OK "/machines should return 200"
-            let machinesLinks = machinesResponse.Headers.GetValues("Link") |> Seq.toList
-            Expect.hasLength machinesLinks 1 "/machines should have 1 Link header"
-
-            // /plain should have NO Link headers
-            let! (plainResponse: HttpResponseMessage) = client.GetAsync("/plain")
-            Expect.equal plainResponse.StatusCode HttpStatusCode.OK "/plain should return 200"
-            Expect.isFalse (plainResponse.Headers.Contains("Link")) "/plain should not have Link headers"
+                // /plain should have NO Link headers
+                let! (plainResponse: HttpResponseMessage) = client.GetAsync("/plain")
+                Expect.equal plainResponse.StatusCode HttpStatusCode.OK "/plain should return 200"
+                Expect.isFalse (plainResponse.Headers.Contains("Link")) "/plain should not have Link headers"
+            })
         }
     ]
 
@@ -222,12 +167,13 @@ let behavioralTests =
                     discoveryMediaType "application/ld+json" "describedby"
                 }
 
-            let client = createLinkTestServer [ errorResource ]
-            let! (response: HttpResponseMessage) = client.GetAsync("/error")
+            do! withLinkServer [ errorResource ] (fun client -> task {
+                let! (response: HttpResponseMessage) = client.GetAsync("/error")
 
-            Expect.equal response.StatusCode HttpStatusCode.NotFound "Should return 404"
-            Expect.isFalse (response.Headers.Contains("Link"))
-                "No Link headers should be present on error responses"
+                Expect.equal response.StatusCode HttpStatusCode.NotFound "Should return 404"
+                Expect.isFalse (response.Headers.Contains("Link"))
+                    "No Link headers should be present on error responses"
+            })
         }
 
         testTask "no Link headers on POST requests" {
@@ -238,11 +184,12 @@ let behavioralTests =
                     discoveryMediaType "application/ld+json" "describedby"
                 }
 
-            let client = createLinkTestServer [ itemsResource ]
-            let! (response: HttpResponseMessage) = client.PostAsync("/items", new StringContent("data"))
+            do! withLinkServer [ itemsResource ] (fun client -> task {
+                let! (response: HttpResponseMessage) = client.PostAsync("/items", new StringContent("data"))
 
-            Expect.isFalse (response.Headers.Contains("Link"))
-                "No Link headers should be present on POST responses"
+                Expect.isFalse (response.Headers.Contains("Link"))
+                    "No Link headers should be present on POST responses"
+            })
         }
 
         testTask "Link headers on HEAD requests" {
@@ -256,18 +203,19 @@ let behavioralTests =
                     discoveryMediaType "application/ld+json" "describedby"
                 }
 
-            let client = createLinkTestServer [ itemsResource ]
-            let request = new HttpRequestMessage(HttpMethod.Head, "/items")
-            let! (response: HttpResponseMessage) = client.SendAsync(request)
+            do! withLinkServer [ itemsResource ] (fun client -> task {
+                let request = new HttpRequestMessage(HttpMethod.Head, "/items")
+                let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-            // HEAD should get Link headers (same as GET, just no body)
-            Expect.isTrue (response.Headers.Contains("Link"))
-                "Link headers should be present on HEAD responses"
+                // HEAD should get Link headers (same as GET, just no body)
+                Expect.isTrue (response.Headers.Contains("Link"))
+                    "Link headers should be present on HEAD responses"
 
-            let linkHeaders = response.Headers.GetValues("Link") |> Seq.toList
-            Expect.hasLength linkHeaders 1 "Should have 1 Link header"
-            Expect.stringContains (linkHeaders.[0]) "</items>; rel=\"describedby\"; type=\"application/ld+json\""
-                "Link header should match expected format"
+                let linkHeaders = response.Headers.GetValues("Link") |> Seq.toList
+                Expect.hasLength linkHeaders 1 "Should have 1 Link header"
+                Expect.stringContains (linkHeaders.[0]) "</items>; rel=\"describedby\"; type=\"application/ld+json\""
+                    "Link header should match expected format"
+            })
         }
 
         testTask "duplicate DiscoveryMediaType entries are deduplicated" {
@@ -280,11 +228,12 @@ let behavioralTests =
                     discoveryMediaType "text/turtle" "describedby"
                 }
 
-            let client = createLinkTestServer [ itemsResource ]
-            let! (response: HttpResponseMessage) = client.GetAsync("/items")
+            do! withLinkServer [ itemsResource ] (fun client -> task {
+                let! (response: HttpResponseMessage) = client.GetAsync("/items")
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "GET should return 200"
-            let linkHeaders = response.Headers.GetValues("Link") |> Seq.toList
-            Expect.hasLength linkHeaders 2 "Duplicate entries should be deduplicated to 2"
+                Expect.equal response.StatusCode HttpStatusCode.OK "GET should return 200"
+                let linkHeaders = response.Headers.GetValues("Link") |> Seq.toList
+                Expect.hasLength linkHeaders 2 "Duplicate entries should be deduplicated to 2"
+            })
         }
     ]

--- a/test/Frank.Discovery.Tests/OptionsDiscoveryTests.fs
+++ b/test/Frank.Discovery.Tests/OptionsDiscoveryTests.fs
@@ -2,6 +2,7 @@ module Frank.Discovery.Tests.OptionsDiscoveryTests
 
 open System.Net
 open System.Net.Http
+open System.Threading.Tasks
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
 open Microsoft.AspNetCore.Http
@@ -34,64 +35,54 @@ module TestResourceBuilderExtensions =
 let simpleHandler : RequestDelegate =
     RequestDelegate(fun ctx -> ctx.Response.WriteAsync("OK"))
 
-/// Creates a test server with the OPTIONS discovery middleware enabled.
-let createDiscoveryTestServer (resources: Resource list) =
-    let allEndpoints =
-        resources
-        |> List.collect (fun r -> r.Endpoints |> Array.toList)
-        |> List.toArray
+/// Run a test against a Host-based test server with configurable middleware, ensuring proper disposal.
+let withTestHost (configureApp: IApplicationBuilder -> unit) (resources: Resource list) (f: HttpClient -> Task) =
+    task {
+        let allEndpoints =
+            resources
+            |> List.collect (fun r -> r.Endpoints |> Array.toList)
+            |> List.toArray
 
-    let dataSource = TestEndpointDataSource(allEndpoints)
+        let dataSource = TestEndpointDataSource(allEndpoints)
 
-    let builder =
-        Host.CreateDefaultBuilder([||])
-            .ConfigureWebHost(fun webBuilder ->
-                webBuilder
-                    .UseTestServer()
-                    .ConfigureServices(fun services ->
-                        services.AddRouting() |> ignore
-                        services.AddSingleton<EndpointDataSource>(dataSource) |> ignore)
-                    .Configure(fun app ->
-                        app
-                            .UseRouting()
-                            .UseMiddleware<OptionsDiscoveryMiddleware>()
-                            .UseEndpoints(fun endpoints ->
+        let host =
+            Host.CreateDefaultBuilder([||])
+                .ConfigureWebHost(fun webBuilder ->
+                    webBuilder
+                        .UseTestServer()
+                        .ConfigureServices(fun services ->
+                            services.AddRouting() |> ignore
+                            services.AddSingleton<EndpointDataSource>(dataSource) |> ignore)
+                        .Configure(fun app ->
+                            app.UseRouting() |> ignore
+                            configureApp app
+                            app.UseEndpoints(fun endpoints ->
                                 endpoints.DataSources.Add(dataSource))
-                        |> ignore)
-                |> ignore)
+                            |> ignore)
+                    |> ignore)
+                .Build()
 
-    let host = builder.Build()
-    host.Start()
-    host.GetTestClient()
+        host.Start()
 
-/// Creates a test server WITHOUT the OPTIONS discovery middleware (for test 4).
-let createTestServerWithoutDiscovery (resources: Resource list) =
-    let allEndpoints =
-        resources
-        |> List.collect (fun r -> r.Endpoints |> Array.toList)
-        |> List.toArray
+        try
+            let client = host.GetTestClient()
 
-    let dataSource = TestEndpointDataSource(allEndpoints)
+            try
+                do! f client
+            finally
+                client.Dispose()
+        finally
+            (host :> System.IDisposable).Dispose()
+    }
+    :> Task
 
-    let builder =
-        Host.CreateDefaultBuilder([||])
-            .ConfigureWebHost(fun webBuilder ->
-                webBuilder
-                    .UseTestServer()
-                    .ConfigureServices(fun services ->
-                        services.AddRouting() |> ignore
-                        services.AddSingleton<EndpointDataSource>(dataSource) |> ignore)
-                    .Configure(fun app ->
-                        app
-                            .UseRouting()
-                            .UseEndpoints(fun endpoints ->
-                                endpoints.DataSources.Add(dataSource))
-                        |> ignore)
-                |> ignore)
+/// Runs a test against a server with the OPTIONS discovery middleware enabled.
+let withDiscoveryServer resources f =
+    withTestHost (fun app -> app.UseMiddleware<OptionsDiscoveryMiddleware>() |> ignore) resources f
 
-    let host = builder.Build()
-    host.Start()
-    host.GetTestClient()
+/// Runs a test against a server WITHOUT the OPTIONS discovery middleware.
+let withServerWithoutDiscovery resources f =
+    withTestHost ignore resources f
 
 // ===== US1: Agent Discovers Available Media Types via OPTIONS =====
 
@@ -106,19 +97,20 @@ let us1Tests =
                     post (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("created")))
                 }
 
-            let client = createDiscoveryTestServer [ itemsResource ]
-            let request = new HttpRequestMessage(HttpMethod.Options, "/items")
-            let! (response: HttpResponseMessage) = client.SendAsync(request)
+            do! withDiscoveryServer [ itemsResource ] (fun client -> task {
+                let request = new HttpRequestMessage(HttpMethod.Options, "/items")
+                let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
+                Expect.equal response.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
 
-            let allowHeader = response.Content.Headers.Allow |> Set.ofSeq
-            Expect.contains allowHeader "GET" "Allow header should contain GET"
-            Expect.contains allowHeader "POST" "Allow header should contain POST"
-            Expect.contains allowHeader "OPTIONS" "Allow header should contain OPTIONS"
+                let allowHeader = response.Content.Headers.Allow |> Set.ofSeq
+                Expect.contains allowHeader "GET" "Allow header should contain GET"
+                Expect.contains allowHeader "POST" "Allow header should contain POST"
+                Expect.contains allowHeader "OPTIONS" "Allow header should contain OPTIONS"
 
-            let! body = response.Content.ReadAsStringAsync()
-            Expect.equal body "" "Response body should be empty"
+                let! body = response.Content.ReadAsStringAsync()
+                Expect.equal body "" "Response body should be empty"
+            })
         }
 
         testTask "resource with GET only returns Allow header with GET, OPTIONS" {
@@ -128,19 +120,20 @@ let us1Tests =
                     get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("healthy")))
                 }
 
-            let client = createDiscoveryTestServer [ healthResource ]
-            let request = new HttpRequestMessage(HttpMethod.Options, "/health")
-            let! (response: HttpResponseMessage) = client.SendAsync(request)
+            do! withDiscoveryServer [ healthResource ] (fun client -> task {
+                let request = new HttpRequestMessage(HttpMethod.Options, "/health")
+                let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
+                Expect.equal response.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
 
-            let allowHeader = response.Content.Headers.Allow |> Set.ofSeq
-            Expect.contains allowHeader "GET" "Allow header should contain GET"
-            Expect.contains allowHeader "OPTIONS" "Allow header should contain OPTIONS"
-            Expect.equal (Set.count allowHeader) 2 "Allow header should contain exactly GET and OPTIONS"
+                let allowHeader = response.Content.Headers.Allow |> Set.ofSeq
+                Expect.contains allowHeader "GET" "Allow header should contain GET"
+                Expect.contains allowHeader "OPTIONS" "Allow header should contain OPTIONS"
+                Expect.equal (Set.count allowHeader) 2 "Allow header should contain exactly GET and OPTIONS"
 
-            let! body = response.Content.ReadAsStringAsync()
-            Expect.equal body "" "Response body should be empty"
+                let! body = response.Content.ReadAsStringAsync()
+                Expect.equal body "" "Response body should be empty"
+            })
         }
 
         testTask "CORS preflight passes through without discovery response" {
@@ -150,17 +143,18 @@ let us1Tests =
                     get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("items")))
                 }
 
-            let client = createDiscoveryTestServer [ itemsResource ]
-            let request = new HttpRequestMessage(HttpMethod.Options, "/items")
-            request.Headers.Add("Access-Control-Request-Method", "GET")
-            let! (response: HttpResponseMessage) = client.SendAsync(request)
+            do! withDiscoveryServer [ itemsResource ] (fun client -> task {
+                let request = new HttpRequestMessage(HttpMethod.Options, "/items")
+                request.Headers.Add("Access-Control-Request-Method", "GET")
+                let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-            // The middleware should pass through for CORS preflights.
-            // Without CORS middleware registered, the response won't be 200 from our middleware.
-            // ASP.NET Core routing may return 405 with its own Allow header, but the key is
-            // our discovery middleware did NOT handle it (no 200 from us).
-            Expect.notEqual response.StatusCode HttpStatusCode.OK
-                "CORS preflight should not be handled by discovery middleware"
+                // The middleware should pass through for CORS preflights.
+                // Without CORS middleware registered, the response won't be 200 from our middleware.
+                // ASP.NET Core routing may return 405 with its own Allow header, but the key is
+                // our discovery middleware did NOT handle it (no 200 from us).
+                Expect.notEqual response.StatusCode HttpStatusCode.OK
+                    "CORS preflight should not be handled by discovery middleware"
+            })
         }
 
         testTask "no discovery effect when middleware is not registered" {
@@ -170,14 +164,15 @@ let us1Tests =
                     get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("items")))
                 }
 
-            let client = createTestServerWithoutDiscovery [ itemsResource ]
-            let request = new HttpRequestMessage(HttpMethod.Options, "/items")
-            let! (response: HttpResponseMessage) = client.SendAsync(request)
+            do! withServerWithoutDiscovery [ itemsResource ] (fun client -> task {
+                let request = new HttpRequestMessage(HttpMethod.Options, "/items")
+                let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-            // Without the discovery middleware, OPTIONS should not return 200.
-            // ASP.NET Core routing may return 405 for method not allowed.
-            Expect.notEqual response.StatusCode HttpStatusCode.OK
-                "Without discovery middleware, OPTIONS should not return 200"
+                // Without the discovery middleware, OPTIONS should not return 200.
+                // ASP.NET Core routing may return 405 for method not allowed.
+                Expect.notEqual response.StatusCode HttpStatusCode.OK
+                    "Without discovery middleware, OPTIONS should not return 200"
+            })
         }
 
         testTask "resource with DiscoveryMediaType metadata returns Link headers" {
@@ -189,27 +184,28 @@ let us1Tests =
                     discoveryMediaType "application/ld+json" "describedby"
                 }
 
-            let client = createDiscoveryTestServer [ itemsResource ]
-            let request = new HttpRequestMessage(HttpMethod.Options, "/items")
-            let! (response: HttpResponseMessage) = client.SendAsync(request)
+            do! withDiscoveryServer [ itemsResource ] (fun client -> task {
+                let request = new HttpRequestMessage(HttpMethod.Options, "/items")
+                let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-            Expect.equal response.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
+                Expect.equal response.StatusCode HttpStatusCode.OK "OPTIONS should return 200"
 
-            let allowHeader = response.Content.Headers.Allow |> Set.ofSeq
-            Expect.contains allowHeader "GET" "Allow header should contain GET"
-            Expect.contains allowHeader "POST" "Allow header should contain POST"
-            Expect.contains allowHeader "OPTIONS" "Allow header should contain OPTIONS"
+                let allowHeader = response.Content.Headers.Allow |> Set.ofSeq
+                Expect.contains allowHeader "GET" "Allow header should contain GET"
+                Expect.contains allowHeader "POST" "Allow header should contain POST"
+                Expect.contains allowHeader "OPTIONS" "Allow header should contain OPTIONS"
 
-            // Verify Link header is emitted for the DiscoveryMediaType
-            let linkHeaders = response.Headers.GetValues("Link") |> Seq.toList
-            Expect.isNonEmpty linkHeaders "Link headers should be present"
-            let linkValue = linkHeaders |> String.concat ", "
-            Expect.stringContains linkValue "</items>" "Link header should contain the resource path"
-            Expect.stringContains linkValue "rel=\"describedby\"" "Link header should contain rel=describedby"
-            Expect.stringContains linkValue "type=\"application/ld+json\"" "Link header should contain media type"
+                // Verify Link header is emitted for the DiscoveryMediaType
+                let linkHeaders = response.Headers.GetValues("Link") |> Seq.toList
+                Expect.isNonEmpty linkHeaders "Link headers should be present"
+                let linkValue = linkHeaders |> String.concat ", "
+                Expect.stringContains linkValue "</items>" "Link header should contain the resource path"
+                Expect.stringContains linkValue "rel=\"describedby\"" "Link header should contain rel=describedby"
+                Expect.stringContains linkValue "type=\"application/ld+json\"" "Link header should contain media type"
 
-            let! body = response.Content.ReadAsStringAsync()
-            Expect.equal body "" "Response body should be empty (FR-013)"
+                let! body = response.Content.ReadAsStringAsync()
+                Expect.equal body "" "Response body should be empty (FR-013)"
+            })
         }
 
         testTask "unmatched route passes through" {
@@ -219,13 +215,14 @@ let us1Tests =
                     get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("items")))
                 }
 
-            let client = createDiscoveryTestServer [ itemsResource ]
-            let request = new HttpRequestMessage(HttpMethod.Options, "/nonexistent")
-            let! (response: HttpResponseMessage) = client.SendAsync(request)
+            do! withDiscoveryServer [ itemsResource ] (fun client -> task {
+                let request = new HttpRequestMessage(HttpMethod.Options, "/nonexistent")
+                let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-            // Unmatched route should not produce a 200 with Allow header
-            let hasAllow = response.Content.Headers.Allow.Count > 0
-            Expect.isFalse hasAllow "Unmatched route should not trigger discovery"
+                // Unmatched route should not produce a 200 with Allow header
+                let hasAllow = response.Content.Headers.Allow.Count > 0
+                Expect.isFalse hasAllow "Unmatched route should not trigger discovery"
+            })
         }
 
         testTask "resource with explicit OPTIONS handler is not overridden" {
@@ -238,12 +235,13 @@ let us1Tests =
                         ctx.Response.WriteAsync("explicit-options")))
                 }
 
-            let client = createDiscoveryTestServer [ itemsResource ]
-            let request = new HttpRequestMessage(HttpMethod.Options, "/items")
-            let! (response: HttpResponseMessage) = client.SendAsync(request)
+            do! withDiscoveryServer [ itemsResource ] (fun client -> task {
+                let request = new HttpRequestMessage(HttpMethod.Options, "/items")
+                let! (response: HttpResponseMessage) = client.SendAsync(request)
 
-            let! body = response.Content.ReadAsStringAsync()
-            Expect.equal body "explicit-options" "Explicit OPTIONS handler should take precedence"
+                let! body = response.Content.ReadAsStringAsync()
+                Expect.equal body "explicit-options" "Explicit OPTIONS handler should take precedence"
+            })
         }
 
         testTask "multiple resources at different routes each get correct Allow headers" {
@@ -261,25 +259,25 @@ let us1Tests =
                     get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("healthy")))
                 }
 
-            let client = createDiscoveryTestServer [ itemsResource; healthResource ]
+            do! withDiscoveryServer [ itemsResource; healthResource ] (fun client -> task {
+                // Check /items
+                let request1 = new HttpRequestMessage(HttpMethod.Options, "/items")
+                let! (response1: HttpResponseMessage) = client.SendAsync(request1)
+                Expect.equal response1.StatusCode HttpStatusCode.OK "OPTIONS /items should return 200"
+                let allow1 = response1.Content.Headers.Allow |> Set.ofSeq
+                Expect.contains allow1 "GET" "/items Allow should contain GET"
+                Expect.contains allow1 "POST" "/items Allow should contain POST"
+                Expect.contains allow1 "DELETE" "/items Allow should contain DELETE"
+                Expect.contains allow1 "OPTIONS" "/items Allow should contain OPTIONS"
 
-            // Check /items
-            let request1 = new HttpRequestMessage(HttpMethod.Options, "/items")
-            let! (response1: HttpResponseMessage) = client.SendAsync(request1)
-            Expect.equal response1.StatusCode HttpStatusCode.OK "OPTIONS /items should return 200"
-            let allow1 = response1.Content.Headers.Allow |> Set.ofSeq
-            Expect.contains allow1 "GET" "/items Allow should contain GET"
-            Expect.contains allow1 "POST" "/items Allow should contain POST"
-            Expect.contains allow1 "DELETE" "/items Allow should contain DELETE"
-            Expect.contains allow1 "OPTIONS" "/items Allow should contain OPTIONS"
-
-            // Check /health
-            let request2 = new HttpRequestMessage(HttpMethod.Options, "/health")
-            let! (response2: HttpResponseMessage) = client.SendAsync(request2)
-            Expect.equal response2.StatusCode HttpStatusCode.OK "OPTIONS /health should return 200"
-            let allow2 = response2.Content.Headers.Allow |> Set.ofSeq
-            Expect.contains allow2 "GET" "/health Allow should contain GET"
-            Expect.contains allow2 "OPTIONS" "/health Allow should contain OPTIONS"
-            Expect.equal (Set.count allow2) 2 "/health Allow should contain exactly GET and OPTIONS"
+                // Check /health
+                let request2 = new HttpRequestMessage(HttpMethod.Options, "/health")
+                let! (response2: HttpResponseMessage) = client.SendAsync(request2)
+                Expect.equal response2.StatusCode HttpStatusCode.OK "OPTIONS /health should return 200"
+                let allow2 = response2.Content.Headers.Allow |> Set.ofSeq
+                Expect.contains allow2 "GET" "/health Allow should contain GET"
+                Expect.contains allow2 "OPTIONS" "/health Allow should contain OPTIONS"
+                Expect.equal (Set.count allow2) 2 "/health Allow should contain exactly GET and OPTIONS"
+            })
         }
     ]

--- a/test/Frank.Statecharts.Tests/Affordances/AffordanceMiddlewareTests.fs
+++ b/test/Frank.Statecharts.Tests/Affordances/AffordanceMiddlewareTests.fs
@@ -5,6 +5,7 @@ open System.Collections.Generic
 open System.Linq
 open System.Net
 open System.Net.Http
+open System.Threading.Tasks
 open Expecto
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Http
@@ -44,44 +45,53 @@ let private getHeaderValues (response: HttpResponseMessage) (name: string) : str
 let private hasHeader (response: HttpResponseMessage) (name: string) : bool =
     getHeaderValues response name |> List.isEmpty |> not
 
-/// Create a test server with the affordance middleware and configurable state key injection.
-let private buildTestServer
+/// Run a test against a configured test server, disposing all resources on completion.
+let private withServer
     (lookup: Dictionary<string, PreComputedAffordance>)
     (stateKeySetter: HttpContext -> unit)
+    (f: HttpClient -> Task)
     =
-    let builder = WebApplication.CreateBuilder([||])
-    builder.WebHost.UseTestServer() |> ignore
-    builder.Services.AddRouting() |> ignore
-    let app = builder.Build()
+    task {
+        let builder = WebApplication.CreateBuilder([||])
+        builder.WebHost.UseTestServer() |> ignore
+        builder.Services.AddRouting() |> ignore
+        let app = builder.Build()
 
-    app.UseRouting() |> ignore
+        app.UseRouting() |> ignore
 
-    // Simulate statechart middleware by setting IStatechartFeature
-    (app :> IApplicationBuilder).Use(fun ctx (next: Func<System.Threading.Tasks.Task>) ->
-        stateKeySetter ctx
-        next.Invoke())
-    |> ignore
-
-    // Register the affordance middleware with pre-computed lookup
-    (app :> IApplicationBuilder).UseMiddleware<AffordanceMiddleware>(lookup) |> ignore
-
-    // Endpoints
-    app.UseEndpoints(fun endpoints ->
-        endpoints.MapGet(
-            "/games/{gameId}",
-            RequestDelegate(fun ctx -> ctx.Response.WriteAsync("OK"))
-        )
+        (app :> IApplicationBuilder).Use(fun ctx (next: Func<System.Threading.Tasks.Task>) ->
+            stateKeySetter ctx
+            next.Invoke())
         |> ignore
 
-        endpoints.MapGet(
-            "/health",
-            RequestDelegate(fun ctx -> ctx.Response.WriteAsync("healthy"))
-        )
-        |> ignore)
-    |> ignore
+        (app :> IApplicationBuilder).UseMiddleware<AffordanceMiddleware>(lookup) |> ignore
 
-    app.Start()
-    app.GetTestServer()
+        app.UseEndpoints(fun endpoints ->
+            endpoints.MapGet(
+                "/games/{gameId}",
+                RequestDelegate(fun ctx -> ctx.Response.WriteAsync("OK"))
+            )
+            |> ignore
+
+            endpoints.MapGet(
+                "/health",
+                RequestDelegate(fun ctx -> ctx.Response.WriteAsync("healthy"))
+            )
+            |> ignore)
+        |> ignore
+
+        app.Start()
+        let server = app.GetTestServer()
+        let client = server.CreateClient()
+
+        try
+            do! f client
+        finally
+            client.Dispose()
+            server.Dispose()
+            (app :> System.IDisposable).Dispose()
+    }
+    :> Task
 
 let private xTurnAffordance =
     { AllowHeaderValue = StringValues("GET, POST")
@@ -112,36 +122,33 @@ let affordanceMiddlewareTests =
               let lookup =
                   buildLookup [ "/games/{gameId}|XTurn", xTurnAffordance ]
 
-              use server =
-                  buildTestServer lookup (fun ctx ->
-                      ctx.SetStatechartState("XTurn", "XTurn", 0))
+              (withServer lookup (fun ctx -> ctx.SetStatechartState("XTurn", "XTurn", 0)) (fun client -> task {
+                  let! (response: HttpResponseMessage) = client.GetAsync("/games/abc")
 
-              use client = server.CreateClient()
+                  Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
 
-              let response =
-                  client.GetAsync("/games/abc").Result
+                  let allow = getHeaderValues response "Allow"
+                  Expect.isNonEmpty allow "Should have Allow header"
+                  let allowValue = allow |> String.concat ", "
 
-              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+                  Expect.isTrue
+                      (allowValue.Contains("GET") && allowValue.Contains("POST"))
+                      "Allow header should list GET and POST for XTurn state"
 
-              let allow = getHeaderValues response "Allow"
-              Expect.isNonEmpty allow "Should have Allow header"
-              let allowValue = allow |> String.concat ", "
+                  let links = getHeaderValues response "Link"
+                  Expect.isNonEmpty links "Should have Link header"
+                  let allLinks = links |> String.concat " "
 
-              Expect.isTrue
-                  (allowValue.Contains("GET") && allowValue.Contains("POST"))
-                  "Allow header should list GET and POST for XTurn state"
+                  Expect.isTrue
+                      (allLinks.Contains("rel=\"profile\""))
+                      "Should contain profile link"
 
-              let links = getHeaderValues response "Link"
-              Expect.isNonEmpty links "Should have Link header"
-              let allLinks = links |> String.concat " "
-
-              Expect.isTrue
-                  (allLinks.Contains("rel=\"profile\""))
-                  "Should contain profile link"
-
-              Expect.isTrue
-                  (allLinks.Contains("rel=\"makeMove\""))
-                  "Should contain makeMove transition link"
+                  Expect.isTrue
+                      (allLinks.Contains("rel=\"makeMove\""))
+                      "Should contain makeMove transition link"
+              }))
+                  .GetAwaiter()
+                  .GetResult()
 
           // T040: Different state yields different headers
           testCase "injects correct headers for Won state (no POST)"
@@ -149,28 +156,25 @@ let affordanceMiddlewareTests =
               let lookup =
                   buildLookup [ "/games/{gameId}|Won", wonAffordance ]
 
-              use server =
-                  buildTestServer lookup (fun ctx ->
-                      ctx.SetStatechartState("Won", "Won", 0))
+              (withServer lookup (fun ctx -> ctx.SetStatechartState("Won", "Won", 0)) (fun client -> task {
+                  let! (response: HttpResponseMessage) = client.GetAsync("/games/abc")
 
-              use client = server.CreateClient()
+                  Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
 
-              let response =
-                  client.GetAsync("/games/abc").Result
+                  let allow = getHeaderValues response "Allow"
+                  Expect.isNonEmpty allow "Should have Allow header"
+                  let allowValue = allow |> String.concat ", "
+                  Expect.isTrue (allowValue.Contains("GET")) "Allow header should list GET"
+                  Expect.isFalse (allowValue.Contains("POST")) "Allow header should NOT list POST for Won state"
 
-              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
-
-              let allow = getHeaderValues response "Allow"
-              Expect.isNonEmpty allow "Should have Allow header"
-              let allowValue = allow |> String.concat ", "
-              Expect.isTrue (allowValue.Contains("GET")) "Allow header should list GET"
-              Expect.isFalse (allowValue.Contains("POST")) "Allow header should NOT list POST for Won state"
-
-              let links = getHeaderValues response "Link"
-              Expect.isNonEmpty links "Should have Link header"
-              let allLinks = links |> String.concat " "
-              Expect.isTrue (allLinks.Contains("rel=\"profile\"")) "Should contain profile link"
-              Expect.isFalse (allLinks.Contains("makeMove")) "Should NOT contain makeMove link"
+                  let links = getHeaderValues response "Link"
+                  Expect.isNonEmpty links "Should have Link header"
+                  let allLinks = links |> String.concat " "
+                  Expect.isTrue (allLinks.Contains("rel=\"profile\"")) "Should contain profile link"
+                  Expect.isFalse (allLinks.Contains("makeMove")) "Should NOT contain makeMove link"
+              }))
+                  .GetAwaiter()
+                  .GetResult()
 
           // T041: Plain resource uses wildcard state key
           testCase "uses wildcard state key for plain resources"
@@ -178,23 +182,23 @@ let affordanceMiddlewareTests =
               let lookup =
                   buildLookup [ "/health|*", healthAffordance ]
 
-              use server = buildTestServer lookup ignore
-              use client = server.CreateClient()
+              (withServer lookup ignore (fun client -> task {
+                  let! (response: HttpResponseMessage) = client.GetAsync("/health")
 
-              let response =
-                  client.GetAsync("/health").Result
+                  Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
 
-              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+                  let allow = getHeaderValues response "Allow"
+                  Expect.isNonEmpty allow "Should have Allow header"
+                  let allowValue = allow |> String.concat ", "
+                  Expect.isTrue (allowValue.Contains("GET")) "Allow header should list GET for health endpoint"
 
-              let allow = getHeaderValues response "Allow"
-              Expect.isNonEmpty allow "Should have Allow header"
-              let allowValue = allow |> String.concat ", "
-              Expect.isTrue (allowValue.Contains("GET")) "Allow header should list GET for health endpoint"
-
-              let links = getHeaderValues response "Link"
-              Expect.isNonEmpty links "Should have Link header"
-              let allLinks = links |> String.concat " "
-              Expect.isTrue (allLinks.Contains("rel=\"profile\"")) "Should contain profile link for health"
+                  let links = getHeaderValues response "Link"
+                  Expect.isNonEmpty links "Should have Link header"
+                  let allLinks = links |> String.concat " "
+                  Expect.isTrue (allLinks.Contains("rel=\"profile\"")) "Should contain profile link for health"
+              }))
+                  .GetAwaiter()
+                  .GetResult()
 
           // T042: Graceful degradation -- no matching entry
           testCase "passes through when no matching affordance entry exists"
@@ -202,30 +206,28 @@ let affordanceMiddlewareTests =
               let lookup =
                   buildLookup [ "/other|*", healthAffordance ]
 
-              use server =
-                  buildTestServer lookup (fun ctx ->
-                      ctx.SetStatechartState("SomeState", "SomeState", 0))
+              (withServer lookup (fun ctx -> ctx.SetStatechartState("SomeState", "SomeState", 0)) (fun client -> task {
+                  let! (response: HttpResponseMessage) = client.GetAsync("/games/abc")
 
-              use client = server.CreateClient()
-
-              let response =
-                  client.GetAsync("/games/abc").Result
-
-              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
-              Expect.isFalse (hasHeader response "Link") "Should not have Link header"
+                  Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+                  Expect.isFalse (hasHeader response "Link") "Should not have Link header"
+              }))
+                  .GetAwaiter()
+                  .GetResult()
 
           // T042: Graceful degradation -- empty lookup
           testCase "passes through with empty affordance lookup"
           <| fun _ ->
               let lookup = buildLookup []
-              use server = buildTestServer lookup ignore
-              use client = server.CreateClient()
 
-              let response =
-                  client.GetAsync("/games/abc").Result
+              (withServer lookup ignore (fun client -> task {
+                  let! (response: HttpResponseMessage) = client.GetAsync("/games/abc")
 
-              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
-              Expect.isFalse (hasHeader response "Link") "Should not have Link header"
+                  Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+                  Expect.isFalse (hasHeader response "Link") "Should not have Link header"
+              }))
+                  .GetAwaiter()
+                  .GetResult()
 
           // T040: Unknown state key -- no fallback to wildcard
           testCase "does not fall back to wildcard when state key is present but unmatched"
@@ -235,18 +237,15 @@ let affordanceMiddlewareTests =
                       [ "/games/{gameId}|XTurn", xTurnAffordance
                         "/games/{gameId}|*", wonAffordance ]
 
-              use server =
-                  buildTestServer lookup (fun ctx ->
-                      ctx.SetStatechartState("UnknownState", "UnknownState", 0))
+              (withServer lookup (fun ctx -> ctx.SetStatechartState("UnknownState", "UnknownState", 0)) (fun client -> task {
+                  let! (response: HttpResponseMessage) = client.GetAsync("/games/abc")
 
-              use client = server.CreateClient()
-
-              let response =
-                  client.GetAsync("/games/abc").Result
-
-              Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
-              // Should NOT use the wildcard entry -- state key was present but didn't match
-              Expect.isFalse (hasHeader response "Link") "Should not have Link header for unknown state" ]
+                  Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+                  // Should NOT use the wildcard entry -- state key was present but didn't match
+                  Expect.isFalse (hasHeader response "Link") "Should not have Link header for unknown state"
+              }))
+                  .GetAwaiter()
+                  .GetResult() ]
 
 [<Tests>]
 let preComputeTests =

--- a/test/Frank.Statecharts.Tests/Affordances/AutoLoadTests.fs
+++ b/test/Frank.Statecharts.Tests/Affordances/AutoLoadTests.fs
@@ -71,9 +71,13 @@ let autoLoadTests =
             app.Start()
             let client = app.GetTestClient()
 
-            let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
-            Expect.equal resp.StatusCode HttpStatusCode.OK "GET should return 200"
-            let! (body: string) = resp.Content.ReadAsStringAsync()
-            Expect.equal body "items" "should get handler response"
+            try
+                let! (resp: HttpResponseMessage) = client.SendAsync(new HttpRequestMessage(HttpMethod.Get, "/items"))
+                Expect.equal resp.StatusCode HttpStatusCode.OK "GET should return 200"
+                let! (body: string) = resp.Content.ReadAsStringAsync()
+                Expect.equal body "items" "should get handler response"
+            finally
+                client.Dispose()
+                (app :> System.IDisposable).Dispose()
         }
     ]


### PR DESCRIPTION
## Summary

- Convert test factory functions that returned `HttpClient` (losing `IHost`/`WebApplication` references) to a `withServer` callback pattern with `try/finally` disposal
- Extract shared `withTestHost` helper in `OptionsDiscoveryTests.fs` to eliminate near-duplicate server builders across Discovery test files
- Ensure all `IDisposable` resources (`HttpClient`, `TestServer`, `IHost`, `WebApplication`) are properly disposed in test teardown
- Remove dead `withFullDiscoveryServer` function

## Files changed (7)

| File | Change |
|------|--------|
| `OptionsDiscoveryTests.fs` | Extract `withTestHost`, collapse `withDiscoveryServer`/`withServerWithoutDiscovery` to one-line wrappers |
| `LinkHeaderTests.fs` | `withLinkServer` delegates to `withTestHost` |
| `JsonHomeMiddlewareTests.fs` | `withServer` (Host-based) + `withCeServer` (WebApplication-based) callback patterns |
| `CombinationTests.fs` | Call sites updated to `withSpec`/`withCeServer` |
| `EdgeCaseTests.fs` | Call sites updated to `withDiscoveryServer` |
| `AffordanceMiddlewareTests.fs` | `withServer` callback pattern with full disposal chain |
| `AutoLoadTests.fs` | Inline `try/finally` for proper disposal |

## Test plan

- [x] `dotnet build Frank.sln` — 0 errors
- [x] `dotnet test Frank.sln --filter "FullyQualifiedName!~Sample"` — all 2034 tests pass
- [x] `dotnet test test/Frank.Tests/` — 89/89 pass
- [x] Rebased cleanly onto master after PR #169 merge

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)