### PR TITLE
feat: projection operator for per-role ALPS profiles

### DIFF
--- a/docs/superpowers/specs/2026-03-23-projection-operator-design.md
+++ b/docs/superpowers/specs/2026-03-23-projection-operator-design.md
@@ -1,0 +1,313 @@
+# Projection Operator — Per-Role ALPS Profiles from Global Protocol
+
+**Issue:** #107 — Projection Operator — Per-Role ALPS Profiles from Global Protocol
+**Date:** 2026-03-23
+**Status:** Design approved
+
+## Overview
+
+Build a projection operator that takes a global statechart with role definitions and derives per-role ALPS profiles — one per role, containing only the descriptors that role can trigger or observe. This is the central mechanism for making Frank's implicit per-role protocol views explicit and verifiable.
+
+The projection operator is a pure function in `Frank.Resources.Model` (zero-dep assembly). It operates on enriched `ExtractedStatechart` types and produces filtered statecharts. The caller swaps the projected statechart into a `UnifiedResource` copy, then passes it to the existing `UnifiedAlpsGenerator.generate` unchanged.
+
+**Scope:** Build-time implementation (CLI pipeline). Request-time middleware (content negotiation) is designed here but implemented in #130.
+
+## Design Decisions
+
+### One ALPS profile per role (not per state)
+
+ALPS profiles are vocabulary documents describing what a role can encounter across its entire interaction. Per-state profiles would create file explosion, break cacheability (invalidated on every state transition), and fight the ALPS spec's intent. State scoping is handled by `availableInStates` extensions on each descriptor.
+
+Output structure:
+- Global profile: `/alps/games` — complete vocabulary, all roles/states
+- Per-role profiles: `/alps/games-playerx`, `/alps/games-playero` — filtered subsets
+
+Slugs use lowercase role names appended with a hyphen separator.
+
+### Pre-resolved role constraints on transitions (not a separate guard map)
+
+Each `TransitionSpec` carries a `RoleConstraint` DU indicating which roles can trigger it. The extraction step eagerly resolves guard + state → permitted roles. The projection operator receives fully-resolved data.
+
+This matches MPST global types where each interaction `p -> q: <label>` already names its participants. Projection is a syntactic filter, not a lookup-dependent computation.
+
+A separate `GuardRoleMap: Map<string, Map<string, string list>>` was rejected — it introduces indirection with no session-type analogue, creates dangling reference risks, and makes the projection operator dependent on external state.
+
+### Uniform projection — no safe descriptor special case
+
+Guards are the sole arbiter of descriptor visibility. No special treatment for safe (GET) descriptors. In MPST, projection inspects participant names, not message types. HTTP method safety is about side effects, not access scope.
+
+Unguarded transitions (no guard) are available to all roles — open-world default matching HTTP conventions. The cross-validator emits a warning for unmapped transitions so teams can confirm intent. Closed-world with totality check deferred to #171.
+
+### Pipeline: enrich → project → generate (Approach C)
+
+Unidirectional pipeline where projection operates on enriched portable types, not on generated ALPS output.
+
+```
+ExtractedStatechart (with Transitions + RoleConstraint)
+  |> Projection.projectForRole roleName  -- pure filter + prune
+  → ExtractedStatechart (projected)
+
+Caller then:
+  → swap projected statechart into UnifiedResource copy
+  → UnifiedAlpsGenerator.generate(projectedResource, baseUri)
+  → per-role ALPS JSON
+```
+
+The projection operator lives in `Frank.Resources.Model` (zero-dep) and knows nothing about `UnifiedResource` or ALPS. The callsite in `Frank.Cli.Core` handles the `UnifiedResource` assembly. `HttpCapabilities` on the `UnifiedResource` are not filtered — the ALPS generator already scopes transition descriptors by the states present in the statechart.
+
+### Same type in, same type out
+
+`projectForRole : string -> ExtractedStatechart -> ExtractedStatechart`. The projected statechart has the same structure as the unprojected one — it's a subset, not a different kind. This gives free composability: any function consuming `ExtractedStatechart` works on both global and projected views.
+
+### Decomposed into composable endomorphisms
+
+Following Seemann's recommendation:
+
+```fsharp
+let filterTransitionsByRole (roleName: string) : ExtractedStatechart -> ExtractedStatechart
+let pruneUnreachableStates : ExtractedStatechart -> ExtractedStatechart
+let projectForRole roleName = filterTransitionsByRole roleName >> pruneUnreachableStates
+```
+
+Each function is independently reusable and testable. `pruneUnreachableStates` is useful after other transformations too.
+
+### Completeness check (post-projection validation)
+
+After projecting all roles, verify that every transition in the global statechart appears in at least one role's projection. This is a simple set-coverage check — the union of all projected transition sets must equal the global transition set.
+
+Other verification steps have homes elsewhere:
+- Deadlock detection → #108
+- Connectedness + mixed choice → #133
+
+## New Types in `Frank.Resources.Model`
+
+### `RoleConstraint` DU
+
+```fsharp
+/// Whether a transition is available to all roles or restricted to specific roles.
+type RoleConstraint =
+    | Unrestricted                    // no guard — all roles (broadcast)
+    | RestrictedTo of string list     // guard resolved — these roles only (directed)
+```
+
+Maps to session type semantics: `Unrestricted` = broadcast message, `RestrictedTo` = directed message.
+
+### `TransitionSpec` record
+
+```fsharp
+/// A single transition in the extracted statechart.
+/// Domain-neutral: no ALPS/SCXML/format-specific concepts.
+type TransitionSpec =
+    { /// The event name (semantic transition name, e.g., "makeMove", "getGame")
+      Event: string
+      /// Source state key (e.g., "XTurn")
+      Source: string
+      /// Target state key (e.g., "OTurn")
+      Target: string
+      /// Guard name controlling this transition (None = unguarded).
+      /// Retained for diagnostics and cross-validation, not used by projection.
+      Guard: string option
+      /// Pre-resolved role constraint. Extraction resolves guard + state → roles.
+      Constraint: RoleConstraint }
+```
+
+Note: not `[<Struct>]` — 5 fields with reference types (`string option`, `RoleConstraint` DU) means no meaningful benefit from struct layout.
+
+### `ExtractedStatechart` addition
+
+One new field:
+
+```fsharp
+type ExtractedStatechart =
+    { RouteTemplate: string
+      StateNames: string list
+      InitialStateKey: string
+      GuardNames: string list
+      StateMetadata: Map<string, StateInfo>
+      Roles: RoleInfo list
+      /// All transitions in the statechart (NEW).
+      Transitions: TransitionSpec list }
+```
+
+`GuardNames` is retained for backward compatibility and cross-validation. The `Guard` field on `TransitionSpec` is the per-transition version.
+
+### `ProjectedProfiles` addition
+
+Flat map for per-role profiles (slug already encodes the role):
+
+```fsharp
+type ProjectedProfiles =
+    { AlpsProfiles: Map<string, string>
+      /// Per-role ALPS profiles keyed by slug (e.g., "games-playerx" → JSON) (NEW).
+      RoleAlpsProfiles: Map<string, string>
+      OwlOntologies: Map<string, string>
+      ShaclShapes: Map<string, string>
+      JsonSchemas: Map<string, string> }
+```
+
+`ProjectedProfiles.empty` and `ProjectedProfiles.isEmpty` must be updated to include `RoleAlpsProfiles`.
+
+## Projection Operator (`Frank.Resources.Model.Projection` module)
+
+```fsharp
+module Projection =
+
+    /// Filter transitions to those available to the given role.
+    /// Unrestricted transitions survive in all projections.
+    /// RestrictedTo transitions survive only if roleName is in the list.
+    let filterTransitionsByRole (roleName: string) (statechart: ExtractedStatechart) : ExtractedStatechart
+
+    /// Remove states unreachable from the initial state via surviving transitions.
+    /// Initial state is always retained. Updates StateNames, StateMetadata,
+    /// and removes transitions referencing pruned states.
+    let pruneUnreachableStates (statechart: ExtractedStatechart) : ExtractedStatechart
+
+    /// Project a statechart for a single role: filter then prune.
+    let projectForRole (roleName: string) : ExtractedStatechart -> ExtractedStatechart
+
+    /// Project for all roles defined in the statechart.
+    /// Returns empty map if statechart has no roles (no-op).
+    let projectAll (statechart: ExtractedStatechart) : Map<string, ExtractedStatechart>
+
+    /// Post-projection completeness check: every global transition must appear
+    /// in at least one role's projection. Returns orphaned transitions.
+    let findOrphanedTransitions
+        (global: ExtractedStatechart)
+        (projections: Map<string, ExtractedStatechart>)
+        : TransitionSpec list
+```
+
+The projection operator is total — every input produces a valid output. No `Result`, no `Option`. A projection with one state and no transitions is valid (role can observe but not act).
+
+Role matching is case-sensitive — role names from `RoleInfo.Name` must match `RestrictedTo` entries exactly. The extraction step is responsible for consistent casing.
+
+## Build-Time Integration (CLI Pipeline)
+
+### Pipeline flow
+
+```
+UnifiedExtractor.extract → UnifiedResource list
+  → for each resource with a Statechart that has Roles:
+      Projection.projectAll → Map<string, ExtractedStatechart>
+      → for each (roleName, projectedChart):
+          copy UnifiedResource with Statechart = Some projectedChart
+          → UnifiedAlpsGenerator.generate(projectedResource, baseUri) → per-role ALPS JSON
+      → also generate global (unprojected) ALPS as today
+      → run findOrphanedTransitions, emit warnings for orphaned transitions
+  → store global profiles in ProjectedProfiles.AlpsProfiles (existing)
+  → store per-role profiles in ProjectedProfiles.RoleAlpsProfiles (new)
+```
+
+Resources with no `Roles` (empty list) skip projection — no per-role profiles generated. This is the common case for most resources today.
+
+### Extraction: populating `Transitions`
+
+The `UnifiedExtractor` currently captures `StateNames`, `GuardNames`, and `StateMetadata` from the statechart builder. It must additionally extract per-state transitions with their guard assignments and resolve `RoleConstraint` values.
+
+Transition data comes from `StateMachine<'State, 'Event, 'Context>` at extraction time:
+- `Transition` function provides state → event → state mappings
+- `Guards` list provides guard names and their runtime predicates
+- `RoleDefinition` list (from `StatefulResourceBuilder`) provides role names
+
+The extraction step resolves: for each (state, transition), which guards apply, and for each guard, which roles are permitted. This resolution uses the `RoleDefinition.ClaimsPredicate` at extraction time (not at projection time). The extracted `RoleConstraint` is the pre-resolved result.
+
+### CLI output
+
+Generated via the existing `frank generate --format alps` command:
+
+```
+projected/games.alps.json           ← global
+projected/games-playerx.alps.json   ← PlayerX projection
+projected/games-playero.alps.json   ← PlayerO projection
+```
+
+### ALPS document annotations
+
+The ALPS generator (not the projection operator) adds annotations to projected profiles:
+- `projectedRole` ext element identifying the role (uses `Classification.ProjectedRoleExtId`)
+- `availableInStates` ext on each transition descriptor (NEW — must be built in this issue; the ALPS generator does not currently emit this)
+- No `protocolState` at build-time (runtime-only "you are here" pin)
+
+### ALPS cross-linking
+
+Added by `UnifiedAlpsGenerator.fs` (not `GeneratorCommon.fs`):
+- Global profile includes `link` elements to per-role profiles with `rel: "related"`
+- Per-role profiles include a `link` element back to the global profile with `rel: "profile"`
+
+## Request-Time Integration (Design Only — Implemented in #130)
+
+### Flow
+
+1. Startup: load `ProjectedProfiles.RoleAlpsProfiles` from cached extraction state
+2. Middleware resolves authenticated user's claims → role name (via `RoleDefinition.ClaimsPredicate`)
+3. Dictionary lookup: role slug → pre-computed profile string
+4. Serve with `Link: </alps/games-playerx>; rel="profile"` header
+5. Unauthenticated/unknown role → global profile with `Link: </alps/games>; rel="profile"`
+
+### What this issue provides for #130
+
+- `ProjectedProfiles.RoleAlpsProfiles` field populated at build-time
+- `Projection.projectForRole` and `projectAll` functions usable at startup
+- Per-role ALPS documents with `projectedRole` ext and cross-links
+
+### What #130 adds
+
+- Claims → role resolution in middleware
+- `Vary: Authorization` on responses where `Link: rel="profile"` varies by role
+- `ReadOnlyMemory<byte>` optimization for zero-copy response writing
+- `protocolState` ext injection based on current resource state
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/Frank.Resources.Model/ResourceTypes.fs` | Add `RoleConstraint`, `TransitionSpec`, `Transitions` field on `ExtractedStatechart`, `RoleAlpsProfiles` field on `ProjectedProfiles`, update `empty` and `isEmpty` |
+| `src/Frank.Resources.Model/Projection.fs` | **New file.** `filterTransitionsByRole`, `pruneUnreachableStates`, `projectForRole`, `projectAll`, `findOrphanedTransitions` |
+| `src/Frank.Resources.Model/Frank.Resources.Model.fsproj` | Add `Projection.fs` to compile order (after `ResourceTypes.fs`) |
+| `src/Frank.Cli.Core/Unified/UnifiedAlpsGenerator.fs` | Emit `projectedRole` ext, `availableInStates` ext, and cross-link `link` elements on projected profiles |
+| `src/Frank.Cli.Core/Commands/UnifiedGenerateCommand.fs` | Integrate projection into generation pipeline; emit orphaned transition warnings |
+| `src/Frank.Cli.Core/Unified/UnifiedExtractor.fs` | Populate `Transitions` on `ExtractedStatechart` during extraction; resolve `RoleConstraint` from guards + roles |
+| `test/Frank.Resources.Model.Tests/` | **New test project or tests.** Projection operator unit tests |
+
+### Binary compatibility
+
+Adding `Transitions` to `ExtractedStatechart` and `RoleAlpsProfiles` to `ProjectedProfiles` are binary-breaking changes. `UnifiedExtractionState` is serialized to `model.bin` via `UnifiedCache`. The `ToolVersion` in `UnifiedCache` must be bumped so stale caches are invalidated.
+
+## Verification
+
+1. `dotnet build Frank.sln` — all projects compile
+2. `dotnet test Frank.sln --filter "FullyQualifiedName!~Sample"` — all existing tests pass
+3. Projection unit tests verify:
+   - `filterTransitionsByRole` keeps correct transitions per role
+   - `pruneUnreachableStates` removes unreachable states, keeps initial, updates StateNames/StateMetadata/Transitions
+   - `projectAll` produces one projection per role; returns empty map for no-role statecharts
+   - `findOrphanedTransitions` detects uncovered transitions as `TransitionSpec list`
+   - Unrestricted transitions appear in all projections
+   - RestrictedTo transitions appear only in permitted role projections
+   - Role matching is case-sensitive
+4. TicTacToe sample: `frank generate --format alps` generates correct per-role ALPS files
+   - PlayerX profile: `makeMove` with `availableInStates: "XTurn"` only
+   - PlayerO profile: `makeMove` with `availableInStates: "OTurn"` only
+   - Both profiles: `getGame` available in all states (unguarded)
+   - Global profile links to per-role profiles; per-role profiles link back
+
+## Related Issues
+
+- #130 — Request-time content negotiation (uses types/functions from this issue)
+- #133 — Cross-validator projection consistency (connectedness, mixed choice checks)
+- #108 — Progress analysis (deadlock, starvation detection)
+- #171 — Closed-world projection with totality check (future exploration)
+- #91 — Cross-validator (completeness check extends this)
+
+## Expert Consensus
+
+Design validated by 6 expert perspectives:
+
+| Expert | Key contribution |
+|--------|-----------------|
+| Amundsen | ALPS is vocabulary, not runtime snapshot. One profile per role. Cross-linking with `rel: "related"` / `rel: "profile"`. |
+| Darrel Miller | HTTP safety ≠ access scope. Cacheability requires stable profile URLs. `Vary: Authorization` for role-dependent `Link` headers. |
+| Wadler | MPST projection correspondence. `RoleConstraint` DU = broadcast vs directed. Completeness check = projectability verification. Uniform projection (no safe special case). |
+| Syme | `TransitionSpec` completes the type. Pre-resolved roles eliminate nested map smell. Pipeline-friendly argument order. |
+| Wlaschin | "Parse, don't validate" — resolve at extraction. `RoleConstraint` DU makes semantics explicit. Projection = what you can *do*. |
+| Seemann | Decompose into composable endomorphisms. Same type in/out. Total function (no Result). Dependency rejection pattern. |

--- a/sample/Frank.TicTacToe.Sample/specs/tictactoe.alps.json
+++ b/sample/Frank.TicTacToe.Sample/specs/tictactoe.alps.json
@@ -1,0 +1,159 @@
+{
+  "alps": {
+    "version": "1.0",
+    "doc": { "format": "text", "value": "Tic-Tac-Toe game state machine with role-based projection" },
+    "ext": [
+      { "id": "projectedRole", "value": "PlayerX,PlayerO,Spectator" }
+    ],
+    "descriptor": [
+      {
+        "id": "position",
+        "type": "semantic",
+        "doc": { "format": "text", "value": "Board position (0-8)" }
+      },
+      {
+        "id": "player",
+        "type": "semantic",
+        "doc": { "format": "text", "value": "Player identifier (X or O)" }
+      },
+      {
+        "id": "XTurn",
+        "type": "semantic",
+        "doc": { "format": "text", "value": "State: Player X's turn" },
+        "descriptor": [
+          {
+            "id": "makeMove-XTurn-OTurn",
+            "type": "unsafe",
+            "rt": "#OTurn",
+            "doc": { "format": "text", "value": "Player X makes a move, transitions to O's turn" },
+            "descriptor": [
+              { "href": "#position" },
+              { "href": "#player" }
+            ],
+            "ext": [
+              { "id": "guard", "value": "TurnGuard" },
+              { "id": "projectedRole", "value": "PlayerX" },
+              { "id": "availableInStates", "value": "XTurn" }
+            ]
+          },
+          {
+            "id": "makeMove-XTurn-XWins",
+            "type": "unsafe",
+            "rt": "#XWins",
+            "doc": { "format": "text", "value": "Player X makes a winning move" },
+            "descriptor": [
+              { "href": "#position" },
+              { "href": "#player" }
+            ],
+            "ext": [
+              { "id": "guard", "value": "TurnGuard" },
+              { "id": "projectedRole", "value": "PlayerX" },
+              { "id": "availableInStates", "value": "XTurn" }
+            ]
+          },
+          {
+            "id": "makeMove-XTurn-Draw",
+            "type": "unsafe",
+            "rt": "#Draw",
+            "doc": { "format": "text", "value": "Player X makes a move that fills the board" },
+            "descriptor": [
+              { "href": "#position" },
+              { "href": "#player" }
+            ],
+            "ext": [
+              { "id": "guard", "value": "TurnGuard" },
+              { "id": "projectedRole", "value": "PlayerX" },
+              { "id": "availableInStates", "value": "XTurn" }
+            ]
+          },
+          { "href": "#getGame" }
+        ]
+      },
+      {
+        "id": "OTurn",
+        "type": "semantic",
+        "doc": { "format": "text", "value": "State: Player O's turn" },
+        "descriptor": [
+          {
+            "id": "makeMove-OTurn-XTurn",
+            "type": "unsafe",
+            "rt": "#XTurn",
+            "doc": { "format": "text", "value": "Player O makes a move, transitions to X's turn" },
+            "descriptor": [
+              { "href": "#position" },
+              { "href": "#player" }
+            ],
+            "ext": [
+              { "id": "guard", "value": "TurnGuard" },
+              { "id": "projectedRole", "value": "PlayerO" },
+              { "id": "availableInStates", "value": "OTurn" }
+            ]
+          },
+          {
+            "id": "makeMove-OTurn-OWins",
+            "type": "unsafe",
+            "rt": "#OWins",
+            "doc": { "format": "text", "value": "Player O makes a winning move" },
+            "descriptor": [
+              { "href": "#position" },
+              { "href": "#player" }
+            ],
+            "ext": [
+              { "id": "guard", "value": "TurnGuard" },
+              { "id": "projectedRole", "value": "PlayerO" },
+              { "id": "availableInStates", "value": "OTurn" }
+            ]
+          },
+          {
+            "id": "makeMove-OTurn-Draw",
+            "type": "unsafe",
+            "rt": "#Draw",
+            "doc": { "format": "text", "value": "Player O makes a move that fills the board" },
+            "descriptor": [
+              { "href": "#position" },
+              { "href": "#player" }
+            ],
+            "ext": [
+              { "id": "guard", "value": "TurnGuard" },
+              { "id": "projectedRole", "value": "PlayerO" },
+              { "id": "availableInStates", "value": "OTurn" }
+            ]
+          },
+          { "href": "#getGame" }
+        ]
+      },
+      {
+        "id": "XWins",
+        "type": "semantic",
+        "doc": { "format": "text", "value": "State: Player X has won" },
+        "descriptor": [
+          { "href": "#getGame" }
+        ]
+      },
+      {
+        "id": "OWins",
+        "type": "semantic",
+        "doc": { "format": "text", "value": "State: Player O has won" },
+        "descriptor": [
+          { "href": "#getGame" }
+        ]
+      },
+      {
+        "id": "Draw",
+        "type": "semantic",
+        "doc": { "format": "text", "value": "State: Game ended in a draw" },
+        "descriptor": [
+          { "href": "#getGame" }
+        ]
+      },
+      {
+        "id": "getGame",
+        "type": "safe",
+        "doc": { "format": "text", "value": "View the current game state" }
+      }
+    ],
+    "link": [
+      { "rel": "self", "href": "http://example.com/alps/tic-tac-toe" }
+    ]
+  }
+}

--- a/sample/Frank.TicTacToe.Sample/specs/tictactoe.smcat
+++ b/sample/Frank.TicTacToe.Sample/specs/tictactoe.smcat
@@ -1,0 +1,20 @@
+# Tic-Tac-Toe state machine with role-based transitions
+initial => XTurn;
+XTurn, OTurn, XWins, OWins, Draw;
+
+# getGame: self-loop on all states (unguarded, all roles)
+XTurn => XTurn: getGame;
+OTurn => OTurn: getGame;
+XWins => XWins: getGame;
+OWins => OWins: getGame;
+Draw => Draw: getGame;
+
+# makeMove from XTurn (role=PlayerX, guard=TurnGuard)
+XTurn => OTurn: makeMove [TurnGuard];
+XTurn => XWins: makeMove [TurnGuard];
+XTurn => Draw: makeMove [TurnGuard];
+
+# makeMove from OTurn (role=PlayerO, guard=TurnGuard)
+OTurn => XTurn: makeMove [TurnGuard];
+OTurn => OWins: makeMove [TurnGuard];
+OTurn => Draw: makeMove [TurnGuard];

--- a/sample/Frank.TicTacToe.Sample/specs/tictactoe.wsd
+++ b/sample/Frank.TicTacToe.Sample/specs/tictactoe.wsd
@@ -1,0 +1,26 @@
+title Tic-Tac-Toe State Machine
+
+participant XTurn
+participant OTurn
+participant XWins
+participant OWins
+participant Draw
+
+# getGame: self-loop on all states (unguarded, all roles can observe)
+XTurn->XTurn: getGame
+OTurn->OTurn: getGame
+XWins->XWins: getGame
+OWins->OWins: getGame
+Draw->Draw: getGame
+
+# makeMove from XTurn (role=PlayerX, guarded by TurnGuard)
+note over XTurn: [guard: role=PlayerX, guard=TurnGuard]
+XTurn->OTurn: makeMove(position, player)
+XTurn->XWins: makeMove(position, player)
+XTurn->Draw: makeMove(position, player)
+
+# makeMove from OTurn (role=PlayerO, guarded by TurnGuard)
+note over OTurn: [guard: role=PlayerO, guard=TurnGuard]
+OTurn->XTurn: makeMove(position, player)
+OTurn->OWins: makeMove(position, player)
+OTurn->Draw: makeMove(position, player)

--- a/src/Frank.Cli.Core/Commands/CompileCommand.fs
+++ b/src/Frank.Cli.Core/Commands/CompileCommand.fs
@@ -33,41 +33,65 @@ module CompileCommand =
             File.Copy(statePath, backupPath)
 
     let private verifyRoundTrip (ontologyPath: string) (shapesPath: string) (manifestPath: string) =
-        // Re-parse ontology
-        let ontologyGraph = new Graph()
+        use ontologyGraph = new Graph()
         let rdfXmlParser = RdfXmlParser()
         use ontologyReader = new StreamReader(ontologyPath)
         rdfXmlParser.Load(ontologyGraph, ontologyReader)
 
-        // Re-parse shapes
-        let shapesGraph = new Graph()
+        use shapesGraph = new Graph()
         let turtleParser = TurtleParser()
         use shapesReader = new StreamReader(shapesPath)
         turtleParser.Load(shapesGraph, shapesReader)
 
-        // Re-parse manifest
         let manifestJson = File.ReadAllText(manifestPath)
         use _ = JsonDocument.Parse(manifestJson)
         ()
 
     /// Populate the Profiles field on the unified extraction state binary.
-    /// Generates ALPS per resource and serializes OWL/SHACL as whole-project strings.
-    /// Re-saves the model.bin with the populated profiles.
-    let private populateProfilesInBinary
-        (projectDir: string)
-        (legacyState: ExtractionState option)
-        : unit =
+    /// Generates ALPS per resource, runs per-role projection where applicable,
+    /// serializes OWL/SHACL as whole-project strings, and re-saves model.bin.
+    let private populateProfilesInBinary (projectDir: string) (legacyState: ExtractionState option) : unit =
         let unifiedPath = UnifiedCache.cachePath projectDir
 
         match UnifiedCache.load unifiedPath with
         | Ok(Some unified) ->
+            // Run projection first so we know which resource slugs get
+            // their global profile overridden with cross-links.
+            let batchResult, projectionResults =
+                ProjectionPipeline.projectAllResources unified.Resources unified.BaseUri
+
+            for result in projectionResults do
+                for err in result.Errors do
+                    eprintfn "%s" err
+
+                for orphan in result.Orphans do
+                    eprintfn
+                        "Warning: transition '%s' (%s -> %s) is not covered by any role projection"
+                        orphan.Event
+                        orphan.Source
+                        orphan.Target
+
+            // Generate plain ALPS for resources that did NOT receive projection treatment.
             let alpsProfiles =
                 unified.Resources
                 |> List.choose (fun resource ->
-                    match UnifiedAlpsGenerator.generate resource unified.BaseUri with
-                    | Ok alpsJson -> Some(resource.ResourceSlug, alpsJson)
-                    | Error _ -> None)
+                    if Set.contains resource.ResourceSlug batchResult.ProjectedSlugs then
+                        None
+                    else
+                        match UnifiedAlpsGenerator.generate resource unified.BaseUri with
+                        | Ok alpsJson -> Some(resource.ResourceSlug, alpsJson)
+                        | Error errs ->
+                            eprintfn
+                                "Warning: failed to generate ALPS profile for %s: %s"
+                                resource.ResourceSlug
+                                (String.concat "; " errs)
+
+                            None)
                 |> Map.ofList
+
+            let mergedAlpsProfiles =
+                batchResult.GlobalProfileOverrides
+                |> Map.fold (fun acc k v -> Map.add k v acc) alpsProfiles
 
             let owlTurtle =
                 match legacyState with
@@ -80,7 +104,8 @@ module CompileCommand =
                 | None -> ""
 
             let profiles: ProjectedProfiles =
-                { AlpsProfiles = alpsProfiles
+                { AlpsProfiles = mergedAlpsProfiles
+                  RoleAlpsProfiles = batchResult.RoleAlpsProfiles
                   OwlOntologies =
                     if String.IsNullOrEmpty owlTurtle then
                         Map.empty
@@ -99,6 +124,7 @@ module CompileCommand =
 
     let execute (projectPath: string) (outputDir: string option) : Result<CompileResult, string> =
         let projectDir = Path.GetDirectoryName projectPath
+
         match ExtractionStateProjector.UnifiedStateLoader.loadExtractionState projectDir with
         | Error e -> Error e
         | Ok state ->
@@ -107,18 +133,13 @@ module CompileCommand =
                 let outDir =
                     outputDir |> Option.defaultValue (Path.Combine(projectDir, "obj", "frank"))
 
-                // Back up existing state before overwriting
                 let statePath = ExtractionState.defaultStatePath projectDir
                 backupState statePath
 
-                // Write all three artifacts via shared serializer
                 let (ontologyPath, shapesPath, manifestPath) =
                     ArtifactSerializer.writeArtifacts state outDir
 
-                // Round-trip verification: re-parse each file to confirm validity
                 verifyRoundTrip ontologyPath shapesPath manifestPath
-
-                // Populate profiles in the unified state binary
                 populateProfilesInBinary projectDir (Some state)
 
                 Ok
@@ -173,8 +194,6 @@ module CompileCommand =
                             ArtifactSerializer.writeArtifacts state outDir
 
                         verifyRoundTrip ontologyPath shapesPath manifestPath
-
-                        // Populate profiles in the unified state binary
                         populateProfilesInBinary projectDir (Some state)
 
                         return

--- a/src/Frank.Cli.Core/Commands/StatechartGenerateCommand.fs
+++ b/src/Frank.Cli.Core/Commands/StatechartGenerateCommand.fs
@@ -15,22 +15,25 @@ type GeneratedArtifact =
       FilePath: string option }
 
 type GenerateResult =
-    { Artifacts: GeneratedArtifact list
-      OutputDirectory: string option
-      GenerationErrors: StatechartError list
-      /// Affordance map JSON output (when --format affordance-map is used)
-      AffordanceMapJson: string option }
+    {
+        Artifacts: GeneratedArtifact list
+        OutputDirectory: string option
+        GenerationErrors: StatechartError list
+        /// Affordance map JSON output (when --format affordance-map is used)
+        AffordanceMapJson: string option
+    }
 
 let private parseFormat (s: string) : Result<FormatTag list, StatechartError> =
     match s.ToLowerInvariant() with
     | "wsd" -> Ok [ Wsd ]
     | "alps" -> Ok [ Alps ]
-    | "alps-xml" | "alpsxml" -> Ok [ AlpsXml ]
+    | "alps-xml"
+    | "alpsxml" -> Ok [ AlpsXml ]
     | "scxml" -> Ok [ Scxml ]
     | "smcat" -> Ok [ Smcat ]
     | "xstate" -> Ok [ XState ]
     | "all" -> Ok FormatPipeline.allFormats
-    | other -> Error (UnknownFormat other)
+    | other -> Error(UnknownFormat other)
 
 /// Generate affordance map JSON from the unified extractor pipeline.
 let private executeAffordanceMap
@@ -43,22 +46,26 @@ let private executeAffordanceMap
         | Error e -> return Error e
         | Ok resources ->
             let json = AffordanceMapGenerator.generate resources baseUri None
+
             match outputDir with
             | Some dir ->
                 Directory.CreateDirectory(dir) |> ignore
                 let filePath = Path.Combine(dir, "affordance-map.json")
                 File.WriteAllText(filePath, json)
-                return Ok
-                    { Artifacts = []
-                      OutputDirectory = Some dir
-                      GenerationErrors = []
-                      AffordanceMapJson = Some json }
+
+                return
+                    Ok
+                        { Artifacts = []
+                          OutputDirectory = Some dir
+                          GenerationErrors = []
+                          AffordanceMapJson = Some json }
             | None ->
-                return Ok
-                    { Artifacts = []
-                      OutputDirectory = None
-                      GenerationErrors = []
-                      AffordanceMapJson = Some json }
+                return
+                    Ok
+                        { Artifacts = []
+                          OutputDirectory = None
+                          GenerationErrors = []
+                          AffordanceMapJson = Some json }
     }
 
 let execute
@@ -70,73 +77,89 @@ let execute
     async {
         // Handle affordance-map as a special format (uses unified extractor)
         match format.ToLowerInvariant() with
-        | "affordance-map" | "affordancemap" ->
+        | "affordance-map"
+        | "affordancemap" ->
             let baseUri = "http://localhost:5000/alps"
             return! executeAffordanceMap projectPath baseUri outputDir
         | _ ->
 
-        match parseFormat format with
-        | Error e -> return Error e
-        | Ok formats ->
-            match! StatechartSourceExtractor.extract projectPath with
+            match parseFormat format with
             | Error e -> return Error e
-            | Ok machines ->
-                let filtered =
-                    match resourceFilter with
-                    | None -> machines
-                    | Some name ->
-                        machines
-                        |> List.filter (fun m ->
-                            let slug = FormatPipeline.resourceSlug m.RouteTemplate
-                            slug = name || m.RouteTemplate.Contains(name))
+            | Ok formats ->
+                match! StatechartSourceExtractor.extract projectPath with
+                | Error e -> return Error e
+                | Ok machines ->
+                    let filtered =
+                        match resourceFilter with
+                        | None -> machines
+                        | Some name ->
+                            machines
+                            |> List.filter (fun m ->
+                                let slug = FormatPipeline.resourceSlug m.RouteTemplate
+                                slug = name || m.RouteTemplate.Contains(name))
 
-                match resourceFilter, filtered with
-                | Some name, [] ->
-                    let available =
-                        machines
-                        |> List.map (fun m -> FormatPipeline.resourceSlug m.RouteTemplate)
+                    match resourceFilter, filtered with
+                    | Some name, [] ->
+                        let available =
+                            machines |> List.map (fun m -> FormatPipeline.resourceSlug m.RouteTemplate)
 
-                    return Error (ResourceNotFound(name, available))
-                | _ ->
-                    let mutable generationErrors = []
-                    let artifacts =
-                        [ for m in filtered do
-                              let slug = FormatPipeline.resourceSlug m.RouteTemplate
+                        return Error(ResourceNotFound(name, available))
+                    | _ ->
+                        let results =
+                            [ for m in filtered do
+                                  let slug = FormatPipeline.resourceSlug m.RouteTemplate
 
-                              for fmt in formats do
-                                  match FormatPipeline.generateFormatFromExtracted fmt slug m with
-                                  | Ok content ->
-                                      { ResourceSlug = slug
-                                        RouteTemplate = m.RouteTemplate
-                                        Format = fmt
-                                        Content = content
-                                        FilePath = None }
-                                  | Error err ->
-                                      generationErrors <- err :: generationErrors ]
+                                  for fmt in formats do
+                                      match FormatPipeline.generateFormatFromExtracted fmt slug m with
+                                      | Ok content ->
+                                          Ok
+                                              { ResourceSlug = slug
+                                                RouteTemplate = m.RouteTemplate
+                                                Format = fmt
+                                                Content = content
+                                                FilePath = None }
+                                      | Error err -> Error err ]
 
-                    match outputDir with
-                    | None ->
-                        return Ok { Artifacts = artifacts
-                                    OutputDirectory = None
-                                    GenerationErrors = List.rev generationErrors
-                                    AffordanceMapJson = None }
-                    | Some dir ->
-                        Directory.CreateDirectory(dir) |> ignore
+                        let artifacts =
+                            results
+                            |> List.choose (function
+                                | Ok a -> Some a
+                                | Error _ -> None)
 
-                        let written =
-                            artifacts
-                            |> List.map (fun a ->
-                                let fileName =
-                                    sprintf "%s%s" a.ResourceSlug (FormatDetector.formatExtension a.Format)
+                        let generationErrors =
+                            results
+                            |> List.choose (function
+                                | Error e -> Some e
+                                | Ok _ -> None)
+                            |> List.rev
 
-                                let filePath = Path.Combine(dir, fileName)
-                                File.WriteAllText(filePath, a.Content)
-                                { a with FilePath = Some filePath })
+                        match outputDir with
+                        | None ->
+                            return
+                                Ok
+                                    { Artifacts = artifacts
+                                      OutputDirectory = None
+                                      GenerationErrors = generationErrors
+                                      AffordanceMapJson = None }
+                        | Some dir ->
+                            Directory.CreateDirectory(dir) |> ignore
 
-                        return Ok { Artifacts = written
-                                    OutputDirectory = Some dir
-                                    GenerationErrors = List.rev generationErrors
-                                    AffordanceMapJson = None }
+                            let written =
+                                artifacts
+                                |> List.map (fun a ->
+                                    let fileName =
+                                        sprintf "%s%s" a.ResourceSlug (FormatDetector.formatExtension a.Format)
+
+                                    let filePath = Path.Combine(dir, fileName)
+                                    File.WriteAllText(filePath, a.Content)
+                                    { a with FilePath = Some filePath })
+
+                            return
+                                Ok
+                                    { Artifacts = written
+                                      OutputDirectory = Some dir
+                                      GenerationErrors = generationErrors
+                                      AffordanceMapJson = None }
     }
 
 /// Execute affordance-map generation with an explicit base URI.
@@ -149,8 +172,7 @@ let executeWithBaseUri
     : Async<Result<GenerateResult, StatechartError>> =
     async {
         match format.ToLowerInvariant() with
-        | "affordance-map" | "affordancemap" ->
-            return! executeAffordanceMap projectPath baseUri outputDir
-        | _ ->
-            return! execute projectPath format outputDir resourceFilter
+        | "affordance-map"
+        | "affordancemap" -> return! executeAffordanceMap projectPath baseUri outputDir
+        | _ -> return! execute projectPath format outputDir resourceFilter
     }

--- a/src/Frank.Cli.Core/Commands/UnifiedGenerateCommand.fs
+++ b/src/Frank.Cli.Core/Commands/UnifiedGenerateCommand.fs
@@ -5,6 +5,7 @@ open System.Text.Json
 open Frank.Resources.Model
 open Frank.Statecharts.Validation
 open Frank.Cli.Core.Unified
+open Frank.Cli.Core.Unified.ProjectionPipeline
 open Frank.Cli.Core.Statechart
 open Frank.Cli.Core.Statechart.StatechartError
 
@@ -33,8 +34,7 @@ let private parseFormat (s: string) : Result<FormatTag list, StatechartError> =
     | "all" -> Ok FormatPipeline.allFormats
     | other -> Error(UnknownFormat other)
 
-let private isAffordanceMapFormat (s: string) : bool =
-    s.ToLowerInvariant() = "affordance-map"
+let private isAffordanceMapFormat (s: string) : bool = s.ToLowerInvariant() = "affordance-map"
 
 let private generateAffordanceMapJson (resources: UnifiedResource list) (baseUri: string) : string =
     use stream = new MemoryStream()
@@ -133,8 +133,7 @@ let execute
                 match! getResources projectPath force with
                 | Error e -> return Error e
                 | Ok(resources, fromCache) ->
-                    let machines =
-                        resources |> List.choose (fun r -> r.Statechart)
+                    let machines = resources |> List.choose (fun r -> r.Statechart)
 
                     let filtered =
                         match resourceFilter with
@@ -152,35 +151,127 @@ let execute
 
                         return Error(ResourceNotFound(name, available))
                     | _ ->
-                        let mutable generationErrors = []
-
-                        let artifacts =
+                        let formatResults =
                             [ for m in filtered do
                                   let slug = FormatPipeline.resourceSlug m.RouteTemplate
 
                                   for fmt in formats do
                                       match FormatPipeline.generateFormatFromExtracted fmt slug m with
                                       | Ok content ->
-                                          { ResourceSlug = slug
-                                            RouteTemplate = m.RouteTemplate
-                                            Format = fmt
-                                            Content = content
-                                            FilePath = None }
-                                      | Error err -> generationErrors <- err :: generationErrors ]
+                                          Ok
+                                              { ResourceSlug = slug
+                                                RouteTemplate = m.RouteTemplate
+                                                Format = fmt
+                                                Content = content
+                                                FilePath = None }
+                                      | Error err -> Error err ]
+
+                        let artifacts =
+                            formatResults
+                            |> List.choose (function
+                                | Ok a -> Some a
+                                | Error _ -> None)
+
+                        let formatErrors =
+                            formatResults
+                            |> List.choose (function
+                                | Error e -> Some e
+                                | Ok _ -> None)
+
+                        let projectionArtifacts, projectionErrors, projectedSlugs =
+                            if formats |> List.contains Alps then
+                                // Find UnifiedResources that match the filtered statecharts
+                                let filteredRoutes = filtered |> List.map (fun m -> m.RouteTemplate) |> Set.ofList
+
+                                let matchingResources =
+                                    resources |> List.filter (fun r -> Set.contains r.RouteTemplate filteredRoutes)
+
+                                let batchResult, projectionResults =
+                                    ProjectionPipeline.projectAllResources matchingResources ""
+
+                                // Print warnings from projection
+                                for result in projectionResults do
+                                    for err in result.Errors do
+                                        eprintfn "%s" err
+
+                                    for orphan in result.Orphans do
+                                        eprintfn
+                                            "Warning: transition '%s' (%s -> %s) is not covered by any role projection"
+                                            orphan.Event
+                                            orphan.Source
+                                            orphan.Target
+
+                                // Build artifacts from projection results
+                                let projResults =
+                                    [ for result in projectionResults do
+                                          for KeyValue(rSlug, content) in result.RoleProfiles do
+                                              Ok
+                                                  { ResourceSlug = rSlug
+                                                    RouteTemplate = "*"
+                                                    Format = Alps
+                                                    Content = content
+                                                    FilePath = None }
+
+                                          for err in result.Errors do
+                                              Error(GenerationFailed(Alps, "projection", err)) ]
+
+                                // Add global profile overrides as artifacts
+                                let globalArts =
+                                    batchResult.GlobalProfileOverrides
+                                    |> Map.toList
+                                    |> List.choose (fun (slug, content) ->
+                                        let route =
+                                            matchingResources
+                                            |> List.tryFind (fun r -> r.ResourceSlug = slug)
+                                            |> Option.map _.RouteTemplate
+                                            |> Option.defaultValue "*"
+
+                                        Some
+                                            { ResourceSlug = slug
+                                              RouteTemplate = route
+                                              Format = Alps
+                                              Content = content
+                                              FilePath = None })
+
+                                let arts =
+                                    projResults
+                                    |> List.choose (function
+                                        | Ok a -> Some a
+                                        | Error _ -> None)
+
+                                let errs =
+                                    projResults
+                                    |> List.choose (function
+                                        | Error e -> Some e
+                                        | Ok _ -> None)
+
+                                (arts @ globalArts, errs, batchResult.ProjectedSlugs)
+                            else
+                                ([], [], Set.empty)
+
+                        let generationErrors = List.rev formatErrors @ List.rev projectionErrors
+
+                        let mergedArtifacts =
+                            let baseArtifacts =
+                                artifacts
+                                |> List.filter (fun a ->
+                                    not (a.Format = Alps && Set.contains a.ResourceSlug projectedSlugs))
+
+                            baseArtifacts @ projectionArtifacts
 
                         match outputDir with
                         | None ->
                             return
                                 Ok
-                                    { Artifacts = artifacts
+                                    { Artifacts = mergedArtifacts
                                       OutputDirectory = None
-                                      GenerationErrors = List.rev generationErrors
+                                      GenerationErrors = generationErrors
                                       FromCache = fromCache }
                         | Some dir ->
                             Directory.CreateDirectory(dir) |> ignore
 
                             let written =
-                                artifacts
+                                mergedArtifacts
                                 |> List.map (fun a ->
                                     let fileName =
                                         sprintf "%s%s" a.ResourceSlug (FormatDetector.formatExtension a.Format)
@@ -193,6 +284,6 @@ let execute
                                 Ok
                                     { Artifacts = written
                                       OutputDirectory = Some dir
-                                      GenerationErrors = List.rev generationErrors
+                                      GenerationErrors = generationErrors
                                       FromCache = fromCache }
     }

--- a/src/Frank.Cli.Core/Extraction/VocabularyAligner.fs
+++ b/src/Frank.Cli.Core/Extraction/VocabularyAligner.fs
@@ -1,50 +1,14 @@
 namespace Frank.Cli.Core.Extraction
 
 open System
-open System.Text.RegularExpressions
 open VDS.RDF
 open Frank.Cli.Core.Rdf
 open Frank.Cli.Core.Rdf.FSharpRdf
 open Frank.Cli.Core.Rdf.Vocabularies
+open Frank.Cli.Core.Shared
 
 /// Aligns extracted RDF to standard vocabularies (Schema.org, Hydra).
 module VocabularyAligner =
-
-    let private splitCamelCase (name: string) =
-        Regex.Replace(name, "([a-z])([A-Z])", "$1 $2").ToLowerInvariant()
-
-    let private normalizeFieldName (name: string) =
-        splitCamelCase(name).Replace(" ", "").ToLowerInvariant()
-
-    let private propertyAlignmentMap: (string list * string) list =
-        [ ([ "name"; "title" ], SchemaOrg.Name)
-          ([ "description"; "summary"; "body" ], SchemaOrg.Description)
-          ([ "email"; "emailaddress" ], SchemaOrg.Email)
-          ([ "url"; "uri"; "website"; "homepage" ], SchemaOrg.Url)
-          ([ "price"; "cost"; "amount" ], SchemaOrg.Price)
-          ([ "createdat"; "datecreated"; "created" ], SchemaOrg.DateCreated)
-          ([ "updatedat"; "datemodified"; "modified" ], SchemaOrg.DateModified)
-          ([ "image"; "imageurl"; "photo" ], SchemaOrg.Image)
-          ([ "telephone"; "phone" ], SchemaOrg.Telephone) ]
-
-    let private classAlignmentMap: (string list * string) list =
-        [ ([ "person"; "user"; "customer"; "member"; "employee"; "author"; "contact" ], SchemaOrg.Person)
-          ([ "organization"; "company"; "business"; "team"; "group" ], SchemaOrg.Organization)
-          ([ "product"; "item"; "goods" ], SchemaOrg.Product)
-          ([ "event"; "meeting"; "appointment"; "booking" ], SchemaOrg.Event)
-          ([ "place"; "location"; "venue" ], SchemaOrg.Place)
-          ([ "creativework"; "post"; "article"; "blog"; "content"; "document"; "page" ], SchemaOrg.CreativeWork)
-          ([ "order"; "purchase" ], SchemaOrg.Order)
-          ([ "review"; "rating"; "feedback" ], SchemaOrg.Review)
-          ([ "offer"; "deal"; "listing" ], SchemaOrg.Offer)
-          ([ "mediaobject"; "file"; "attachment"; "media" ], SchemaOrg.MediaObject) ]
-
-    let private tryFindIn (map: (string list * string) list) (name: string) : string option =
-        let normalized = normalizeFieldName name
-
-        map
-        |> List.tryFind (fun (names, _) -> names |> List.contains normalized)
-        |> Option.map snd
 
     let alignVocabularies (config: TypeMapper.MappingConfig) (graph: IGraph) : IGraph =
         if not (config.Vocabularies |> List.contains "schema.org") then
@@ -79,7 +43,7 @@ module VocabularyAligner =
                 for labelTriple in labelTriples do
                     match labelTriple.Object with
                     | :? ILiteralNode as lit ->
-                        match tryFindIn propertyAlignmentMap lit.Value with
+                        match SchemaAlignment.tryFindIn SchemaAlignment.propertyAlignmentMap lit.Value with
                         | Some schemaUri ->
                             let equivNode = createUriNode graph equivalentPropUri
                             let schemaNode = createUriNode graph (Uri schemaUri)
@@ -104,7 +68,7 @@ module VocabularyAligner =
                 for labelTriple in labelTriples do
                     match labelTriple.Object with
                     | :? ILiteralNode as lit ->
-                        match tryFindIn classAlignmentMap lit.Value with
+                        match SchemaAlignment.tryFindIn SchemaAlignment.classAlignmentMap lit.Value with
                         | Some schemaUri ->
                             let equivNode = createUriNode graph equivalentClassUri
                             let schemaNode = createUriNode graph (Uri schemaUri)

--- a/src/Frank.Cli.Core/Frank.Cli.Core.fsproj
+++ b/src/Frank.Cli.Core/Frank.Cli.Core.fsproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <Compile Include="Rdf/FSharpRdf.fs" />
     <Compile Include="Rdf/Vocabularies.fs" />
+    <!-- Shared utilities -->
+    <Compile Include="Shared/SchemaAlignment.fs" />
     <Compile Include="Analysis/AstAnalyzer.fs" />
     <Compile Include="Analysis/TypeAnalyzer.fs" />
     <Compile Include="Extraction/UriHelpers.fs" />
@@ -36,6 +38,7 @@
     <Compile Include="Unified/UnifiedExtractor.fs" />
     <Compile Include="Unified/UnifiedAlpsGenerator.fs" />
     <Compile Include="Unified/AffordanceMapGenerator.fs" />
+    <Compile Include="Unified/ProjectionPipeline.fs" />
     <Compile Include="Unified/ExtractionStateProjector.fs" />
     <Compile Include="Help/HelpTypes.fs" />
     <Compile Include="Help/FuzzyMatch.fs" />

--- a/src/Frank.Cli.Core/Shared/SchemaAlignment.fs
+++ b/src/Frank.Cli.Core/Shared/SchemaAlignment.fs
@@ -1,0 +1,53 @@
+namespace Frank.Cli.Core.Shared
+
+open System.Text.RegularExpressions
+
+/// Shared Schema.org vocabulary alignment functions and data.
+/// Used by both VocabularyAligner (RDF graph alignment) and
+/// UnifiedAlpsGenerator (ALPS profile generation).
+module SchemaAlignment =
+
+    let splitCamelCase (name: string) =
+        Regex.Replace(name, "([a-z])([A-Z])", "$1 $2").ToLowerInvariant()
+
+    let normalizeFieldName (name: string) =
+        splitCamelCase(name).Replace(" ", "").ToLowerInvariant()
+
+    let propertyAlignmentMap: (string list * string) list =
+        [ ([ "name"; "title" ], "https://schema.org/name")
+          ([ "description"; "summary"; "body" ], "https://schema.org/description")
+          ([ "email"; "emailaddress" ], "https://schema.org/email")
+          ([ "url"; "uri"; "website"; "homepage" ], "https://schema.org/url")
+          ([ "price"; "cost"; "amount" ], "https://schema.org/price")
+          ([ "createdat"; "datecreated"; "created" ], "https://schema.org/dateCreated")
+          ([ "updatedat"; "datemodified"; "modified" ], "https://schema.org/dateModified")
+          ([ "image"; "imageurl"; "photo" ], "https://schema.org/image")
+          ([ "telephone"; "phone" ], "https://schema.org/telephone") ]
+
+    let classAlignmentMap: (string list * string) list =
+        [ ([ "person"; "user"; "customer"; "member"; "employee"; "author"; "contact" ], "https://schema.org/Person")
+          ([ "organization"; "company"; "business"; "team"; "group" ], "https://schema.org/Organization")
+          ([ "product"; "item"; "goods" ], "https://schema.org/Product")
+          ([ "event"; "meeting"; "appointment"; "booking" ], "https://schema.org/Event")
+          ([ "place"; "location"; "venue" ], "https://schema.org/Place")
+          ([ "creativework"; "post"; "article"; "blog"; "content"; "document"; "page" ],
+           "https://schema.org/CreativeWork")
+          ([ "order"; "purchase" ], "https://schema.org/Order")
+          ([ "review"; "rating"; "feedback" ], "https://schema.org/Review")
+          ([ "offer"; "deal"; "listing" ], "https://schema.org/Offer")
+          ([ "mediaobject"; "file"; "attachment"; "media" ], "https://schema.org/MediaObject") ]
+
+    /// Try to find a Schema.org alignment in the given map for a field/class name.
+    let tryFindIn (map: (string list * string) list) (name: string) : string option =
+        let normalized = normalizeFieldName name
+
+        map
+        |> List.tryFind (fun (names, _) -> names |> List.contains normalized)
+        |> Option.map snd
+
+    /// Try to find a Schema.org property alignment for a field name.
+    let tryFindPropertyAlignment (fieldName: string) : string option =
+        tryFindIn propertyAlignmentMap fieldName
+
+    /// Try to find a Schema.org class alignment for a class name.
+    let tryFindClassAlignment (className: string) : string option = tryFindIn classAlignmentMap className

--- a/src/Frank.Cli.Core/Statechart/StatechartExtractor.fs
+++ b/src/Frank.Cli.Core/Statechart/StatechartExtractor.fs
@@ -20,4 +20,5 @@ module StatechartExtractor =
           InitialStateKey = initialStateKey
           GuardNames = guardNames
           StateMetadata = stateMetadata
-          Roles = roles }
+          Roles = roles
+          Transitions = [] }

--- a/src/Frank.Cli.Core/Unified/ProjectionPipeline.fs
+++ b/src/Frank.Cli.Core/Unified/ProjectionPipeline.fs
@@ -1,0 +1,133 @@
+module Frank.Cli.Core.Unified.ProjectionPipeline
+
+open Frank.Resources.Model
+
+/// Filename-safe slug for a role-scoped profile (e.g., "games-playerx").
+let roleSlug (resourceSlug: string) (roleName: string) : string =
+    $"{resourceSlug}-{roleName.ToLowerInvariant()}"
+
+/// Keep only capabilities whose state key exists in the projected statechart
+/// (or that have no state key at all, meaning they apply globally).
+let filterCapabilitiesByStates (stateNames: string list) (capabilities: HttpCapability list) : HttpCapability list =
+    let stateSet = Set.ofList stateNames
+
+    capabilities
+    |> List.filter (fun cap ->
+        match cap.StateKey with
+        | None -> true
+        | Some sk -> Set.contains sk stateSet)
+
+/// Result of running the projection pipeline for a single resource.
+type ProjectionResult =
+    { RoleProfiles: Map<string, string>
+      UpdatedGlobalProfile: string option
+      Orphans: TransitionSpec list
+      Errors: string list }
+
+/// Run per-role projection for a resource that has roles and transitions.
+/// Generates a role-scoped ALPS profile per role, checks for orphaned
+/// transitions, and regenerates the global profile with cross-links.
+/// Pure: errors and orphans are captured in the result, not printed.
+let projectResource (resource: UnifiedResource) (baseUri: string) : ProjectionResult =
+    match resource.Statechart with
+    | Some sc when not sc.Roles.IsEmpty && not sc.Transitions.IsEmpty ->
+        let projections = Projection.projectAll sc
+
+        let roleSlugs =
+            projections
+            |> Map.toList
+            |> List.map (fun (roleName, _) -> roleSlug resource.ResourceSlug roleName)
+
+        let roleProfiles, errors =
+            projections
+            |> Map.toList
+            |> List.fold
+                (fun (profiles, errs) (roleName, projectedChart) ->
+                    let slug = roleSlug resource.ResourceSlug roleName
+
+                    let projectedResource =
+                        { resource with
+                            ResourceSlug = slug
+                            Statechart = Some projectedChart
+                            HttpCapabilities =
+                                filterCapabilitiesByStates projectedChart.StateNames resource.HttpCapabilities }
+
+                    let ctx: UnifiedAlpsGenerator.ProjectionContext =
+                        { ProjectedRole = Some roleName
+                          RelatedProfileSlugs = []
+                          ProfileSlug = Some resource.ResourceSlug }
+
+                    match UnifiedAlpsGenerator.generateWithContext projectedResource baseUri (Some ctx) with
+                    | Ok alpsJson -> (Map.add slug alpsJson profiles, errs)
+                    | Error genErrs ->
+                        let detail = String.concat "; " genErrs
+                        let msg = $"Warning: failed to generate role profile for {slug}: {detail}"
+                        (profiles, msg :: errs))
+                (Map.empty, [])
+
+        let orphans = Projection.findOrphanedTransitions sc projections
+
+        let globalCtx: UnifiedAlpsGenerator.ProjectionContext =
+            { ProjectedRole = None
+              RelatedProfileSlugs = roleSlugs
+              ProfileSlug = None }
+
+        let updatedGlobal, globalErrors =
+            match UnifiedAlpsGenerator.generateWithContext resource baseUri (Some globalCtx) with
+            | Ok alpsJson -> (Some alpsJson, [])
+            | Error genErrs ->
+                let detail = String.concat "; " genErrs
+
+                let msg =
+                    $"Warning: failed to regenerate global profile for {resource.ResourceSlug}: {detail}"
+
+                (None, [ msg ])
+
+        { RoleProfiles = roleProfiles
+          UpdatedGlobalProfile = updatedGlobal
+          Orphans = orphans
+          Errors = List.rev errors @ globalErrors }
+
+    | _ ->
+        { RoleProfiles = Map.empty
+          UpdatedGlobalProfile = None
+          Orphans = []
+          Errors = [] }
+
+/// Aggregate result from projecting all resources.
+type BatchProjectionResult =
+    { RoleAlpsProfiles: Map<string, string>
+      GlobalProfileOverrides: Map<string, string>
+      ProjectedSlugs: Set<string> }
+
+/// Run projection across all resources, merging role profiles and tracking
+/// which global slugs were overridden. Callers handle warning output.
+let projectAllResources
+    (resources: UnifiedResource list)
+    (baseUri: string)
+    : BatchProjectionResult * ProjectionResult list =
+    let results =
+        resources
+        |> List.map (fun resource -> resource, projectResource resource baseUri)
+
+    let roleAcc, globalAcc, slugAcc =
+        results
+        |> List.fold
+            (fun (roles, globals, slugs) (resource, result) ->
+                let roles' = result.RoleProfiles |> Map.fold (fun acc k v -> Map.add k v acc) roles
+
+                let globals', slugs' =
+                    match result.UpdatedGlobalProfile with
+                    | Some profile ->
+                        (Map.add resource.ResourceSlug profile globals, Set.add resource.ResourceSlug slugs)
+                    | None -> (globals, slugs)
+
+                (roles', globals', slugs'))
+            (Map.empty, Map.empty, Set.empty)
+
+    let allResults = results |> List.map snd
+
+    ({ RoleAlpsProfiles = roleAcc
+       GlobalProfileOverrides = globalAcc
+       ProjectedSlugs = slugAcc },
+     allResults)

--- a/src/Frank.Cli.Core/Unified/UnifiedAlpsGenerator.fs
+++ b/src/Frank.Cli.Core/Unified/UnifiedAlpsGenerator.fs
@@ -3,42 +3,10 @@ module Frank.Cli.Core.Unified.UnifiedAlpsGenerator
 open System.IO
 open System.Text
 open System.Text.Json
-open System.Text.RegularExpressions
 open Frank.Cli.Core.Analysis
+open Frank.Cli.Core.Shared
 open Frank.Resources.Model
 open Frank.Statecharts.Alps.Classification
-
-// ============================================================================
-// Schema.org Vocabulary Alignment (T027)
-//
-// Extracted from VocabularyAligner.fs -- pure data + pure function, no RDF graph
-// mutation. Shared logic so both VocabularyAligner and this module can use it.
-// ============================================================================
-
-let private splitCamelCase (name: string) =
-    Regex.Replace(name, "([a-z])([A-Z])", "$1 $2").ToLowerInvariant()
-
-let private normalizeFieldName (name: string) =
-    splitCamelCase(name).Replace(" ", "").ToLowerInvariant()
-
-let private alignmentMap: (string list * string) list =
-    [ ([ "name"; "title" ], "https://schema.org/name")
-      ([ "description"; "summary"; "body" ], "https://schema.org/description")
-      ([ "email"; "emailaddress" ], "https://schema.org/email")
-      ([ "url"; "uri"; "website"; "homepage" ], "https://schema.org/url")
-      ([ "price"; "cost"; "amount" ], "https://schema.org/price")
-      ([ "createdat"; "datecreated"; "created" ], "https://schema.org/dateCreated")
-      ([ "updatedat"; "datemodified"; "modified" ], "https://schema.org/dateModified")
-      ([ "image"; "imageurl"; "photo" ], "https://schema.org/image")
-      ([ "telephone"; "phone" ], "https://schema.org/telephone") ]
-
-/// Try to find a Schema.org alignment for a field name.
-let tryFindAlignment (fieldName: string) : string option =
-    let normalized = normalizeFieldName fieldName
-
-    alignmentMap
-    |> List.tryFind (fun (names, _) -> names |> List.contains normalized)
-    |> Option.map snd
 
 // ============================================================================
 // IANA-Precedence Link Relation Derivation (T028)
@@ -49,29 +17,14 @@ let tryFindAlignment (fieldName: string) : string option =
 /// `create` and `delete` are NOT IANA-registered -- use ALPS fragment URIs for those.
 let private ianaRelationForMethod (method: string) (isSingleResource: bool) : string option =
     match method.ToUpperInvariant() with
-    | "GET" when isSingleResource -> Some "self"
-    | "GET" -> Some "collection"
-    | "PUT" -> Some "edit"
-    | "PATCH" -> Some "edit"
+    | "GET" when isSingleResource -> Some RelSelf
+    | "GET" -> Some RelCollection
+    | "PUT" -> Some RelEdit
+    | "PATCH" -> Some RelEdit
     | _ -> None
 
 /// Determine if a route template represents a single resource (has a parameter).
-let private isSingleResourceRoute (routeTemplate: string) : bool =
-    routeTemplate.Contains("{")
-
-/// Derive a link relation type for a given HTTP method and resource context.
-/// IANA-registered relations take precedence; otherwise use ALPS fragment URIs.
-let deriveRelationType (baseUri: string) (resourceSlug: string) (method: string) (stateKey: string option) : string =
-    let isSingle = isSingleResourceRoute ""  // Will be called with route info separately
-    match ianaRelationForMethod method isSingle with
-    | Some rel -> rel
-    | None ->
-        let descriptorId =
-            match stateKey with
-            | Some state -> $"{state}-{method.ToLowerInvariant()}{resourceSlug}"
-            | None -> $"{method.ToLowerInvariant()}{resourceSlug}"
-
-        $"{baseUri}/{resourceSlug}#{descriptorId}"
+let private isSingleResourceRoute (routeTemplate: string) : bool = routeTemplate.Contains("{")
 
 /// Derive a link relation type using full route context.
 let deriveRelationTypeForRoute
@@ -88,8 +41,10 @@ let deriveRelationTypeForRoute
     | None ->
         let descriptorId =
             match stateKey with
-            | Some state -> $"{state}-{method.ToLowerInvariant()}{resourceSlug |> fun s -> s.Substring(0, 1).ToUpperInvariant() + s.Substring(1)}"
-            | None -> $"{method.ToLowerInvariant()}{resourceSlug |> fun s -> s.Substring(0, 1).ToUpperInvariant() + s.Substring(1)}"
+            | Some state ->
+                $"{state}-{method.ToLowerInvariant()}{resourceSlug |> fun s -> s.Substring(0, 1).ToUpperInvariant() + s.Substring(1)}"
+            | None ->
+                $"{method.ToLowerInvariant()}{resourceSlug |> fun s -> s.Substring(0, 1).ToUpperInvariant() + s.Substring(1)}"
 
         $"{baseUri}/{resourceSlug}#{descriptorId}"
 
@@ -121,8 +76,12 @@ let private transitionDescriptorId (method: string) (resourceSlug: string) (stat
 /// Map an HTTP method to an ALPS transition type string.
 let private alpsTransitionType (method: string) : string =
     match method.ToUpperInvariant() with
-    | "GET" | "HEAD" | "OPTIONS" -> "safe"
-    | "PUT" | "DELETE" | "PATCH" -> "idempotent"
+    | "GET"
+    | "HEAD"
+    | "OPTIONS" -> "safe"
+    | "PUT"
+    | "DELETE"
+    | "PATCH" -> "idempotent"
     | "POST" -> "unsafe"
     | _ -> "unsafe"
 
@@ -136,7 +95,7 @@ let private writeFieldDescriptor (writer: Utf8JsonWriter) (field: AnalyzedField)
     writer.WriteString("id", field.Name)
     writer.WriteString("type", "semantic")
 
-    match tryFindAlignment field.Name with
+    match SchemaAlignment.tryFindPropertyAlignment field.Name with
     | Some schemaUri -> writer.WriteString("href", schemaUri)
     | None -> ()
 
@@ -159,6 +118,7 @@ let private writeTransitionDescriptor
     (transitionType: string)
     (semanticIds: string list)
     (rel: string)
+    (stateKey: string option)
     =
     writer.WriteStartObject()
     writer.WriteString("id", descriptorId)
@@ -166,10 +126,7 @@ let private writeTransitionDescriptor
 
     // rt links to semantic descriptors
     if not semanticIds.IsEmpty then
-        let rtValue =
-            semanticIds
-            |> List.map (fun id -> "#" + id)
-            |> String.concat " "
+        let rtValue = semanticIds |> List.map (fun id -> "#" + id) |> String.concat " "
 
         writer.WriteString("rt", rtValue)
 
@@ -183,15 +140,36 @@ let private writeTransitionDescriptor
         writer.WriteEndObject()
         writer.WriteEndArray()
 
+    // availableInStates extension
+    match stateKey with
+    | Some state ->
+        writer.WritePropertyName("ext")
+        writer.WriteStartArray()
+        writer.WriteStartObject()
+        writer.WriteString("id", AvailableInStatesExtId)
+        writer.WriteString("value", state)
+        writer.WriteEndObject()
+        writer.WriteEndArray()
+    | None -> ()
+
     writer.WriteEndObject()
 
 // ============================================================================
 // Core ALPS Generation (T026, T029)
 // ============================================================================
 
-/// Generate an ALPS JSON document from a UnifiedResource and base URI.
-/// Returns Ok with the ALPS JSON string, or Error with parse failure messages.
-let generate (resource: UnifiedResource) (baseUri: string) : Result<string, string list> =
+/// Context for per-role profile generation. None fields = global profile.
+type ProjectionContext =
+    { ProjectedRole: string option
+      RelatedProfileSlugs: string list
+      ProfileSlug: string option }
+
+/// Generate with optional projection context for per-role profiles.
+let generateWithContext
+    (resource: UnifiedResource)
+    (baseUri: string)
+    (projectionContext: ProjectionContext option)
+    : Result<string, string list> =
     use stream = new MemoryStream()
     use writer = new Utf8JsonWriter(stream, JsonWriterOptions(Indented = true))
 
@@ -273,20 +251,14 @@ let generate (resource: UnifiedResource) (baseUri: string) : Result<string, stri
         | None ->
             // Plain resource (T029): emit transitions without state scoping
             for cap in resource.HttpCapabilities do
-                let descriptorId =
-                    transitionDescriptorId cap.Method resource.ResourceSlug None
+                let descriptorId = transitionDescriptorId cap.Method resource.ResourceSlug None
 
                 let transType = alpsTransitionType cap.Method
 
                 let rel =
-                    deriveRelationTypeForRoute
-                        baseUri
-                        resource.ResourceSlug
-                        resource.RouteTemplate
-                        cap.Method
-                        None
+                    deriveRelationTypeForRoute baseUri resource.ResourceSlug resource.RouteTemplate cap.Method None
 
-                writeTransitionDescriptor writer descriptorId transType semanticIds rel
+                writeTransitionDescriptor writer descriptorId transType semanticIds rel None
 
         | Some _sc ->
             // Stateful resource: emit state-scoped transitions
@@ -304,24 +276,62 @@ let generate (resource: UnifiedResource) (baseUri: string) : Result<string, stri
                         cap.Method
                         cap.StateKey
 
-                writeTransitionDescriptor writer descriptorId transType semanticIds rel
+                writeTransitionDescriptor writer descriptorId transType semanticIds rel cap.StateKey
 
         writer.WriteEndArray()
+
+    // ── Document-level links (cross-linking) ──
+    match projectionContext with
+    | Some ctx ->
+        let hasLinks = not ctx.RelatedProfileSlugs.IsEmpty || ctx.ProfileSlug.IsSome
+
+        if hasLinks then
+            writer.WritePropertyName("link")
+            writer.WriteStartArray()
+
+            for slug in ctx.RelatedProfileSlugs do
+                writer.WriteStartObject()
+                writer.WriteString("rel", RelRelated)
+                writer.WriteString("href", $"{baseUri}/{slug}")
+                writer.WriteEndObject()
+
+            match ctx.ProfileSlug with
+            | Some slug ->
+                writer.WriteStartObject()
+                writer.WriteString("rel", RelProfile)
+                writer.WriteString("href", $"{baseUri}/{slug}")
+                writer.WriteEndObject()
+            | None -> ()
+
+            writer.WriteEndArray()
+    | None -> ()
 
     // ── Role extensions from statechart ──
-    match resource.Statechart with
-    | Some sc when not sc.Roles.IsEmpty ->
+    match projectionContext with
+    | Some { ProjectedRole = Some role } ->
+        // Projected profile: emit only the projected role
         writer.WritePropertyName("ext")
         writer.WriteStartArray()
-
-        for role in sc.Roles do
-            writer.WriteStartObject()
-            writer.WriteString("id", ProjectedRoleExtId)
-            writer.WriteString("value", role.Name)
-            writer.WriteEndObject()
-
+        writer.WriteStartObject()
+        writer.WriteString("id", ProjectedRoleExtId)
+        writer.WriteString("value", role)
+        writer.WriteEndObject()
         writer.WriteEndArray()
-    | _ -> ()
+    | _ ->
+        // Global profile: emit all roles from statechart
+        match resource.Statechart with
+        | Some sc when not sc.Roles.IsEmpty ->
+            writer.WritePropertyName("ext")
+            writer.WriteStartArray()
+
+            for role in sc.Roles do
+                writer.WriteStartObject()
+                writer.WriteString("id", ProjectedRoleExtId)
+                writer.WriteString("value", role.Name)
+                writer.WriteEndObject()
+
+            writer.WriteEndArray()
+        | _ -> ()
 
     writer.WriteEndObject()
     writer.WriteEndObject()
@@ -330,14 +340,16 @@ let generate (resource: UnifiedResource) (baseUri: string) : Result<string, stri
     let json = Encoding.UTF8.GetString(stream.ToArray())
 
     // ── Round-trip validation (T030) ──
-    let parseResult =
-        Frank.Statecharts.Alps.JsonParser.parseAlpsJson json
+    let parseResult = Frank.Statecharts.Alps.JsonParser.parseAlpsJson json
 
     if parseResult.Errors.IsEmpty then
         Ok json
     else
-        let errorMessages =
-            parseResult.Errors
-            |> List.map (fun e -> e.Description)
+        let errorMessages = parseResult.Errors |> List.map (fun e -> e.Description)
 
         Error errorMessages
+
+/// Generate an ALPS JSON document from a UnifiedResource and base URI.
+/// Returns Ok with the ALPS JSON string, or Error with parse failure messages.
+let generate (resource: UnifiedResource) (baseUri: string) : Result<string, string list> =
+    generateWithContext resource baseUri None

--- a/src/Frank.Cli.Core/Unified/UnifiedCache.fs
+++ b/src/Frank.Cli.Core/Unified/UnifiedCache.fs
@@ -87,7 +87,7 @@ let computeSourceHash (projectDir: string) : string =
 
 /// CLI version for cache compatibility checking.
 /// Update this when UnifiedExtractionState schema changes.
-let currentToolVersion = "7.3.0"
+let currentToolVersion = "7.3.1"
 
 /// Reason why the cache is stale and re-extraction is needed.
 type StalenessReason =

--- a/src/Frank.Resources.Model/Frank.Resources.Model.fsproj
+++ b/src/Frank.Resources.Model/Frank.Resources.Model.fsproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Compile Include="TypeAnalysis.fs" />
     <Compile Include="ResourceTypes.fs" />
+    <Compile Include="Projection.fs" />
     <Compile Include="RuntimeTypes.fs" />
     <Compile Include="AffordanceTypes.fs" />
   </ItemGroup>

--- a/src/Frank.Resources.Model/Projection.fs
+++ b/src/Frank.Resources.Model/Projection.fs
@@ -1,0 +1,88 @@
+namespace Frank.Resources.Model
+
+/// Per-role projection of statecharts.
+/// All functions are pure, total (no Result/Option), and format-agnostic.
+module Projection =
+
+    /// Filter transitions to those available to the given role.
+    /// Unrestricted transitions survive in all projections.
+    /// RestrictedTo transitions survive only if roleName is in the list.
+    let filterTransitionsByRole (roleName: string) (statechart: ExtractedStatechart) : ExtractedStatechart =
+        let filtered =
+            statechart.Transitions
+            |> List.filter (fun t ->
+                match t.Constraint with
+                | Unrestricted -> true
+                | RestrictedTo roles -> List.contains roleName roles)
+
+        { statechart with
+            Transitions = filtered }
+
+    /// Remove states unreachable from the initial state via surviving transitions.
+    /// Initial state is always retained. Updates StateNames, StateMetadata,
+    /// and removes transitions referencing pruned states.
+    /// Uses a pre-built adjacency map for O(V+E) traversal.
+    let pruneUnreachableStates (statechart: ExtractedStatechart) : ExtractedStatechart =
+        let adjacency =
+            statechart.Transitions
+            |> List.groupBy (fun t -> t.Source)
+            |> List.map (fun (k, ts) -> k, ts |> List.map (fun t -> t.Target))
+            |> Map.ofList
+
+        let rec reachable (visited: Set<string>) (frontier: string list) =
+            match frontier with
+            | [] -> visited
+            | state :: rest ->
+                if Set.contains state visited then
+                    reachable visited rest
+                else
+                    let visited' = Set.add state visited
+
+                    let neighbors =
+                        adjacency
+                        |> Map.tryFind state
+                        |> Option.defaultValue []
+                        |> List.filter (fun t -> not (Set.contains t visited'))
+
+                    reachable visited' (neighbors @ rest)
+
+        let reachableStates = reachable Set.empty [ statechart.InitialStateKey ]
+
+        { statechart with
+            StateNames = statechart.StateNames |> List.filter (fun s -> Set.contains s reachableStates)
+            StateMetadata =
+                statechart.StateMetadata
+                |> Map.filter (fun k _ -> Set.contains k reachableStates)
+            Transitions =
+                statechart.Transitions
+                |> List.filter (fun t -> Set.contains t.Source reachableStates && Set.contains t.Target reachableStates) }
+
+    /// Project a statechart for a single role.
+    /// Prune globally first (remove truly disconnected states using all transitions),
+    /// then filter transitions by role. In multi-party protocols, state reachability
+    /// is global — all participants encounter all globally-reachable states because
+    /// other roles advance the state machine.
+    let projectForRole (roleName: string) : ExtractedStatechart -> ExtractedStatechart =
+        pruneUnreachableStates >> filterTransitionsByRole roleName
+
+    /// Project for all roles defined in the statechart.
+    /// Returns empty map if statechart has no roles (no-op).
+    /// Prunes unreachable states once, then filters per role.
+    let projectAll (statechart: ExtractedStatechart) : Map<string, ExtractedStatechart> =
+        let pruned = pruneUnreachableStates statechart
+
+        statechart.Roles
+        |> List.map (fun role -> role.Name, filterTransitionsByRole role.Name pruned)
+        |> Map.ofList
+
+    /// Post-projection completeness check: every global transition must appear
+    /// in at least one role's projection. Returns orphaned transitions.
+    let findOrphanedTransitions
+        (globalChart: ExtractedStatechart)
+        (projections: Map<string, ExtractedStatechart>)
+        : TransitionSpec list =
+        let coveredTransitions =
+            projections |> Map.values |> Seq.collect (fun sc -> sc.Transitions) |> Set.ofSeq
+
+        globalChart.Transitions
+        |> List.filter (fun t -> not (Set.contains t coveredTransitions))

--- a/src/Frank.Resources.Model/ResourceTypes.fs
+++ b/src/Frank.Resources.Model/ResourceTypes.fs
@@ -10,25 +10,31 @@ type StateInfo =
 
 /// Pre-generated profile strings for all formats, keyed by resource slug.
 type ProjectedProfiles =
-    { /// ALPS JSON per resource slug
-      AlpsProfiles: Map<string, string>
-      /// OWL Turtle per resource slug
-      OwlOntologies: Map<string, string>
-      /// SHACL Turtle per resource slug
-      ShaclShapes: Map<string, string>
-      /// JSON Schema per resource slug
-      JsonSchemas: Map<string, string> }
+    {
+        /// ALPS JSON per resource slug
+        AlpsProfiles: Map<string, string>
+        /// Per-role ALPS profiles keyed by slug (e.g., "games-playerx" → JSON).
+        RoleAlpsProfiles: Map<string, string>
+        /// OWL Turtle per resource slug
+        OwlOntologies: Map<string, string>
+        /// SHACL Turtle per resource slug
+        ShaclShapes: Map<string, string>
+        /// JSON Schema per resource slug
+        JsonSchemas: Map<string, string>
+    }
 
 module ProjectedProfiles =
 
     let empty: ProjectedProfiles =
         { AlpsProfiles = Map.empty
+          RoleAlpsProfiles = Map.empty
           OwlOntologies = Map.empty
           ShaclShapes = Map.empty
           JsonSchemas = Map.empty }
 
     let isEmpty (profiles: ProjectedProfiles) : bool =
         Map.isEmpty profiles.AlpsProfiles
+        && Map.isEmpty profiles.RoleAlpsProfiles
         && Map.isEmpty profiles.OwlOntologies
         && Map.isEmpty profiles.ShaclShapes
         && Map.isEmpty profiles.JsonSchemas
@@ -40,70 +46,106 @@ type RoleInfo =
     { Name: string
       Description: string option }
 
+/// Whether a transition is available to all roles or restricted to specific roles.
+/// Maps to MPST semantics: Unrestricted = broadcast, RestrictedTo = directed message.
+type RoleConstraint =
+    | Unrestricted
+    | RestrictedTo of string list
+
+/// A single transition in the extracted statechart.
+/// Domain-neutral: no ALPS/SCXML/format-specific concepts.
+/// Pre-resolved: extraction resolves guard + state → RoleConstraint eagerly.
+type TransitionSpec =
+    {
+        /// Semantic transition name (e.g., "makeMove", "getGame").
+        Event: string
+        /// Source state key (e.g., "XTurn").
+        Source: string
+        /// Target state key (e.g., "OTurn").
+        Target: string
+        /// Guard name controlling this transition (None = unguarded).
+        /// Retained for diagnostics and cross-validation, not used by projection.
+        Guard: string option
+        /// Pre-resolved role constraint. RestrictedTo [] = dead transition (no role can trigger).
+        Constraint: RoleConstraint
+    }
+
 /// Structured representation of a single stateful resource extracted from source.
 /// String keys (StateNames, InitialStateKey, GuardNames) are F# DU case names
 /// derived from the state type at compile time (e.g., "XTurn", "GameOver").
 type ExtractedStatechart =
-    { RouteTemplate: string
-      StateNames: string list
-      InitialStateKey: string
-      GuardNames: string list
-      StateMetadata: Map<string, StateInfo>
-      Roles: RoleInfo list }
+    {
+        RouteTemplate: string
+        StateNames: string list
+        InitialStateKey: string
+        GuardNames: string list
+        StateMetadata: Map<string, StateInfo>
+        Roles: RoleInfo list
+        /// All transitions in the statechart. Populated during extraction.
+        Transitions: TransitionSpec list
+    }
 
 /// HTTP capability for a resource, optionally scoped to a state.
 type HttpCapability =
-    { /// HTTP method (GET, POST, PUT, DELETE, PATCH)
-      Method: string
-      /// Which state this applies to (None = always available, for plain resources)
-      StateKey: string option
-      /// IANA or ALPS-derived link relation type URI
-      LinkRelation: string
-      /// true for GET/HEAD/OPTIONS (safe methods)
-      IsSafe: bool }
+    {
+        /// HTTP method (GET, POST, PUT, DELETE, PATCH)
+        Method: string
+        /// Which state this applies to (None = always available, for plain resources)
+        StateKey: string option
+        /// IANA or ALPS-derived link relation type URI
+        LinkRelation: string
+        /// true for GET/HEAD/OPTIONS (safe methods)
+        IsSafe: bool
+    }
 
 /// Computed invariant checks for structure-behavior consistency.
 type DerivedResourceFields =
-    { /// State DU cases not covered by any inState call
-      OrphanStates: string list
-      /// DU cases in the state type but not in the statechart
-      UnhandledCases: string list
-      /// Per-state: which type fields are relevant
-      StateStructure: Map<string, AnalyzedField list>
-      /// Ratio of mapped types to total types (0.0-1.0)
-      TypeCoverage: float }
+    {
+        /// State DU cases not covered by any inState call
+        OrphanStates: string list
+        /// DU cases in the state type but not in the statechart
+        UnhandledCases: string list
+        /// Per-state: which type fields are relevant
+        StateStructure: Map<string, AnalyzedField list>
+        /// Ratio of mapped types to total types (0.0-1.0)
+        TypeCoverage: float
+    }
 
 /// A combined description of a single HTTP resource.
 type UnifiedResource =
-    { /// HTTP route pattern (e.g., /games/{gameId})
-      RouteTemplate: string
-      /// Filename-safe slug derived from route (e.g., games)
-      ResourceSlug: string
-      /// F# types associated with this resource (records, DUs)
-      TypeInfo: AnalyzedType list
-      /// Behavioral data (None for plain resource CEs)
-      Statechart: ExtractedStatechart option
-      /// Methods available (globally or per-state)
-      HttpCapabilities: HttpCapability list
-      /// Computed invariant checks
-      DerivedFields: DerivedResourceFields }
+    {
+        /// HTTP route pattern (e.g., /games/{gameId})
+        RouteTemplate: string
+        /// Filename-safe slug derived from route (e.g., games)
+        ResourceSlug: string
+        /// F# types associated with this resource (records, DUs)
+        TypeInfo: AnalyzedType list
+        /// Behavioral data (None for plain resource CEs)
+        Statechart: ExtractedStatechart option
+        /// Methods available (globally or per-state)
+        HttpCapabilities: HttpCapability list
+        /// Computed invariant checks
+        DerivedFields: DerivedResourceFields
+    }
 
 /// The cached state persisted to binary.
 type UnifiedExtractionState =
-    { /// All extracted resources
-      Resources: UnifiedResource list
-      /// Hash of source files for staleness detection
-      SourceHash: string
-      /// Base URI for ALPS profile namespace
-      BaseUri: string
-      /// Schema.org vocabularies used for alignment
-      Vocabularies: string list
-      /// Timestamp of extraction
-      ExtractedAt: DateTimeOffset
-      /// CLI version for cache compatibility
-      ToolVersion: string
-      /// Pre-computed profile strings for runtime serving (ALPS, OWL, SHACL, JSON Schema)
-      Profiles: ProjectedProfiles }
+    {
+        /// All extracted resources
+        Resources: UnifiedResource list
+        /// Hash of source files for staleness detection
+        SourceHash: string
+        /// Base URI for ALPS profile namespace
+        BaseUri: string
+        /// Schema.org vocabularies used for alignment
+        Vocabularies: string list
+        /// Timestamp of extraction
+        ExtractedAt: DateTimeOffset
+        /// CLI version for cache compatibility
+        ToolVersion: string
+        /// Pre-computed profile strings for runtime serving (ALPS, OWL, SHACL, JSON Schema)
+        Profiles: ProjectedProfiles
+    }
 
 module ResourceModel =
 

--- a/src/Frank.Statecharts/Affordances/ProfileMiddleware.fs
+++ b/src/Frank.Statecharts/Affordances/ProfileMiddleware.fs
@@ -46,6 +46,10 @@ module ProfileMiddlewareExtensions =
             for slug, alpsJson in Map.toSeq profiles.AlpsProfiles do
                 mapProfileEndpoint endpoints "/alps" slug alpsJson "application/alps+json"
 
+            // Per-role ALPS endpoints
+            for slug, alpsJson in Map.toSeq profiles.RoleAlpsProfiles do
+                mapProfileEndpoint endpoints "/alps" slug alpsJson "application/alps+json"
+
             // OWL ontology endpoints
             for slug, owlTurtle in Map.toSeq profiles.OwlOntologies do
                 mapProfileEndpoint endpoints "/ontology" slug owlTurtle "text/turtle"
@@ -63,24 +67,27 @@ module ProfileMiddlewareExtensions =
         member endpoints.MapProfileDiscovery(profiles: ProjectedProfiles) =
             let discoveryJson =
                 let alps =
-                    profiles.AlpsProfiles
-                    |> Map.toList
-                    |> List.map (fun (slug, _) -> sprintf """{"slug":"%s","url":"/alps/%s","type":"application/alps+json"}""" slug slug)
+                    (Map.toList profiles.AlpsProfiles @ Map.toList profiles.RoleAlpsProfiles)
+                    |> List.map (fun (slug, _) ->
+                        sprintf """{"slug":"%s","url":"/alps/%s","type":"application/alps+json"}""" slug slug)
 
                 let ontology =
                     profiles.OwlOntologies
                     |> Map.toList
-                    |> List.map (fun (slug, _) -> sprintf """{"slug":"%s","url":"/ontology/%s","type":"text/turtle"}""" slug slug)
+                    |> List.map (fun (slug, _) ->
+                        sprintf """{"slug":"%s","url":"/ontology/%s","type":"text/turtle"}""" slug slug)
 
                 let shapes =
                     profiles.ShaclShapes
                     |> Map.toList
-                    |> List.map (fun (slug, _) -> sprintf """{"slug":"%s","url":"/shapes/%s","type":"text/turtle"}""" slug slug)
+                    |> List.map (fun (slug, _) ->
+                        sprintf """{"slug":"%s","url":"/shapes/%s","type":"text/turtle"}""" slug slug)
 
                 let schemas =
                     profiles.JsonSchemas
                     |> Map.toList
-                    |> List.map (fun (slug, _) -> sprintf """{"slug":"%s","url":"/schemas/%s","type":"application/schema+json"}""" slug slug)
+                    |> List.map (fun (slug, _) ->
+                        sprintf """{"slug":"%s","url":"/schemas/%s","type":"application/schema+json"}""" slug slug)
 
                 let all = alps @ ontology @ shapes @ schemas
 

--- a/src/Frank.Statecharts/Alps/Classification.fs
+++ b/src/Frank.Statecharts/Alps/Classification.fs
@@ -23,9 +23,7 @@ and ParsedExtension =
       Href: string option
       Value: string option }
 
-and ParsedLink =
-    { Rel: string
-      Href: string }
+and ParsedLink = { Rel: string; Href: string }
 
 // ---------------------------------------------------------------------------
 // Pass 2: State classification heuristics (T005, ported from Mapper.fs)
@@ -34,7 +32,9 @@ and ParsedLink =
 /// Check whether a raw type string represents a transition type.
 let isTransitionTypeStr (typeStr: string option) =
     match typeStr with
-    | Some "safe" | Some "unsafe" | Some "idempotent" -> true
+    | Some "safe"
+    | Some "unsafe"
+    | Some "idempotent" -> true
     | _ -> false
 
 /// Collect the set of descriptor ids that are referenced as rt targets.
@@ -80,6 +80,25 @@ let buildDescriptorIndex (descriptors: ParsedDescriptor list) : Map<string, Pars
             acc
 
     collectAll Map.empty descriptors
+
+// ---------------------------------------------------------------------------
+// IANA link relation constants
+// ---------------------------------------------------------------------------
+
+[<Literal>]
+let RelSelf = "self"
+
+[<Literal>]
+let RelEdit = "edit"
+
+[<Literal>]
+let RelCollection = "collection"
+
+[<Literal>]
+let RelRelated = "related"
+
+[<Literal>]
+let RelProfile = "profile"
 
 // ---------------------------------------------------------------------------
 // ALPS extension vocabulary IDs (T008)
@@ -152,15 +171,22 @@ let classifyExtension (ext: ParsedExtension) : Annotation =
 
     match ext.Id with
     | GuardExtId -> AlpsAnnotation(AlpsGuardExt value)
-    | ProjectedRoleExtId | ProtocolStateExtId -> AlpsAnnotation(AlpsRole(ext.Id, value))
+    | ProjectedRoleExtId
+    | ProtocolStateExtId -> AlpsAnnotation(AlpsRole(ext.Id, value))
     | AvailableInStatesExtId ->
         let states =
-            value.Split(',', System.StringSplitOptions.RemoveEmptyEntries ||| System.StringSplitOptions.TrimEntries)
+            value.Split(
+                ',',
+                System.StringSplitOptions.RemoveEmptyEntries
+                ||| System.StringSplitOptions.TrimEntries
+            )
             |> Array.toList
 
         AlpsAnnotation(AlpsAvailableInStates states)
-    | ClientObligationExtId | AdvancesProtocolExtId | DualOfExtId | CutPointExtId ->
-        AlpsAnnotation(AlpsDuality(ext.Id, value))
+    | ClientObligationExtId
+    | AdvancesProtocolExtId
+    | DualOfExtId
+    | CutPointExtId -> AlpsAnnotation(AlpsDuality(ext.Id, value))
     | _ -> AlpsAnnotation(AlpsExtension(ext.Id, ext.Href, ext.Value))
 
 // ---------------------------------------------------------------------------
@@ -174,12 +200,10 @@ let buildStateAnnotations (d: ParsedDescriptor) : Annotation list =
         | Some value -> [ AlpsAnnotation(AlpsDocumentation(d.DocFormat, value)) ]
         | None -> []
 
-    let extAnnotations =
-        d.Extensions |> List.map classifyExtension
+    let extAnnotations = d.Extensions |> List.map classifyExtension
 
     let linkAnnotations =
-        d.Links
-        |> List.map (fun l -> AlpsAnnotation(AlpsLink(l.Rel, l.Href)))
+        d.Links |> List.map (fun l -> AlpsAnnotation(AlpsLink(l.Rel, l.Href)))
 
     docAnnotation @ extAnnotations @ linkAnnotations
 
@@ -277,8 +301,7 @@ let classifyDescriptors
     let rtTargets = collectRtTargets descriptors
     let index = buildDescriptorIndex descriptors
 
-    let stateDescriptors =
-        descriptors |> List.filter (isStateDescriptor rtTargets)
+    let stateDescriptors = descriptors |> List.filter (isStateDescriptor rtTargets)
 
     let nonStateDescriptors =
         descriptors
@@ -288,8 +311,7 @@ let classifyDescriptors
             && (d.Type.IsNone || d.Type = Some "semantic"))
 
     // Build state elements
-    let stateElements =
-        stateDescriptors |> List.map (fun d -> StateDecl(toStateNode d))
+    let stateElements = stateDescriptors |> List.map (fun d -> StateDecl(toStateNode d))
 
     // Build transition elements from each state's children
     let transitionElements =
@@ -311,11 +333,9 @@ let classifyDescriptors
         | None -> []
 
     let linkAnnotations =
-        rootLinks
-        |> List.map (fun l -> AlpsAnnotation(AlpsLink(l.Rel, l.Href)))
+        rootLinks |> List.map (fun l -> AlpsAnnotation(AlpsLink(l.Rel, l.Href)))
 
-    let extAnnotations =
-        rootExtensions |> List.map classifyExtension
+    let extAnnotations = rootExtensions |> List.map classifyExtension
 
     let dataDescriptorAnnotations =
         nonStateDescriptors

--- a/src/Frank.Statecharts/Alps/JsonParser.fs
+++ b/src/Frank.Statecharts/Alps/JsonParser.fs
@@ -1,4 +1,4 @@
-module internal Frank.Statecharts.Alps.JsonParser
+module Frank.Statecharts.Alps.JsonParser
 
 open System.Text.Json
 open Frank.Statecharts.Ast

--- a/src/Frank.Statecharts/Frank.Statecharts.fsproj
+++ b/src/Frank.Statecharts/Frank.Statecharts.fsproj
@@ -34,6 +34,8 @@
     <Compile Include="Alps/GeneratorCommon.fs" />
     <Compile Include="Alps/JsonGenerator.fs" />
     <Compile Include="Alps/XmlGenerator.fs" />
+    <!-- Transition extraction (depends on Alps/Classification) -->
+    <Compile Include="TransitionExtractor.fs" />
     <!-- SCXML parser -->
     <Compile Include="Scxml/Parser.fs" />
     <Compile Include="Scxml/Generator.fs" />

--- a/src/Frank.Statecharts/TransitionExtractor.fs
+++ b/src/Frank.Statecharts/TransitionExtractor.fs
@@ -1,0 +1,58 @@
+module Frank.Statecharts.TransitionExtractor
+
+open Frank.Statecharts.Ast
+open Frank.Statecharts.Alps.Classification
+open Frank.Resources.Model
+
+// ---------------------------------------------------------------------------
+// Bridge from parsed StatechartDocument to TransitionSpec list
+// ---------------------------------------------------------------------------
+
+/// Extract RoleConstraint from a transition edge's annotations.
+/// Finds AlpsRole annotations whose id matches ProjectedRoleExtId and
+/// collects their values into RestrictedTo; no matches yields Unrestricted.
+let private resolveConstraint (annotations: Annotation list) : RoleConstraint =
+    let roleValues =
+        annotations
+        |> List.choose (fun ann ->
+            match ann with
+            | AlpsAnnotation(AlpsRole(id, value)) when id = ProjectedRoleExtId -> Some value
+            | _ -> None)
+
+    match roleValues with
+    | [] -> Unrestricted
+    | values -> RestrictedTo values
+
+/// Extract RoleInfo list from document-level annotations.
+/// Roles declared at the document level appear as AlpsRole annotations
+/// with id = ProjectedRoleExtId. Comma-separated values are split into
+/// individual roles (e.g., "PlayerX,PlayerO,Spectator" → 3 RoleInfo).
+let extractRoles (doc: StatechartDocument) : RoleInfo list =
+    doc.Annotations
+    |> List.collect (fun ann ->
+        match ann with
+        | AlpsAnnotation(AlpsRole(id, value)) when id = ProjectedRoleExtId ->
+            value.Split(
+                ',',
+                System.StringSplitOptions.RemoveEmptyEntries
+                ||| System.StringSplitOptions.TrimEntries
+            )
+            |> Array.toList
+            |> List.map (fun name -> { Name = name; Description = None })
+        | _ -> [])
+
+/// Extract TransitionSpec list from a StatechartDocument.
+/// Iterates doc.Elements, collects TransitionElement edges, and maps each
+/// to a domain-neutral TransitionSpec with pre-resolved role constraints.
+let extract (doc: StatechartDocument) : TransitionSpec list =
+    doc.Elements
+    |> List.choose (fun elem ->
+        match elem with
+        | TransitionElement edge ->
+            Some
+                { Event = edge.Event |> Option.defaultValue "unknown"
+                  Source = edge.Source
+                  Target = edge.Target |> Option.defaultValue edge.Source
+                  Guard = edge.Guard
+                  Constraint = resolveConstraint edge.Annotations }
+        | _ -> None)

--- a/test/Frank.Cli.Core.Tests/Frank.Cli.Core.Tests.fsproj
+++ b/test/Frank.Cli.Core.Tests/Frank.Cli.Core.Tests.fsproj
@@ -37,6 +37,7 @@
     <Compile Include="Unified/UnifiedAlpsGeneratorTests.fs" />
     <Compile Include="Unified/AffordanceMapGeneratorTests.fs" />
     <Compile Include="Unified/ExtractionStateProjectorTests.fs" />
+    <Compile Include="Unified/ProjectionIntegrationTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
@@ -51,6 +52,7 @@
   <ItemGroup>
     <ProjectReference Include="../../src/Frank.Cli.Core/Frank.Cli.Core.fsproj" />
     <ProjectReference Include="../../src/Frank.Resources.Model/Frank.Resources.Model.fsproj" />
+    <ProjectReference Include="../../src/Frank.Statecharts/Frank.Statecharts.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Frank.Cli.Core.Tests/Unified/AffordanceMapGeneratorTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/AffordanceMapGeneratorTests.fs
@@ -42,7 +42,8 @@ let private ticTacToeResource: UnifiedResource =
                 AllowedMethods = [ "GET" ]
                 Description = None } ]
             |> Map.ofList
-          Roles = [] }
+          Roles = []
+          Transitions = [] }
 
     { RouteTemplate = "/games/{gameId}"
       ResourceSlug = "games"

--- a/test/Frank.Cli.Core.Tests/Unified/ProjectionIntegrationTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/ProjectionIntegrationTests.fs
@@ -1,0 +1,365 @@
+module Frank.Cli.Core.Tests.Unified.ProjectionIntegrationTests
+
+open Expecto
+open Frank.Statecharts.Ast
+open Frank.Statecharts.Alps.JsonParser
+open Frank.Statecharts.TransitionExtractor
+open Frank.Resources.Model
+open Frank.Resources.Model.Projection
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Shared ALPS JSON fixture (TicTacToe with role-based projection)
+// ══════════════════════════════════════════════════════════════════════════════
+
+let private alpsJson =
+    """
+{
+  "alps": {
+    "version": "1.0",
+    "doc": { "format": "text", "value": "Tic-Tac-Toe game state machine with role-based projection" },
+    "ext": [
+      { "id": "projectedRole", "value": "PlayerX,PlayerO,Spectator" }
+    ],
+    "descriptor": [
+      {
+        "id": "position",
+        "type": "semantic",
+        "doc": { "format": "text", "value": "Board position (0-8)" }
+      },
+      {
+        "id": "player",
+        "type": "semantic",
+        "doc": { "format": "text", "value": "Player identifier (X or O)" }
+      },
+      {
+        "id": "XTurn",
+        "type": "semantic",
+        "doc": { "format": "text", "value": "State: Player X's turn" },
+        "descriptor": [
+          {
+            "id": "makeMove-XTurn-OTurn",
+            "type": "unsafe",
+            "rt": "#OTurn",
+            "doc": { "format": "text", "value": "Player X makes a move, transitions to O's turn" },
+            "descriptor": [
+              { "href": "#position" },
+              { "href": "#player" }
+            ],
+            "ext": [
+              { "id": "guard", "value": "TurnGuard" },
+              { "id": "projectedRole", "value": "PlayerX" },
+              { "id": "availableInStates", "value": "XTurn" }
+            ]
+          },
+          {
+            "id": "makeMove-XTurn-XWins",
+            "type": "unsafe",
+            "rt": "#XWins",
+            "doc": { "format": "text", "value": "Player X makes a winning move" },
+            "descriptor": [
+              { "href": "#position" },
+              { "href": "#player" }
+            ],
+            "ext": [
+              { "id": "guard", "value": "TurnGuard" },
+              { "id": "projectedRole", "value": "PlayerX" },
+              { "id": "availableInStates", "value": "XTurn" }
+            ]
+          },
+          {
+            "id": "makeMove-XTurn-Draw",
+            "type": "unsafe",
+            "rt": "#Draw",
+            "doc": { "format": "text", "value": "Player X makes a move that fills the board" },
+            "descriptor": [
+              { "href": "#position" },
+              { "href": "#player" }
+            ],
+            "ext": [
+              { "id": "guard", "value": "TurnGuard" },
+              { "id": "projectedRole", "value": "PlayerX" },
+              { "id": "availableInStates", "value": "XTurn" }
+            ]
+          },
+          { "href": "#getGame" }
+        ]
+      },
+      {
+        "id": "OTurn",
+        "type": "semantic",
+        "doc": { "format": "text", "value": "State: Player O's turn" },
+        "descriptor": [
+          {
+            "id": "makeMove-OTurn-XTurn",
+            "type": "unsafe",
+            "rt": "#XTurn",
+            "doc": { "format": "text", "value": "Player O makes a move, transitions to X's turn" },
+            "descriptor": [
+              { "href": "#position" },
+              { "href": "#player" }
+            ],
+            "ext": [
+              { "id": "guard", "value": "TurnGuard" },
+              { "id": "projectedRole", "value": "PlayerO" },
+              { "id": "availableInStates", "value": "OTurn" }
+            ]
+          },
+          {
+            "id": "makeMove-OTurn-OWins",
+            "type": "unsafe",
+            "rt": "#OWins",
+            "doc": { "format": "text", "value": "Player O makes a winning move" },
+            "descriptor": [
+              { "href": "#position" },
+              { "href": "#player" }
+            ],
+            "ext": [
+              { "id": "guard", "value": "TurnGuard" },
+              { "id": "projectedRole", "value": "PlayerO" },
+              { "id": "availableInStates", "value": "OTurn" }
+            ]
+          },
+          {
+            "id": "makeMove-OTurn-Draw",
+            "type": "unsafe",
+            "rt": "#Draw",
+            "doc": { "format": "text", "value": "Player O makes a move that fills the board" },
+            "descriptor": [
+              { "href": "#position" },
+              { "href": "#player" }
+            ],
+            "ext": [
+              { "id": "guard", "value": "TurnGuard" },
+              { "id": "projectedRole", "value": "PlayerO" },
+              { "id": "availableInStates", "value": "OTurn" }
+            ]
+          },
+          { "href": "#getGame" }
+        ]
+      },
+      {
+        "id": "XWins",
+        "type": "semantic",
+        "doc": { "format": "text", "value": "State: Player X has won" },
+        "descriptor": [
+          { "href": "#getGame" }
+        ]
+      },
+      {
+        "id": "OWins",
+        "type": "semantic",
+        "doc": { "format": "text", "value": "State: Player O has won" },
+        "descriptor": [
+          { "href": "#getGame" }
+        ]
+      },
+      {
+        "id": "Draw",
+        "type": "semantic",
+        "doc": { "format": "text", "value": "State: Game ended in a draw" },
+        "descriptor": [
+          { "href": "#getGame" }
+        ]
+      },
+      {
+        "id": "getGame",
+        "type": "safe",
+        "rt": "#XTurn",
+        "doc": { "format": "text", "value": "View the current game state" }
+      }
+    ],
+    "link": [
+      { "rel": "self", "href": "http://example.com/alps/tic-tac-toe" }
+    ]
+  }
+}
+"""
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Helpers
+// ══════════════════════════════════════════════════════════════════════════════
+
+/// Parse the ALPS JSON and return the StatechartDocument (fails test on error).
+let private parseDocument () : StatechartDocument =
+    let result = parseAlpsJson alpsJson
+    Expect.isEmpty result.Errors "ALPS JSON should parse without errors"
+    result.Document
+
+/// Build an ExtractedStatechart from parsed transitions and roles.
+let private buildStatechart (doc: StatechartDocument) : ExtractedStatechart =
+    let transitions = extract doc
+    let roles = extractRoles doc
+
+    let stateNames =
+        transitions
+        |> List.collect (fun t -> [ t.Source; t.Target ])
+        |> List.distinct
+        |> List.sort
+
+    { RouteTemplate = "/games/{gameId}"
+      StateNames = stateNames
+      InitialStateKey = "XTurn"
+      GuardNames = [ "TurnGuard" ]
+      StateMetadata = Map.empty
+      Roles = roles
+      Transitions = transitions }
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Tests
+// ══════════════════════════════════════════════════════════════════════════════
+
+[<Tests>]
+let projectionIntegrationTests =
+    testList
+        "Projection integration"
+        [ testList
+              "Parse ALPS JSON and extract transitions"
+              [ testCase "parses without errors"
+                <| fun _ ->
+                    let result = parseAlpsJson alpsJson
+                    Expect.isEmpty result.Errors "No parse errors"
+                    Expect.isEmpty result.Warnings "No parse warnings"
+
+                testCase "extracts transitions from parsed document"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let transitions = extract doc
+                    Expect.isGreaterThan transitions.Length 0 "Should extract at least one transition"
+
+                testCase "XTurn makeMove transitions are restricted to PlayerX"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let transitions = extract doc
+
+                    let xTurnMoves =
+                        transitions
+                        |> List.filter (fun t -> t.Source = "XTurn" && t.Event.StartsWith("makeMove"))
+
+                    Expect.isGreaterThan xTurnMoves.Length 0 "Should have makeMove transitions from XTurn"
+
+                    for t in xTurnMoves do
+                        Expect.equal t.Constraint (RestrictedTo [ "PlayerX" ]) $"XTurn transition %s{t.Event} should be restricted to PlayerX"
+
+                testCase "OTurn makeMove transitions are restricted to PlayerO"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let transitions = extract doc
+
+                    let oTurnMoves =
+                        transitions
+                        |> List.filter (fun t -> t.Source = "OTurn" && t.Event.StartsWith("makeMove"))
+
+                    Expect.isGreaterThan oTurnMoves.Length 0 "Should have makeMove transitions from OTurn"
+
+                    for t in oTurnMoves do
+                        Expect.equal t.Constraint (RestrictedTo [ "PlayerO" ]) $"OTurn transition %s{t.Event} should be restricted to PlayerO"
+
+                testCase "getGame transitions from states are unrestricted"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let transitions = extract doc
+
+                    let getGameTransitions =
+                        transitions
+                        |> List.filter (fun t -> t.Event.StartsWith("getGame"))
+
+                    Expect.isGreaterThan getGameTransitions.Length 0 "Should have getGame transitions"
+
+                    for t in getGameTransitions do
+                        Expect.equal t.Constraint Unrestricted $"getGame from %s{t.Source} should be Unrestricted" ]
+
+          testList
+              "Extract transitions and project per role"
+              [ testCase "PlayerX projection includes only XTurn makeMove transitions"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let statechart = buildStatechart doc
+                    let projected = projectForRole "PlayerX" statechart
+
+                    let makeMoves =
+                        projected.Transitions
+                        |> List.filter (fun t -> t.Event.StartsWith("makeMove"))
+
+                    Expect.isGreaterThan makeMoves.Length 0 "PlayerX should have makeMove transitions"
+
+                    for t in makeMoves do
+                        Expect.equal t.Source "XTurn" $"PlayerX makeMove transition should be from XTurn, got %s{t.Source}"
+
+                testCase "PlayerO projection includes only OTurn makeMove transitions"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let statechart = buildStatechart doc
+                    let projected = projectForRole "PlayerO" statechart
+
+                    let makeMoves =
+                        projected.Transitions
+                        |> List.filter (fun t -> t.Event.StartsWith("makeMove"))
+
+                    Expect.isGreaterThan makeMoves.Length 0 "PlayerO should have makeMove transitions"
+
+                    for t in makeMoves do
+                        Expect.equal t.Source "OTurn" $"PlayerO makeMove transition should be from OTurn, got %s{t.Source}"
+
+                testCase "Spectator projection has no makeMove transitions"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let statechart = buildStatechart doc
+                    let projected = projectForRole "Spectator" statechart
+
+                    let makeMoves =
+                        projected.Transitions
+                        |> List.filter (fun t -> t.Event.StartsWith("makeMove"))
+
+                    Expect.isEmpty makeMoves "Spectator should have no makeMove transitions"
+
+                testCase "all projections retain getGame transitions"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let statechart = buildStatechart doc
+
+                    for role in [ "PlayerX"; "PlayerO"; "Spectator" ] do
+                        let projected = projectForRole role statechart
+
+                        let getGames =
+                            projected.Transitions
+                            |> List.filter (fun t -> t.Event.StartsWith("getGame"))
+
+                        Expect.isGreaterThan getGames.Length 0 $"%s{role} should retain getGame transitions" ]
+
+          testList
+              "Completeness check"
+              [ testCase "findOrphanedTransitions returns empty for all roles"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let statechart = buildStatechart doc
+                    let projections = projectAll statechart
+                    let orphaned = findOrphanedTransitions statechart projections
+                    Expect.isEmpty orphaned "All transitions should be covered by at least one role projection"
+
+                testCase "projectAll produces a projection for each role"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let statechart = buildStatechart doc
+                    let projections = projectAll statechart
+                    Expect.equal projections.Count 3 "Should have 3 role projections"
+                    Expect.isTrue (projections.ContainsKey "PlayerX") "Should have PlayerX projection"
+                    Expect.isTrue (projections.ContainsKey "PlayerO") "Should have PlayerO projection"
+                    Expect.isTrue (projections.ContainsKey "Spectator") "Should have Spectator projection" ]
+
+          testList
+              "Extract roles from document"
+              [ testCase "document-level roles are extracted"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let roles = extractRoles doc
+                    let roleNames = roles |> List.map (fun r -> r.Name)
+
+                    Expect.contains roleNames "PlayerX" "Should contain PlayerX"
+                    Expect.contains roleNames "PlayerO" "Should contain PlayerO"
+                    Expect.contains roleNames "Spectator" "Should contain Spectator"
+
+                testCase "exactly 3 roles extracted"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let roles = extractRoles doc
+                    Expect.equal roles.Length 3 "Should extract exactly 3 roles" ] ]

--- a/test/Frank.Cli.Core.Tests/Unified/UnifiedAlpsGeneratorTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/UnifiedAlpsGeneratorTests.fs
@@ -6,6 +6,7 @@ open Frank.Statecharts
 open Frank.Resources.Model
 open Frank.Cli.Core.Analysis
 open Frank.Cli.Core.Statechart
+open Frank.Cli.Core.Shared.SchemaAlignment
 open Frank.Cli.Core.Unified
 open Frank.Cli.Core.Unified.UnifiedAlpsGenerator
 
@@ -73,7 +74,8 @@ let private ticTacToeStatechart: ExtractedStatechart =
             AllowedMethods = [ "GET" ]
             Description = None } ]
         |> Map.ofList
-      Roles = [] }
+      Roles = []
+      Transitions = [] }
 
 let private ticTacToeResource: UnifiedResource =
     { RouteTemplate = "/games/{gameId}"
@@ -181,38 +183,50 @@ let unifiedAlpsGeneratorTests =
           // ── T027: Vocabulary Alignment ──
           testList
               "vocabularyAlignment"
-              [ testCase "tryFindAlignment matches known Schema.org fields"
-                <| fun _ ->
-                    Expect.equal (tryFindAlignment "name") (Some "https://schema.org/name") "name -> schema.org/name"
-                    Expect.equal (tryFindAlignment "description") (Some "https://schema.org/description") "description"
-                    Expect.equal (tryFindAlignment "email") (Some "https://schema.org/email") "email"
-                    Expect.equal (tryFindAlignment "url") (Some "https://schema.org/url") "url"
-                    Expect.equal (tryFindAlignment "price") (Some "https://schema.org/price") "price"
-                    Expect.equal (tryFindAlignment "image") (Some "https://schema.org/image") "image"
-                    Expect.equal (tryFindAlignment "telephone") (Some "https://schema.org/telephone") "telephone"
-
-                testCase "tryFindAlignment handles camelCase splitting"
+              [ testCase "tryFindPropertyAlignment matches known Schema.org fields"
                 <| fun _ ->
                     Expect.equal
-                        (tryFindAlignment "emailAddress")
+                        (tryFindPropertyAlignment "name")
+                        (Some "https://schema.org/name")
+                        "name -> schema.org/name"
+
+                    Expect.equal
+                        (tryFindPropertyAlignment "description")
+                        (Some "https://schema.org/description")
+                        "description"
+
+                    Expect.equal (tryFindPropertyAlignment "email") (Some "https://schema.org/email") "email"
+                    Expect.equal (tryFindPropertyAlignment "url") (Some "https://schema.org/url") "url"
+                    Expect.equal (tryFindPropertyAlignment "price") (Some "https://schema.org/price") "price"
+                    Expect.equal (tryFindPropertyAlignment "image") (Some "https://schema.org/image") "image"
+
+                    Expect.equal
+                        (tryFindPropertyAlignment "telephone")
+                        (Some "https://schema.org/telephone")
+                        "telephone"
+
+                testCase "tryFindPropertyAlignment handles camelCase splitting"
+                <| fun _ ->
+                    Expect.equal
+                        (tryFindPropertyAlignment "emailAddress")
                         (Some "https://schema.org/email")
                         "emailAddress -> email"
 
                     Expect.equal
-                        (tryFindAlignment "createdAt")
+                        (tryFindPropertyAlignment "createdAt")
                         (Some "https://schema.org/dateCreated")
                         "createdAt -> dateCreated"
 
                     Expect.equal
-                        (tryFindAlignment "dateModified")
+                        (tryFindPropertyAlignment "dateModified")
                         (Some "https://schema.org/dateModified")
                         "dateModified"
 
-                testCase "tryFindAlignment returns None for unknown fields"
+                testCase "tryFindPropertyAlignment returns None for unknown fields"
                 <| fun _ ->
-                    Expect.isNone (tryFindAlignment "board") "board has no Schema.org alignment"
-                    Expect.isNone (tryFindAlignment "winner") "winner has no Schema.org alignment"
-                    Expect.isNone (tryFindAlignment "cells") "cells has no Schema.org alignment" ]
+                    Expect.isNone (tryFindPropertyAlignment "board") "board has no Schema.org alignment"
+                    Expect.isNone (tryFindPropertyAlignment "winner") "winner has no Schema.org alignment"
+                    Expect.isNone (tryFindPropertyAlignment "cells") "cells has no Schema.org alignment" ]
 
           // ── T028: Link Relation Derivation ──
           testList
@@ -284,26 +298,17 @@ let unifiedAlpsGeneratorTests =
                         let descriptors = getDescriptors json
 
                         // Should have semantic descriptors for fields
-                        let semanticDescs =
-                            descriptors |> List.filter (descriptorHasType "semantic")
+                        let semanticDescs = descriptors |> List.filter (descriptorHasType "semantic")
 
-                        Expect.isGreaterThan
-                            semanticDescs.Length
-                            0
-                            "Should have at least one semantic descriptor"
+                        Expect.isGreaterThan semanticDescs.Length 0 "Should have at least one semantic descriptor"
 
                         // Should have safe descriptor for GET
-                        let safeDescs =
-                            descriptors |> List.filter (descriptorHasType "safe")
+                        let safeDescs = descriptors |> List.filter (descriptorHasType "safe")
 
-                        Expect.isGreaterThan
-                            safeDescs.Length
-                            0
-                            "Should have at least one safe descriptor"
+                        Expect.isGreaterThan safeDescs.Length 0 "Should have at least one safe descriptor"
 
                         // Check status field is present
-                        let hasStatus =
-                            descriptors |> List.exists (descriptorHasId "status")
+                        let hasStatus = descriptors |> List.exists (descriptorHasId "status")
 
                         Expect.isTrue hasStatus "Should have 'status' descriptor"
 
@@ -317,8 +322,7 @@ let unifiedAlpsGeneratorTests =
                         let descriptors = getDescriptors json
 
                         // The 'name' field should have an href to schema.org
-                        let nameDesc =
-                            descriptors |> List.tryFind (descriptorHasId "name")
+                        let nameDesc = descriptors |> List.tryFind (descriptorHasId "name")
 
                         Expect.isSome nameDesc "Should have 'name' descriptor"
 
@@ -326,10 +330,7 @@ let unifiedAlpsGeneratorTests =
 
                         match nameElem.TryGetProperty("href") with
                         | true, href ->
-                            Expect.equal
-                                (href.GetString())
-                                "https://schema.org/name"
-                                "name should link to Schema.org"
+                            Expect.equal (href.GetString()) "https://schema.org/name" "name should link to Schema.org"
                         | _ -> failtest "name descriptor should have href"
 
                 testCase "plain resource has no state-dependent transition descriptors"
@@ -340,13 +341,9 @@ let unifiedAlpsGeneratorTests =
                     | Error errors -> failtest $"Generation failed: {errors}"
                     | Ok json ->
                         // Should not contain any state-prefixed descriptor ids
-                        Expect.isFalse
-                            (json.Contains("XTurn"))
-                            "Plain resource should not contain state names"
+                        Expect.isFalse (json.Contains("XTurn")) "Plain resource should not contain state names"
 
-                        Expect.isFalse
-                            (json.Contains("OTurn"))
-                            "Plain resource should not contain state names"
+                        Expect.isFalse (json.Contains("OTurn")) "Plain resource should not contain state names"
 
                 testCase "minimal resource with no type info produces valid ALPS"
                 <| fun _ ->
@@ -358,18 +355,11 @@ let unifiedAlpsGeneratorTests =
                         let descriptors = getDescriptors json
 
                         // Should have at least the transition descriptor
-                        Expect.isGreaterThan
-                            descriptors.Length
-                            0
-                            "Should have at least one descriptor"
+                        Expect.isGreaterThan descriptors.Length 0 "Should have at least one descriptor"
 
-                        let safeDescs =
-                            descriptors |> List.filter (descriptorHasType "safe")
+                        let safeDescs = descriptors |> List.filter (descriptorHasType "safe")
 
-                        Expect.isGreaterThan
-                            safeDescs.Length
-                            0
-                            "Should have safe descriptor for GET"
+                        Expect.isGreaterThan safeDescs.Length 0 "Should have safe descriptor for GET"
 
                 testCase "tic-tac-toe resource contains semantic descriptors"
                 <| fun _ ->
@@ -382,19 +372,14 @@ let unifiedAlpsGeneratorTests =
 
                         // Should have the DU type descriptor
                         let hasTicTacToeState =
-                            descriptors
-                            |> List.exists (descriptorHasId "TicTacToeState")
+                            descriptors |> List.exists (descriptorHasId "TicTacToeState")
 
                         Expect.isTrue hasTicTacToeState "Should have TicTacToeState descriptor"
 
                         // Should have semantic descriptors
-                        let semanticDescs =
-                            descriptors |> List.filter (descriptorHasType "semantic")
+                        let semanticDescs = descriptors |> List.filter (descriptorHasType "semantic")
 
-                        Expect.isGreaterThan
-                            semanticDescs.Length
-                            0
-                            "Should have semantic descriptors"
+                        Expect.isGreaterThan semanticDescs.Length 0 "Should have semantic descriptors"
 
                 testCase "tic-tac-toe resource contains safe and unsafe transition descriptors"
                 <| fun _ ->
@@ -406,22 +391,14 @@ let unifiedAlpsGeneratorTests =
                         let descriptors = getDescriptors json
 
                         // Should have safe descriptors (GET)
-                        let safeDescs =
-                            descriptors |> List.filter (descriptorHasType "safe")
+                        let safeDescs = descriptors |> List.filter (descriptorHasType "safe")
 
-                        Expect.isGreaterThan
-                            safeDescs.Length
-                            0
-                            "Should have safe descriptors for GET"
+                        Expect.isGreaterThan safeDescs.Length 0 "Should have safe descriptors for GET"
 
                         // Should have unsafe descriptors (POST)
-                        let unsafeDescs =
-                            descriptors |> List.filter (descriptorHasType "unsafe")
+                        let unsafeDescs = descriptors |> List.filter (descriptorHasType "unsafe")
 
-                        Expect.isGreaterThan
-                            unsafeDescs.Length
-                            0
-                            "Should have unsafe descriptors for POST"
+                        Expect.isGreaterThan unsafeDescs.Length 0 "Should have unsafe descriptors for POST"
 
                 testCase "tic-tac-toe transitions include state-scoped descriptor ids"
                 <| fun _ ->
@@ -455,11 +432,9 @@ let unifiedAlpsGeneratorTests =
                     | Ok json ->
                         let descriptors = getDescriptors json
 
-                        let hasCells =
-                            descriptors |> List.exists (descriptorHasId "cells")
+                        let hasCells = descriptors |> List.exists (descriptorHasId "cells")
 
-                        let hasSize =
-                            descriptors |> List.exists (descriptorHasId "size")
+                        let hasSize = descriptors |> List.exists (descriptorHasId "size")
 
                         Expect.isTrue hasCells "Should have 'cells' descriptor from Board record"
                         Expect.isTrue hasSize "Should have 'size' descriptor from Board record" ]

--- a/test/Frank.Cli.Core.Tests/Unified/UnifiedExtractorTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/UnifiedExtractorTests.fs
@@ -209,7 +209,8 @@ let game = statefulResource "/games/{gameId}" {
                               "Won", { IsFinal = true; AllowedMethods = [ "GET" ]; Description = None }
                               "Draw", { IsFinal = true; AllowedMethods = [ "GET" ]; Description = None } ]
                             |> Map.ofList
-                          Roles = [] }
+                          Roles = []
+                          Transitions = [] }
 
                     let resource =
                         { RouteTemplate = "/games/{gameId}"
@@ -241,7 +242,8 @@ let game = statefulResource "/games/{gameId}" {
                           InitialStateKey = "XTurn"
                           GuardNames = []
                           StateMetadata = Map.empty
-                          Roles = [] }
+                          Roles = []
+                          Transitions = [] }
 
                     let stateType =
                         { FullName = "Test.GameState"
@@ -276,7 +278,8 @@ let game = statefulResource "/games/{gameId}" {
                           InitialStateKey = "Playing"
                           GuardNames = []
                           StateMetadata = Map.empty
-                          Roles = [] }
+                          Roles = []
+                          Transitions = [] }
 
                     let stateType =
                         { FullName = "Test.GameState"
@@ -329,7 +332,8 @@ let game = statefulResource "/games/{gameId}" {
                           InitialStateKey = "A"
                           GuardNames = []
                           StateMetadata = Map.empty
-                          Roles = [] }
+                          Roles = []
+                          Transitions = [] }
 
                     let stateType =
                         { FullName = "Test.State"

--- a/test/Frank.Resources.Model.Tests/Frank.Resources.Model.Tests.fsproj
+++ b/test/Frank.Resources.Model.Tests/Frank.Resources.Model.Tests.fsproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Compile Include="ResourceSlugTests.fs" />
     <Compile Include="AffordanceMapTests.fs" />
+    <Compile Include="ProjectionTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Frank.Resources.Model.Tests/ProjectionTests.fs
+++ b/test/Frank.Resources.Model.Tests/ProjectionTests.fs
@@ -1,0 +1,240 @@
+module Frank.Resources.Model.Tests.ProjectionTests
+
+open Expecto
+open Frank.Resources.Model
+
+// -- Test fixtures --
+
+let private mkTransition event source target guard roleConstraint =
+    { Event = event
+      Source = source
+      Target = target
+      Guard = guard
+      Constraint = roleConstraint }
+
+/// TicTacToe-like statechart with two players and a spectator.
+let private ticTacToeChart: ExtractedStatechart =
+    { RouteTemplate = "/games/{gameId}"
+      StateNames = [ "XTurn"; "OTurn"; "XWins"; "OWins"; "Draw" ]
+      InitialStateKey = "XTurn"
+      GuardNames = [ "TurnGuard" ]
+      StateMetadata =
+        Map.ofList
+            [ "XTurn", { AllowedMethods = [ "GET"; "PUT" ]; IsFinal = false; Description = None }
+              "OTurn", { AllowedMethods = [ "GET"; "PUT" ]; IsFinal = false; Description = None }
+              "XWins", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None }
+              "OWins", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None }
+              "Draw", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None } ]
+      Roles =
+        [ { Name = "PlayerX"; Description = Some "Player X" }
+          { Name = "PlayerO"; Description = Some "Player O" }
+          { Name = "Spectator"; Description = Some "Observer" } ]
+      Transitions =
+        [ // Unguarded GET — all roles can observe
+          mkTransition "getGame" "XTurn" "XTurn" None Unrestricted
+          mkTransition "getGame" "OTurn" "OTurn" None Unrestricted
+          mkTransition "getGame" "XWins" "XWins" None Unrestricted
+          mkTransition "getGame" "OWins" "OWins" None Unrestricted
+          mkTransition "getGame" "Draw" "Draw" None Unrestricted
+          // Guarded makeMove — role-restricted per state
+          mkTransition "makeMove" "XTurn" "OTurn" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "XTurn" "XWins" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "XTurn" "Draw" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "OTurn" "XTurn" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ])
+          mkTransition "makeMove" "OTurn" "OWins" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ])
+          mkTransition "makeMove" "OTurn" "Draw" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ]) ] }
+
+/// Simple chart with a dead transition (RestrictedTo []).
+let private deadTransitionChart: ExtractedStatechart =
+    { RouteTemplate = "/items"
+      StateNames = [ "Active"; "Archived" ]
+      InitialStateKey = "Active"
+      GuardNames = [ "DeadGuard" ]
+      StateMetadata =
+        Map.ofList
+            [ "Active", { AllowedMethods = [ "GET" ]; IsFinal = false; Description = None }
+              "Archived", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None } ]
+      Roles = [ { Name = "Admin"; Description = None } ]
+      Transitions =
+        [ mkTransition "getItem" "Active" "Active" None Unrestricted
+          mkTransition "archive" "Active" "Archived" (Some "DeadGuard") (RestrictedTo []) ] }
+
+/// Chart with disconnected state (no path from initial).
+let private disconnectedChart: ExtractedStatechart =
+    { RouteTemplate = "/docs"
+      StateNames = [ "Draft"; "Published"; "Orphan" ]
+      InitialStateKey = "Draft"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "Draft", { AllowedMethods = [ "GET"; "PUT" ]; IsFinal = false; Description = None }
+              "Published", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None }
+              "Orphan", { AllowedMethods = [ "GET" ]; IsFinal = false; Description = None } ]
+      Roles = [ { Name = "Editor"; Description = None } ]
+      Transitions =
+        [ mkTransition "publish" "Draft" "Published" None Unrestricted
+          mkTransition "view" "Draft" "Draft" None Unrestricted
+          mkTransition "view" "Published" "Published" None Unrestricted
+          // Orphan state has a transition but is unreachable from initial
+          mkTransition "orphanAction" "Orphan" "Draft" None Unrestricted ] }
+
+// -- Tests --
+
+[<Tests>]
+let filterTransitionsByRoleTests =
+    testList
+        "filterTransitionsByRole"
+        [ testCase "keeps unrestricted transitions for all roles"
+          <| fun _ ->
+              let projected = Projection.filterTransitionsByRole "PlayerX" ticTacToeChart
+              let getTransitions = projected.Transitions |> List.filter (fun t -> t.Event = "getGame")
+              Expect.equal (List.length getTransitions) 5 "All 5 getGame transitions survive"
+
+          testCase "keeps restricted transitions only for permitted roles"
+          <| fun _ ->
+              let projected = Projection.filterTransitionsByRole "PlayerX" ticTacToeChart
+
+              let movesFromXTurn =
+                  projected.Transitions
+                  |> List.filter (fun t -> t.Event = "makeMove" && t.Source = "XTurn")
+
+              let movesFromOTurn =
+                  projected.Transitions
+                  |> List.filter (fun t -> t.Event = "makeMove" && t.Source = "OTurn")
+
+              Expect.equal (List.length movesFromXTurn) 3 "PlayerX has 3 makeMove transitions from XTurn"
+              Expect.equal (List.length movesFromOTurn) 0 "PlayerX has no makeMove transitions from OTurn"
+
+          testCase "unknown role keeps only unrestricted transitions"
+          <| fun _ ->
+              let projected = Projection.filterTransitionsByRole "Unknown" ticTacToeChart
+              let allMoves = projected.Transitions |> List.filter (fun t -> t.Event = "makeMove")
+              Expect.equal (List.length allMoves) 0 "Unknown role has no makeMove transitions"
+
+              let allGets = projected.Transitions |> List.filter (fun t -> t.Event = "getGame")
+              Expect.equal (List.length allGets) 5 "Unknown role still has all getGame transitions"
+
+          testCase "spectator sees only unrestricted transitions"
+          <| fun _ ->
+              let projected = Projection.filterTransitionsByRole "Spectator" ticTacToeChart
+              let allMoves = projected.Transitions |> List.filter (fun t -> t.Event = "makeMove")
+              Expect.equal (List.length allMoves) 0 "Spectator has no makeMove transitions"
+
+          testCase "RestrictedTo empty list filters out the transition"
+          <| fun _ ->
+              let projected = Projection.filterTransitionsByRole "Admin" deadTransitionChart
+              let archives = projected.Transitions |> List.filter (fun t -> t.Event = "archive")
+              Expect.equal (List.length archives) 0 "Dead transition filtered out" ]
+
+[<Tests>]
+let pruneUnreachableStatesTests =
+    testList
+        "pruneUnreachableStates"
+        [ testCase "removes disconnected states"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates disconnectedChart
+              Expect.isFalse (List.contains "Orphan" pruned.StateNames) "Orphan state removed"
+              Expect.isTrue (List.contains "Draft" pruned.StateNames) "Draft survives"
+              Expect.isTrue (List.contains "Published" pruned.StateNames) "Published survives"
+
+          testCase "always retains initial state"
+          <| fun _ ->
+              // Filter all transitions from a chart, then prune
+              let emptyTransitions = { ticTacToeChart with Transitions = [] }
+              let pruned = Projection.pruneUnreachableStates emptyTransitions
+              Expect.isTrue (List.contains "XTurn" pruned.StateNames) "Initial state retained"
+
+          testCase "updates StateMetadata for pruned states"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates disconnectedChart
+              Expect.isFalse (Map.containsKey "Orphan" pruned.StateMetadata) "Orphan metadata removed"
+              Expect.isTrue (Map.containsKey "Draft" pruned.StateMetadata) "Draft metadata retained"
+
+          testCase "removes transitions referencing pruned states"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates disconnectedChart
+
+              let orphanTransitions =
+                  pruned.Transitions
+                  |> List.filter (fun t -> t.Source = "Orphan" || t.Target = "Orphan")
+
+              Expect.equal (List.length orphanTransitions) 0 "No transitions reference Orphan" ]
+
+[<Tests>]
+let projectForRoleTests =
+    testList
+        "projectForRole"
+        [ testCase "PlayerX projection includes makeMove in XTurn only"
+          <| fun _ ->
+              let projected = Projection.projectForRole "PlayerX" ticTacToeChart
+
+              let xTurnMoves =
+                  projected.Transitions
+                  |> List.filter (fun t -> t.Event = "makeMove" && t.Source = "XTurn")
+
+              let oTurnMoves =
+                  projected.Transitions
+                  |> List.filter (fun t -> t.Event = "makeMove" && t.Source = "OTurn")
+
+              Expect.isNonEmpty xTurnMoves "PlayerX has makeMove from XTurn"
+              Expect.isEmpty oTurnMoves "PlayerX has no makeMove from OTurn"
+
+          testCase "PlayerO projection includes makeMove in OTurn only"
+          <| fun _ ->
+              let projected = Projection.projectForRole "PlayerO" ticTacToeChart
+
+              let oTurnMoves =
+                  projected.Transitions
+                  |> List.filter (fun t -> t.Event = "makeMove" && t.Source = "OTurn")
+
+              let xTurnMoves =
+                  projected.Transitions
+                  |> List.filter (fun t -> t.Event = "makeMove" && t.Source = "XTurn")
+
+              Expect.isNonEmpty oTurnMoves "PlayerO has makeMove from OTurn"
+              Expect.isEmpty xTurnMoves "PlayerO has no makeMove from XTurn"
+
+          testCase "both players can observe all states"
+          <| fun _ ->
+              let playerX = Projection.projectForRole "PlayerX" ticTacToeChart
+              let playerO = Projection.projectForRole "PlayerO" ticTacToeChart
+
+              // All states reachable via unguarded getGame + guarded makeMove transitions
+              Expect.equal (List.length playerX.StateNames) 5 "PlayerX sees all 5 states"
+              Expect.equal (List.length playerO.StateNames) 5 "PlayerO sees all 5 states" ]
+
+[<Tests>]
+let projectAllTests =
+    testList
+        "projectAll"
+        [ testCase "produces one entry per role"
+          <| fun _ ->
+              let projections = Projection.projectAll ticTacToeChart
+              Expect.equal (Map.count projections) 3 "Three roles = three projections"
+              Expect.isTrue (Map.containsKey "PlayerX" projections) "PlayerX projection exists"
+              Expect.isTrue (Map.containsKey "PlayerO" projections) "PlayerO projection exists"
+              Expect.isTrue (Map.containsKey "Spectator" projections) "Spectator projection exists"
+
+          testCase "returns empty map for statechart with no roles"
+          <| fun _ ->
+              let noRoles = { ticTacToeChart with Roles = [] }
+              let projections = Projection.projectAll noRoles
+              Expect.equal (Map.count projections) 0 "No roles = empty map" ]
+
+[<Tests>]
+let findOrphanedTransitionsTests =
+    testList
+        "findOrphanedTransitions"
+        [ testCase "returns empty for fully covered transitions"
+          <| fun _ ->
+              let projections = Projection.projectAll ticTacToeChart
+              let orphans = Projection.findOrphanedTransitions ticTacToeChart projections
+              Expect.isEmpty orphans "TicTacToe has no orphaned transitions"
+
+          testCase "detects dead transitions (RestrictedTo [])"
+          <| fun _ ->
+              let projections = Projection.projectAll deadTransitionChart
+              let orphans = Projection.findOrphanedTransitions deadTransitionChart projections
+
+              let archiveOrphans = orphans |> List.filter (fun t -> t.Event = "archive")
+              Expect.isNonEmpty archiveOrphans "Dead transition detected as orphan" ]

--- a/test/Frank.Statecharts.Tests/Affordances/ProfileMiddlewareTests.fs
+++ b/test/Frank.Statecharts.Tests/Affordances/ProfileMiddlewareTests.fs
@@ -80,6 +80,7 @@ let private jsonSchemaFixture =
 
 let private testProfiles: ProjectedProfiles =
     { AlpsProfiles = Map.ofList [ ("games", alpsJsonFixture) ]
+      RoleAlpsProfiles = Map.empty
       OwlOntologies = Map.ofList [ ("games", owlTurtleFixture) ]
       ShaclShapes = Map.ofList [ ("games", shaclTurtleFixture) ]
       JsonSchemas = Map.ofList [ ("games", jsonSchemaFixture) ] }


### PR DESCRIPTION
## Summary

- Implement #107: projection operator that derives per-role ALPS profiles from a global statechart
- Pure, total projection functions in zero-dep `Frank.Resources.Model` assembly
- `TransitionExtractor` bridge from parsed spec files to `TransitionSpec` with resolved `RoleConstraint`
- ALPS generator emits `availableInStates`, `projectedRole`, and cross-link elements
- `ProjectionPipeline` shared orchestration used by both `CompileCommand` and `UnifiedGenerateCommand`
- `ProfileMiddleware` serves per-role profiles at `/alps/{slug}` (e.g., `/alps/games-playerx`)
- TicTacToe spec files (WSD, smcat, ALPS JSON) with role annotations as test cases
- 38 new tests (25 unit + 13 integration), all existing tests pass
- Bonus: extracted `SchemaAlignment` shared module, converted mutable error patterns to functional, added IANA link relation constants, fixed `Graph()` disposal

## Design decisions (expert-validated)

| Decision | Rationale |
|----------|-----------|
| One ALPS profile per role (not per state) | ALPS = vocabulary document; `availableInStates` handles state scoping |
| `RoleConstraint` DU on `TransitionSpec` (pre-resolved) | MPST: each interaction names its participants; "parse, don't validate" |
| Uniform projection (no safe descriptor special case) | Guards are sole arbiter; HTTP safety ≠ access scope |
| `pruneUnreachableStates >> filterTransitionsByRole` | Multi-party protocols: state reachability is global |
| `Transitions = []` in F# source extractor | Honest — runtime closures can't be statically analyzed; spec files provide real data |

## Test plan

- [x] `dotnet build Frank.sln` — 0 errors
- [x] `dotnet test Frank.sln --filter "FullyQualifiedName!~Sample"` — all tests pass
- [x] `dotnet fantomas --check` — all changed files clean
- [x] Projection unit tests: filter, prune, project, completeness check, TicTacToe scenario
- [x] Integration tests: parse ALPS JSON → extract transitions → project per role → verify
- [ ] Manual: `frank generate --format alps` on TicTacToe spec files produces per-role output

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)