### PR TITLE
feat: post-hoc session conformance checking

### DIFF
--- a/src/Frank.Provenance/ConformanceChecker.fs
+++ b/src/Frank.Provenance/ConformanceChecker.fs
@@ -1,0 +1,55 @@
+namespace Frank.Provenance
+
+open Frank.Resources.Model
+
+/// Post-hoc conformance checking of provenance records against per-role projected profiles.
+[<RequireQualifiedAccess>]
+module ConformanceChecker =
+
+    /// Classify why a role failed conformance for a given transition.
+    let private classifyRoleFailure
+        (transitionSets: Map<string, Set<string * string * string>>)
+        (key: string * string * string)
+        (role: string)
+        : ViolationReason option =
+        match Map.tryFind role transitionSets with
+        | None -> Some(ViolationReason.RoleNotInProjection role)
+        | Some ts ->
+            if Set.contains key ts then None
+            else Some(ViolationReason.TransitionNotInProjection role)
+
+    /// Check a single record against pre-built per-role transition sets.
+    let private checkRecord
+        (transitionSets: Map<string, Set<string * string * string>>)
+        (record: ProvenanceRecord)
+        : ConformanceViolation option =
+        let key =
+            (record.Activity.PreviousState, record.Activity.EventName, record.Activity.NewState)
+
+        match record.ActingRoles with
+        | [] -> Some { Record = record; Reasons = [ ViolationReason.NoActingRoles ] }
+        | roles ->
+            let reasons = roles |> List.choose (classifyRoleFailure transitionSets key)
+
+            if List.length reasons = List.length roles then
+                Some { Record = record; Reasons = reasons }
+            else
+                None
+
+    /// Verify provenance records against per-role projected profiles.
+    /// A transition is conformant if at least one acting role's projection includes it.
+    let checkConformance
+        (projections: Map<string, ExtractedStatechart>)
+        (records: ProvenanceRecord list)
+        : ConformanceReport =
+        let transitionSets =
+            projections
+            |> Map.map (fun _ proj ->
+                proj.Transitions
+                |> List.map (fun t -> (t.Source, t.Event, t.Target))
+                |> Set.ofList)
+
+        let violations = records |> List.choose (checkRecord transitionSets)
+
+        { TotalRecords = List.length records
+          Violations = violations }

--- a/src/Frank.Provenance/ConformanceTypes.fs
+++ b/src/Frank.Provenance/ConformanceTypes.fs
@@ -1,0 +1,32 @@
+namespace Frank.Provenance
+
+/// Why a provenance record violated role conformance.
+[<RequireQualifiedAccess>]
+type ViolationReason =
+    /// Role's projected profile has no matching transition for this event in this state.
+    | TransitionNotInProjection of role: string
+    /// Role is not recognized by the protocol (not in the projection map).
+    | RoleNotInProjection of role: string
+    /// No acting roles were recorded — conformance cannot be verified.
+    | NoActingRoles
+
+/// A single conformance violation tied to a specific provenance record.
+type ConformanceViolation =
+    {
+        /// The provenance record that violated conformance.
+        Record: ProvenanceRecord
+        /// Why the violation occurred, one entry per failing role or structural issue.
+        Reasons: ViolationReason list
+    }
+
+/// Result of checking a sequence of provenance records against projected profiles.
+type ConformanceReport =
+    {
+        /// Total records checked.
+        TotalRecords: int
+        /// Records that violated conformance.
+        Violations: ConformanceViolation list
+    }
+
+    /// Records that passed conformance (at least one acting role had the transition).
+    member this.ConformantCount = this.TotalRecords - this.Violations.Length

--- a/src/Frank.Provenance/Frank.Provenance.fsproj
+++ b/src/Frank.Provenance/Frank.Provenance.fsproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <Compile Include="ProvVocabulary.fs" />
     <Compile Include="Types.fs" />
+    <Compile Include="ConformanceTypes.fs" />
+    <Compile Include="ConformanceChecker.fs" />
     <Compile Include="Store.fs" />
     <Compile Include="MailboxProcessorStore.fs" />
     <Compile Include="GraphBuilder.fs" />
@@ -24,6 +26,7 @@
   <ItemGroup>
     <ProjectReference Include="../Frank/Frank.fsproj" />
     <ProjectReference Include="../Frank.LinkedData/Frank.LinkedData.fsproj" />
+    <ProjectReference Include="../Frank.Resources.Model/Frank.Resources.Model.fsproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Frank.Provenance/GraphBuilder.fs
+++ b/src/Frank.Provenance/GraphBuilder.fs
@@ -90,6 +90,11 @@ module GraphBuilder =
             (uriNode graph ProvVocabulary.Frank.eventName)
             (plainLiteral graph activity.EventName)
 
+        let actingRolePred = uriNode graph ProvVocabulary.Frank.actingRole
+
+        for role in record.ActingRoles do
+            assertTriple graph activityNode actingRolePred (plainLiteral graph role)
+
     let private addUsedEntity (graph: IGraph) (record: ProvenanceRecord) =
         let entity = record.UsedEntity
         let entityNode = uriNode graph entity.Id

--- a/src/Frank.Provenance/ProvVocabulary.fs
+++ b/src/Frank.Provenance/ProvVocabulary.fs
@@ -100,6 +100,9 @@ module ProvVocabulary =
         [<Literal>]
         let agentModel = FrankNamespace + "agentModel"
 
+        [<Literal>]
+        let actingRole = FrankNamespace + "actingRole"
+
     /// RDF vocabulary constants.
     [<RequireQualifiedAccess>]
     module Rdf =

--- a/src/Frank.Provenance/TransitionObserver.fs
+++ b/src/Frank.Provenance/TransitionObserver.fs
@@ -25,6 +25,8 @@ type TransitionEvent =
         HttpMethod: string
         /// HTTP headers from the triggering request.
         Headers: Map<string, string>
+        /// Protocol roles held by the acting principal.
+        Roles: string list
     }
 
 /// Private module for extracting a ProvenanceAgent from request context.
@@ -120,7 +122,8 @@ type TransitionObserver(store: IProvenanceStore, logger: ILogger<TransitionObser
           Activity = activity
           Agent = agent
           GeneratedEntity = generatedEntity
-          UsedEntity = usedEntity }
+          UsedEntity = usedEntity
+          ActingRoles = event.Roles }
 
     interface IObserver<TransitionEvent> with
 

--- a/src/Frank.Provenance/Types.fs
+++ b/src/Frank.Provenance/Types.fs
@@ -72,6 +72,8 @@ type ProvenanceRecord =
         GeneratedEntity: ProvenanceEntity
         /// The entity used (input) by this activity.
         UsedEntity: ProvenanceEntity
+        /// Protocol roles held by the acting principal at the time of the transition.
+        ActingRoles: string list
     }
 
 /// A collection of provenance records for a resource.

--- a/test/Frank.LinkedData.Tests/ProvenanceGraphTests.fs
+++ b/test/Frank.LinkedData.Tests/ProvenanceGraphTests.fs
@@ -80,7 +80,8 @@ let private makeTestProvenanceRecords (resourceUri: string) : ProvenanceRecord l
           Activity = activity
           Agent = agent
           GeneratedEntity = generatedEntity
-          UsedEntity = usedEntity }
+          UsedEntity = usedEntity
+          ActingRoles = [] }
 
     let record2 =
         let activity =
@@ -111,7 +112,8 @@ let private makeTestProvenanceRecords (resourceUri: string) : ProvenanceRecord l
           Activity = activity
           Agent = agent
           GeneratedEntity = generatedEntity
-          UsedEntity = usedEntity }
+          UsedEntity = usedEntity
+          ActingRoles = [] }
 
     [ record1; record2 ]
 

--- a/test/Frank.Provenance.Tests/AgentTypeTests.fs
+++ b/test/Frank.Provenance.Tests/AgentTypeTests.fs
@@ -28,7 +28,8 @@ let private makeEvent (user: ClaimsPrincipal option) (headers: Map<string, strin
       Timestamp = DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero)
       User = user
       HttpMethod = "POST"
-      Headers = headers }
+      Headers = headers
+      Roles = [] }
 
 let private authenticatedPrincipal name identifier =
     let claims =

--- a/test/Frank.Provenance.Tests/ConformanceTests.fs
+++ b/test/Frank.Provenance.Tests/ConformanceTests.fs
@@ -1,0 +1,195 @@
+module Frank.Provenance.Tests.ConformanceTests
+
+open System
+open Expecto
+open Frank.Provenance
+open Frank.Resources.Model
+
+// -- Test fixtures --
+
+let private mkTransition event source target roleConstraint =
+    { Event = event
+      Source = source
+      Target = target
+      Guard = None
+      Constraint = roleConstraint }
+
+/// TicTacToe-like statechart with two players and a spectator.
+let private ticTacToeChart: ExtractedStatechart =
+    { RouteTemplate = "/games/{gameId}"
+      StateNames = [ "XTurn"; "OTurn"; "XWins"; "OWins"; "Draw" ]
+      InitialStateKey = "XTurn"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "XTurn", { AllowedMethods = [ "GET"; "PUT" ]; IsFinal = false; Description = None }
+              "OTurn", { AllowedMethods = [ "GET"; "PUT" ]; IsFinal = false; Description = None }
+              "XWins", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None }
+              "OWins", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None }
+              "Draw", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None } ]
+      Roles =
+        [ { Name = "PlayerX"; Description = Some "Player X" }
+          { Name = "PlayerO"; Description = Some "Player O" }
+          { Name = "Spectator"; Description = Some "Observer" } ]
+      Transitions =
+        [ mkTransition "getGame" "XTurn" "XTurn" Unrestricted
+          mkTransition "getGame" "OTurn" "OTurn" Unrestricted
+          mkTransition "getGame" "XWins" "XWins" Unrestricted
+          mkTransition "getGame" "OWins" "OWins" Unrestricted
+          mkTransition "getGame" "Draw" "Draw" Unrestricted
+          mkTransition "makeMove" "XTurn" "OTurn" (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "XTurn" "XWins" (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "XTurn" "Draw" (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "OTurn" "XTurn" (RestrictedTo [ "PlayerO" ])
+          mkTransition "makeMove" "OTurn" "OWins" (RestrictedTo [ "PlayerO" ])
+          mkTransition "makeMove" "OTurn" "Draw" (RestrictedTo [ "PlayerO" ]) ] }
+
+/// Pre-projected per-role profiles from the TicTacToe chart.
+let private projections = Projection.projectAll ticTacToeChart
+
+let private now = DateTimeOffset(2026, 3, 23, 12, 0, 0, TimeSpan.Zero)
+
+let private makeRecord (roles: string list) (prevState: string) (newState: string) (event: string) =
+    let activity =
+        { ProvenanceActivity.Id = $"urn:frank:activity:{Guid.NewGuid()}"
+          HttpMethod = "POST"
+          ResourceUri = "/games/1"
+          EventName = event
+          PreviousState = prevState
+          NewState = newState
+          StartedAt = now
+          EndedAt = now }
+
+    let agent =
+        { ProvenanceAgent.Id = "urn:frank:agent:person:test"
+          AgentType = AgentType.Person("Test", "test") }
+
+    let usedEntity =
+        { ProvenanceEntity.Id = $"urn:frank:entity:{Guid.NewGuid()}"
+          ResourceUri = "/games/1"
+          StateName = prevState
+          CapturedAt = now }
+
+    let generatedEntity =
+        { ProvenanceEntity.Id = $"urn:frank:entity:{Guid.NewGuid()}"
+          ResourceUri = "/games/1"
+          StateName = newState
+          CapturedAt = now }
+
+    { ProvenanceRecord.Id = $"urn:frank:record:{Guid.NewGuid()}"
+      ResourceUri = "/games/1"
+      RecordedAt = now
+      Activity = activity
+      Agent = agent
+      GeneratedEntity = generatedEntity
+      UsedEntity = usedEntity
+      ActingRoles = roles }
+
+[<Tests>]
+let conformanceTests =
+    testList
+        "ConformanceChecker"
+        [ test "valid trace produces clean report" {
+              let records =
+                  [ makeRecord [ "PlayerX" ] "XTurn" "OTurn" "makeMove"
+                    makeRecord [ "PlayerO" ] "OTurn" "XTurn" "makeMove"
+                    makeRecord [ "PlayerX" ] "XTurn" "XWins" "makeMove" ]
+
+              let report = ConformanceChecker.checkConformance projections records
+
+              Expect.equal report.TotalRecords 3 "TotalRecords"
+              Expect.equal report.ConformantCount 3 "ConformantCount"
+              Expect.isEmpty report.Violations "No violations"
+          }
+
+          test "single violation when role lacks transition" {
+              let records = [ makeRecord [ "PlayerO" ] "XTurn" "OTurn" "makeMove" ]
+
+              let report = ConformanceChecker.checkConformance projections records
+
+              Expect.equal report.Violations.Length 1 "One violation"
+              let v = report.Violations.[0]
+              Expect.equal v.Reasons.Length 1 "One reason"
+
+              match v.Reasons.[0] with
+              | ViolationReason.TransitionNotInProjection role ->
+                  Expect.equal role "PlayerO" "Violating role"
+              | other -> failtest $"Expected TransitionNotInProjection, got {other}"
+          }
+
+          test "multi-role pass when at least one role has transition" {
+              let records = [ makeRecord [ "Spectator"; "PlayerX" ] "XTurn" "OTurn" "makeMove" ]
+
+              let report = ConformanceChecker.checkConformance projections records
+
+              Expect.equal report.ConformantCount 1 "Conformant"
+              Expect.isEmpty report.Violations "No violations — PlayerX authorizes"
+          }
+
+          test "multi-role all-fail when no role has transition" {
+              let records = [ makeRecord [ "Spectator"; "PlayerO" ] "XTurn" "OTurn" "makeMove" ]
+
+              let report = ConformanceChecker.checkConformance projections records
+
+              Expect.equal report.Violations.Length 1 "One violation"
+              let v = report.Violations.[0]
+              Expect.equal v.Reasons.Length 2 "Both roles failed"
+          }
+
+          test "no acting roles produces NoActingRoles violation" {
+              let records = [ makeRecord [] "XTurn" "OTurn" "makeMove" ]
+
+              let report = ConformanceChecker.checkConformance projections records
+
+              Expect.equal report.Violations.Length 1 "One violation"
+
+              match report.Violations.[0].Reasons.[0] with
+              | ViolationReason.NoActingRoles -> ()
+              | other -> failtest $"Expected NoActingRoles, got {other}"
+          }
+
+          test "role not in projection map produces RoleNotInProjection" {
+              let records = [ makeRecord [ "UnknownRole" ] "XTurn" "OTurn" "makeMove" ]
+
+              let report = ConformanceChecker.checkConformance projections records
+
+              Expect.equal report.Violations.Length 1 "One violation"
+
+              match report.Violations.[0].Reasons.[0] with
+              | ViolationReason.RoleNotInProjection role ->
+                  Expect.equal role "UnknownRole" "Unknown role flagged"
+              | other -> failtest $"Expected RoleNotInProjection, got {other}"
+          }
+
+          test "empty records produces clean empty report" {
+              let report = ConformanceChecker.checkConformance projections []
+
+              Expect.equal report.TotalRecords 0 "TotalRecords"
+              Expect.equal report.ConformantCount 0 "ConformantCount"
+              Expect.isEmpty report.Violations "No violations"
+          }
+
+          test "mixed trace reports correct counts" {
+              let records =
+                  [ makeRecord [ "PlayerX" ] "XTurn" "OTurn" "makeMove" // valid
+                    makeRecord [ "PlayerO" ] "XTurn" "OTurn" "makeMove" // invalid
+                    makeRecord [ "PlayerO" ] "OTurn" "XTurn" "makeMove" ] // valid
+
+              let report = ConformanceChecker.checkConformance projections records
+
+              Expect.equal report.TotalRecords 3 "TotalRecords"
+              Expect.equal report.ConformantCount 2 "ConformantCount"
+              Expect.equal report.Violations.Length 1 "One violation"
+          }
+
+          test "unrestricted transition passes for all roles" {
+              let records =
+                  [ makeRecord [ "Spectator" ] "XTurn" "XTurn" "getGame"
+                    makeRecord [ "PlayerX" ] "OTurn" "OTurn" "getGame"
+                    makeRecord [ "PlayerO" ] "XWins" "XWins" "getGame" ]
+
+              let report = ConformanceChecker.checkConformance projections records
+
+              Expect.equal report.ConformantCount 3 "All conformant"
+              Expect.isEmpty report.Violations "No violations for unrestricted transitions"
+          } ]

--- a/test/Frank.Provenance.Tests/CustomStoreTests.fs
+++ b/test/Frank.Provenance.Tests/CustomStoreTests.fs
@@ -87,7 +87,8 @@ let private makeRecord (id: string) (resourceUri: string) (agentId: string) (rec
       Activity = activity
       Agent = agent
       GeneratedEntity = generatedEntity
-      UsedEntity = usedEntity }
+      UsedEntity = usedEntity
+      ActingRoles = [] }
 
 let private createLogger () =
     let factory: ILoggerFactory =

--- a/test/Frank.Provenance.Tests/Frank.Provenance.Tests.fsproj
+++ b/test/Frank.Provenance.Tests/Frank.Provenance.Tests.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="IntegrationTests.fs" />
     <Compile Include="SparqlHelpers.fs" />
     <Compile Include="ProvenanceGraphTests.fs" />
+    <Compile Include="ConformanceTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 
@@ -32,6 +33,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/Frank.Provenance/Frank.Provenance.fsproj" />
+    <ProjectReference Include="../../src/Frank.Resources.Model/Frank.Resources.Model.fsproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Frank.Provenance.Tests/GraphBuilderTests.fs
+++ b/test/Frank.Provenance.Tests/GraphBuilderTests.fs
@@ -55,7 +55,8 @@ let private makeRecord (agent: ProvenanceAgent) =
       Activity = activity
       Agent = agent
       GeneratedEntity = generatedEntity
-      UsedEntity = usedEntity }
+      UsedEntity = usedEntity
+      ActingRoles = [] }
 
 let private personAgent =
     { ProvenanceAgent.Id = "urn:frank:agent:alice"
@@ -150,6 +151,35 @@ let graphBuilderTests =
                     Expect.isTrue
                         (hasLiteralTriple graph record.Activity.Id ProvVocabulary.Frank.eventName "Submit")
                         "Activity should have frank:eventName"
+                }
+
+                test "activity has frank:actingRole triples for each role" {
+                    let record =
+                        { makeRecord personAgent with
+                            ActingRoles = [ "PlayerX"; "Spectator" ] }
+
+                    let graph = GraphBuilder.toGraph [ record ]
+
+                    Expect.isTrue
+                        (hasLiteralTriple graph record.Activity.Id ProvVocabulary.Frank.actingRole "PlayerX")
+                        "Activity should have frank:actingRole PlayerX"
+
+                    Expect.isTrue
+                        (hasLiteralTriple graph record.Activity.Id ProvVocabulary.Frank.actingRole "Spectator")
+                        "Activity should have frank:actingRole Spectator"
+                }
+
+                test "activity with no roles emits no frank:actingRole triples" {
+                    let record = makeRecord personAgent
+                    let graph = GraphBuilder.toGraph [ record ]
+
+                    let activityNode = graph.CreateUriNode(UriFactory.Create(record.Activity.Id))
+
+                    let rolePred =
+                        graph.CreateUriNode(UriFactory.Create(ProvVocabulary.Frank.actingRole))
+
+                    let triples = graph.GetTriplesWithSubjectPredicate(activityNode, rolePred).Count()
+                    Expect.equal triples 0 "Activity with no roles should have no frank:actingRole triples"
                 } ]
 
           testList

--- a/test/Frank.Provenance.Tests/IntegrationTests.fs
+++ b/test/Frank.Provenance.Tests/IntegrationTests.fs
@@ -58,7 +58,8 @@ let private makeTransitionEvent
       Timestamp = DateTimeOffset.UtcNow
       User = user
       HttpMethod = "POST"
-      Headers = Map.empty }
+      Headers = Map.empty
+      Roles = [] }
 
 /// Builds a minimal ProvenanceRecord for seeding read-only tests.
 let private makeRecord (resourceUri: string) (prevState: string) (newState: string) (agentId: string) =
@@ -96,7 +97,8 @@ let private makeRecord (resourceUri: string) (prevState: string) (newState: stri
       Activity = activity
       Agent = agent
       GeneratedEntity = generatedEntity
-      UsedEntity = usedEntity }
+      UsedEntity = usedEntity
+      ActingRoles = [] }
 
 /// Creates a full-pipeline test server with:
 ///   - a real MailboxProcessorProvenanceStore (default config)
@@ -447,7 +449,8 @@ let integrationTests =
                                 { ProvenanceEntity.Id = $"gen-{i}"
                                   ResourceUri = "/test/config"
                                   StateName = "B"
-                                  CapturedAt = baseTime.AddSeconds(float i) } }
+                                  CapturedAt = baseTime.AddSeconds(float i) }
+                              ActingRoles = [] }
                         )
 
                     do! Async.Sleep 150

--- a/test/Frank.Provenance.Tests/MiddlewareTests.fs
+++ b/test/Frank.Provenance.Tests/MiddlewareTests.fs
@@ -50,7 +50,8 @@ let private makeRecord resourceUri =
       Activity = activity
       Agent = agent
       GeneratedEntity = generatedEntity
-      UsedEntity = usedEntity }
+      UsedEntity = usedEntity
+      ActingRoles = [] }
 
 /// A simple in-memory IProvenanceStore for testing.
 type private TestProvenanceStore(records: ProvenanceRecord list) =

--- a/test/Frank.Provenance.Tests/ProvenanceGraphTests.fs
+++ b/test/Frank.Provenance.Tests/ProvenanceGraphTests.fs
@@ -48,7 +48,8 @@ let private makeTestProvenanceRecords (resourceUri: string) : ProvenanceRecord l
           Activity = activity
           Agent = agent
           GeneratedEntity = generatedEntity
-          UsedEntity = usedEntity }
+          UsedEntity = usedEntity
+          ActingRoles = [] }
 
     let record2 =
         let activity =
@@ -79,7 +80,8 @@ let private makeTestProvenanceRecords (resourceUri: string) : ProvenanceRecord l
           Activity = activity
           Agent = agent
           GeneratedEntity = generatedEntity
-          UsedEntity = usedEntity }
+          UsedEntity = usedEntity
+          ActingRoles = [] }
 
     [ record1; record2 ]
 

--- a/test/Frank.Provenance.Tests/StoreTests.fs
+++ b/test/Frank.Provenance.Tests/StoreTests.fs
@@ -46,7 +46,8 @@ let private makeRecord id resourceUri agentId (recordedAt: DateTimeOffset) =
       Activity = activity
       Agent = agent
       GeneratedEntity = generatedEntity
-      UsedEntity = usedEntity }
+      UsedEntity = usedEntity
+      ActingRoles = [] }
 
 let private defaultConfig = ProvenanceStoreConfig.defaults
 

--- a/test/Frank.Provenance.Tests/TransitionObserverTests.fs
+++ b/test/Frank.Provenance.Tests/TransitionObserverTests.fs
@@ -60,7 +60,8 @@ type EventBuilder() =
           Timestamp = defaultArg timestamp (DateTimeOffset(2025, 7, 1, 12, 0, 0, TimeSpan.Zero))
           User = user
           HttpMethod = defaultArg httpMethod "POST"
-          Headers = defaultArg headers Map.empty }
+          Headers = defaultArg headers Map.empty
+          Roles = [] }
 
 let private createLogger () =
     let factory: ILoggerFactory =

--- a/test/Frank.Provenance.Tests/TypeTests.fs
+++ b/test/Frank.Provenance.Tests/TypeTests.fs
@@ -130,7 +130,8 @@ let typeTests =
                           Activity = activity
                           Agent = agent
                           GeneratedEntity = generatedEntity
-                          UsedEntity = usedEntity }
+                          UsedEntity = usedEntity
+                          ActingRoles = [] }
 
                     Expect.equal record.Id "record-1" "Id"
                     Expect.equal record.ResourceUri "/orders/123" "ResourceUri"


### PR DESCRIPTION
## Summary

- Add `ActingRoles: string list` to `ProvenanceRecord` and `Roles: string list` to `TransitionEvent` to capture protocol roles held by the acting principal
- New pure `ConformanceChecker.checkConformance` function that verifies provenance records against per-role projected ALPS profiles (output of `Projection.projectAll`)
- Existential conformance: a transition is valid if ANY acting role's projection includes it (MPST capability union semantics)
- Distinguish `TransitionNotInProjection` (role exists, transition missing) from `RoleNotInProjection` (role unknown to protocol) from `NoActingRoles` (no roles recorded)
- Emit `frank:actingRole` triples in PROV-O RDF graph
- Projection-only scope — dual conformance (obligation fulfillment, cut consistency) deferred to v7.4.0

**Breaking change**: `ProvenanceRecord` and `TransitionEvent` have new required fields. Binary-breaking for custom `IProvenanceStore` implementations.

Closes #132

## Test plan

- [x] 9 conformance checker tests: valid trace, single violation, multi-role pass/fail, no roles, unknown role, empty records, mixed trace, unrestricted transitions
- [x] 2 GraphBuilder tests: `frank:actingRole` triple emission for non-empty and empty roles
- [x] All 133 provenance tests pass (was 120 pre-PR)
- [x] All 2074 tests across 16 test assemblies pass
- [x] `dotnet build Frank.sln` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)