### PR TITLE
feat: add projection consistency validator with 4 MPST checks

### DIFF
--- a/src/Frank.Cli.Core/Commands/UnifiedValidateCommand.fs
+++ b/src/Frank.Cli.Core/Commands/UnifiedValidateCommand.fs
@@ -1,0 +1,56 @@
+module Frank.Cli.Core.Commands.UnifiedValidateCommand
+
+open System.IO
+open Frank.Resources.Model
+open Frank.Statecharts.Analysis.ProjectionValidator
+open Frank.Cli.Core.Unified
+open Frank.Cli.Core.Statechart.StatechartError
+
+type UnifiedValidateResult =
+    { ProjectionResults: ProjectionCheckResult list
+      TotalIssues: int
+      TotalErrors: int
+      TotalWarnings: int
+      ResourcesChecked: int
+      FromCache: bool }
+
+let private buildResult (fromCache: bool) (resources: UnifiedResource list) : UnifiedValidateResult =
+    let withRoles =
+        resources
+        |> List.choose (fun r ->
+            r.Statechart
+            |> Option.bind (fun sc -> if sc.Roles.IsEmpty then None else Some(r.RouteTemplate, sc)))
+
+    let results = withRoles |> List.map (fun (route, sc) -> validateProjection route sc)
+
+    let totalIssues = results |> List.sumBy (fun r -> r.Issues.Length)
+
+    let totalErrors =
+        results
+        |> List.sumBy (fun r -> r.Issues |> List.filter (fun i -> i.Severity = Severity.Error) |> List.length)
+
+    let totalWarnings =
+        results
+        |> List.sumBy (fun r -> r.Issues |> List.filter (fun i -> i.Severity = Severity.Warning) |> List.length)
+
+    { ProjectionResults = results
+      TotalIssues = totalIssues
+      TotalErrors = totalErrors
+      TotalWarnings = totalWarnings
+      ResourcesChecked = withRoles.Length
+      FromCache = fromCache }
+
+let execute (projectPath: string) (force: bool) : Async<Result<UnifiedValidateResult, StatechartError>> =
+    async {
+        if not (File.Exists projectPath) then
+            return Error(FileNotFound projectPath)
+        else
+            let projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath))
+
+            match UnifiedCache.tryLoadFresh projectDir force with
+            | Ok state -> return Ok(buildResult true state.Resources)
+            | Error _ ->
+                match! UnifiedExtractor.extract projectPath with
+                | Error e -> return Error e
+                | Ok resources -> return Ok(buildResult false resources)
+    }

--- a/src/Frank.Cli.Core/Frank.Cli.Core.fsproj
+++ b/src/Frank.Cli.Core/Frank.Cli.Core.fsproj
@@ -61,6 +61,7 @@
     <!-- Unified commands -->
     <Compile Include="Commands/UnifiedExtractCommand.fs" />
     <Compile Include="Commands/UnifiedGenerateCommand.fs" />
+    <Compile Include="Commands/UnifiedValidateCommand.fs" />
     <Compile Include="Output/JsonOutput.fs" />
     <Compile Include="Output/TextOutput.fs" />
   </ItemGroup>

--- a/src/Frank.Cli.Core/Output/JsonOutput.fs
+++ b/src/Frank.Cli.Core/Output/JsonOutput.fs
@@ -235,32 +235,42 @@ module JsonOutput =
         writeString writer "stateDirectory" result.StateDirectory
 
         writer.WriteStartObject("extraction")
+
         let extractionState =
             match result.Extraction with
             | ExtractionStatus.NotExtracted -> "not_extracted"
             | ExtractionStatus.Current -> "current"
             | ExtractionStatus.Stale -> "stale"
             | ExtractionStatus.Unreadable _ -> "unreadable"
+
         writeString writer "state" extractionState
         writer.WriteEndObject()
 
         writer.WriteStartObject("artifacts")
+
         let artifactState =
             match result.Artifacts with
             | ArtifactStatus.Present -> "present"
             | ArtifactStatus.Missing _ -> "missing"
+
         writeString writer "state" artifactState
+
         match result.Artifacts with
         | ArtifactStatus.Present ->
             writer.WriteStartArray("files")
             writer.WriteEndArray()
         | ArtifactStatus.Missing missing ->
             writer.WriteStartArray("missingFiles")
-            for f in missing do writer.WriteStringValue(f)
+
+            for f in missing do
+                writer.WriteStringValue(f)
+
             writer.WriteEndArray()
+
         writer.WriteEndObject()
 
         writer.WriteStartObject("recommendedAction")
+
         let (action, message) =
             match result.RecommendedAction with
             | RecommendedAction.RunExtract -> ("run_extract", "Run extract to begin")
@@ -268,6 +278,7 @@ module JsonOutput =
             | RecommendedAction.RunCompile -> ("run_compile", "Run compile to generate artifacts")
             | RecommendedAction.UpToDate -> ("up_to_date", "No action needed")
             | RecommendedAction.RecoverExtract reason -> ("recover_extract", $"Re-extract to recover: {reason}")
+
         writeString writer "action" action
         writeString writer "message" message
         writer.WriteEndObject()
@@ -281,18 +292,22 @@ module JsonOutput =
         use writer = new Utf8JsonWriter(stream, JsonWriterOptions(Indented = true))
         writer.WriteStartObject()
         writer.WriteStartArray("commands")
+
         for (name, summary) in index.Commands do
             writer.WriteStartObject()
             writeString writer "name" name
             writeString writer "summary" summary
             writer.WriteEndObject()
+
         writer.WriteEndArray()
         writer.WriteStartArray("topics")
+
         for (name, summary) in index.Topics do
             writer.WriteStartObject()
             writeString writer "name" name
             writeString writer "summary" summary
             writer.WriteEndObject()
+
         writer.WriteEndArray()
         writer.WriteEndObject()
         writer.Flush()
@@ -316,6 +331,7 @@ module JsonOutput =
         writeString writer "status" "not_found"
         writeString writer "query" query
         writer.WriteStartArray("suggestions")
+
         for name in suggestions do
             writer.WriteStartObject()
             writeString writer "name" name
@@ -330,7 +346,9 @@ module JsonOutput =
                     writeString writer "summary" topic.Summary
                     writeString writer "type" "topic"
                 | None -> ()
+
             writer.WriteEndObject()
+
         writer.WriteEndArray()
         writer.WriteEndObject()
         writer.Flush()
@@ -362,8 +380,10 @@ module JsonOutput =
 
         if not result.GenerationErrors.IsEmpty then
             writer.WriteStartArray("generationErrors")
+
             for err in result.GenerationErrors do
                 writer.WriteStringValue(Frank.Cli.Core.Statechart.StatechartError.formatError err)
+
             writer.WriteEndArray()
 
         writer.WriteEndObject()
@@ -392,29 +412,87 @@ module JsonOutput =
         writer.WriteStartObject()
         writeString writer "status" "ok"
         writer.WriteStartArray("stateMachines")
+
         for sm in result.StateMachines do
             writer.WriteStartObject()
             writeString writer "routeTemplate" sm.RouteTemplate
             writeString writer "initialState" sm.InitialStateKey
             writer.WriteStartArray("states")
-            for s in sm.StateNames do writer.WriteStringValue(s)
+
+            for s in sm.StateNames do
+                writer.WriteStringValue(s)
+
             writer.WriteEndArray()
             writer.WriteStartArray("guards")
-            for g in sm.GuardNames do writer.WriteStringValue(g)
+
+            for g in sm.GuardNames do
+                writer.WriteStringValue(g)
+
             writer.WriteEndArray()
             writer.WriteStartObject("stateMetadata")
+
             for KeyValue(name, info) in sm.StateMetadata do
                 writer.WriteStartObject(name)
                 writer.WriteStartArray("allowedMethods")
-                for m in info.AllowedMethods do writer.WriteStringValue(m)
+
+                for m in info.AllowedMethods do
+                    writer.WriteStringValue(m)
+
                 writer.WriteEndArray()
                 writer.WriteBoolean("isFinal", info.IsFinal)
+
                 match info.Description with
                 | Some d -> writeString writer "description" d
                 | None -> writer.WriteNull("description")
+
                 writer.WriteEndObject()
+
             writer.WriteEndObject()
             writer.WriteEndObject()
+
+        writer.WriteEndArray()
+        writer.WriteEndObject()
+        writer.Flush()
+        Encoding.UTF8.GetString(stream.ToArray())
+
+    let formatUnifiedValidateResult (result: UnifiedValidateCommand.UnifiedValidateResult) : string =
+        use stream = new MemoryStream()
+        use writer = new Utf8JsonWriter(stream, JsonWriterOptions(Indented = true))
+        writer.WriteStartObject()
+        writeString writer "status" (if result.TotalErrors > 0 then "fail" else "ok")
+        writer.WriteBoolean("fromCache", result.FromCache)
+        writeNumber writer "resourcesChecked" result.ResourcesChecked
+        writeNumber writer "totalIssues" result.TotalIssues
+        writeNumber writer "totalErrors" result.TotalErrors
+        writeNumber writer "totalWarnings" result.TotalWarnings
+        writer.WriteStartArray("results")
+
+        for r in result.ProjectionResults do
+            writer.WriteStartObject()
+            writeString writer "resourceRoute" r.ResourceRoute
+            writeNumber writer "checksRun" r.ChecksRun
+            writer.WriteStartArray("issues")
+
+            for issue in r.Issues do
+                writer.WriteStartObject()
+
+                writeString
+                    writer
+                    "check"
+                    (Frank.Statecharts.Analysis.ProjectionValidator.ProjectionCheckKind.toString issue.Check)
+
+                let severity =
+                    match issue.Severity with
+                    | Frank.Statecharts.Analysis.ProjectionValidator.Severity.Error -> "error"
+                    | Frank.Statecharts.Analysis.ProjectionValidator.Severity.Warning -> "warning"
+
+                writeString writer "severity" severity
+                writeString writer "message" issue.Message
+                writer.WriteEndObject()
+
+            writer.WriteEndArray()
+            writer.WriteEndObject()
+
         writer.WriteEndArray()
         writer.WriteEndObject()
         writer.Flush()

--- a/src/Frank.Cli.Core/Output/TextOutput.fs
+++ b/src/Frank.Cli.Core/Output/TextOutput.fs
@@ -6,6 +6,7 @@ open Frank.Cli.Core.Help
 
 module TextOutput =
 
+    open Frank.Statecharts.Analysis
     open Frank.Cli.Core.Output.AnsiColors
 
     let formatExtractResult (result: ExtractCommand.ExtractResult) : string =
@@ -154,6 +155,7 @@ module TextOutput =
             | ExtractionStatus.Current -> "current"
             | ExtractionStatus.Stale -> "stale (source files changed since extraction)"
             | ExtractionStatus.Unreadable reason -> $"unreadable ({reason})"
+
         sb.AppendLine($"Extraction: {extractionText}") |> ignore
 
         let artifactText =
@@ -163,36 +165,45 @@ module TextOutput =
                 | ExtractionStatus.Stale -> "present (may be outdated)"
                 | _ -> "present"
             | ArtifactStatus.Missing _ -> "not present"
+
         sb.AppendLine($"Artifacts: {artifactText}") |> ignore
 
         let actionText =
             match result.RecommendedAction with
-            | RecommendedAction.RunExtract ->
-                $"run 'frank extract --project {result.ProjectPath} --base-uri <URI>'"
-            | RecommendedAction.ReExtract ->
-                $"run 'frank extract --project {result.ProjectPath} --base-uri <URI>'"
-            | RecommendedAction.RunCompile ->
-                $"run 'frank compile --project {result.ProjectPath}'"
+            | RecommendedAction.RunExtract -> $"run 'frank extract --project {result.ProjectPath} --base-uri <URI>'"
+            | RecommendedAction.ReExtract -> $"run 'frank extract --project {result.ProjectPath} --base-uri <URI>'"
+            | RecommendedAction.RunCompile -> $"run 'frank compile --project {result.ProjectPath}'"
             | RecommendedAction.UpToDate -> "up to date (no action needed)"
             | RecommendedAction.RecoverExtract _ ->
                 $"run 'frank extract --project {result.ProjectPath} --base-uri <URI>' to recover"
+
         sb.AppendLine($"Recommended action: {actionText}") |> ignore
 
         sb.ToString()
 
     let formatHelpIndex (index: HelpSubcommand.HelpIndex) : string =
         let sb = System.Text.StringBuilder()
-        sb.AppendLine("frank: Semantic resource extraction for Frank applications") |> ignore
+
+        sb.AppendLine("frank: Semantic resource extraction for Frank applications")
+        |> ignore
+
         sb.AppendLine() |> ignore
         sb.AppendLine("COMMANDS") |> ignore
+
         for (name, summary) in index.Commands do
             sb.AppendLine(sprintf "  %-12s%s" name summary) |> ignore
+
         sb.AppendLine() |> ignore
         sb.AppendLine("TOPICS") |> ignore
+
         for (name, summary) in index.Topics do
             sb.AppendLine(sprintf "  %-12s%s" name summary) |> ignore
+
         sb.AppendLine() |> ignore
-        sb.AppendLine("Use 'frank help <command>' for detailed help on a command.") |> ignore
+
+        sb.AppendLine("Use 'frank help <command>' for detailed help on a command.")
+        |> ignore
+
         sb.AppendLine("Use 'frank help <topic>' for topic documentation.") |> ignore
         sb.ToString()
 
@@ -206,9 +217,11 @@ module TextOutput =
     let formatNoMatch (query: string) (suggestions: string list) : string =
         let sb = System.Text.StringBuilder()
         sb.AppendLine($"Unknown command or topic: '{query}'") |> ignore
+
         if not suggestions.IsEmpty then
             sb.AppendLine() |> ignore
             sb.AppendLine("Did you mean?") |> ignore
+
             for name in suggestions do
                 match HelpContent.findCommand name with
                 | Some cmd -> sb.AppendLine(sprintf "  %-12s%s" name cmd.Summary) |> ignore
@@ -216,6 +229,7 @@ module TextOutput =
                     match HelpContent.findTopic name with
                     | Some topic -> sb.AppendLine(sprintf "  %-12s%s" name topic.Summary) |> ignore
                     | None -> sb.AppendLine($"  {name}") |> ignore
+
         sb.AppendLine() |> ignore
         sb.AppendLine("Use 'frank help' to see all commands and topics.") |> ignore
         sb.ToString()
@@ -248,9 +262,13 @@ module TextOutput =
 
             if not result.GenerationErrors.IsEmpty then
                 sb.AppendLine() |> ignore
-                sb.AppendLine(red (sprintf "Generation errors (%d):" result.GenerationErrors.Length)) |> ignore
+
+                sb.AppendLine(red (sprintf "Generation errors (%d):" result.GenerationErrors.Length))
+                |> ignore
+
                 for err in result.GenerationErrors do
-                    sb.AppendLine(sprintf "  - %s" (Frank.Cli.Core.Statechart.StatechartError.formatError err)) |> ignore
+                    sb.AppendLine(sprintf "  - %s" (Frank.Cli.Core.Statechart.StatechartError.formatError err))
+                    |> ignore
 
             sb.ToString()
 
@@ -270,26 +288,68 @@ module TextOutput =
             "No state machines found in the assembly."
         else
             let sb = System.Text.StringBuilder()
+
             for sm in result.StateMachines do
                 let header = bold (sprintf "Statechart: %s" sm.RouteTemplate)
                 sb.AppendLine(header) |> ignore
                 sb.AppendLine(sprintf "  Initial State: %s" sm.InitialStateKey) |> ignore
                 let stateList = sm.StateNames |> String.concat ", "
                 sb.AppendLine(sprintf "  States: %s" stateList) |> ignore
+
                 if not sm.GuardNames.IsEmpty then
                     let guardList = sm.GuardNames |> String.concat ", "
                     sb.AppendLine(sprintf "  Guards: %s" guardList) |> ignore
+
                 sb.AppendLine("  State Details:") |> ignore
+
                 for KeyValue(name, info) in sm.StateMetadata do
                     sb.AppendLine(sprintf "    %s:" name) |> ignore
                     let methods = info.AllowedMethods |> String.concat ", "
                     sb.AppendLine(sprintf "      Methods: %s" methods) |> ignore
                     sb.AppendLine(sprintf "      Final: %b" info.IsFinal) |> ignore
+
                     match info.Description with
                     | Some desc -> sb.AppendLine(sprintf "      Description: %s" desc) |> ignore
                     | None -> ()
+
                 sb.AppendLine() |> ignore
+
             sb.ToString()
+
+    let formatUnifiedValidateResult (result: UnifiedValidateCommand.UnifiedValidateResult) : string =
+        let sb = System.Text.StringBuilder()
+        let appendLine (s: string) = sb.AppendLine(s) |> ignore
+
+        let statusText = if result.TotalErrors > 0 then red "FAIL" else green "PASS"
+
+        appendLine (bold (sprintf "Projection Validation: %s" statusText))
+        appendLine ""
+        appendLine $"Resources checked: {result.ResourcesChecked}"
+
+        let totalChecks = result.ProjectionResults |> List.sumBy _.ChecksRun
+
+        appendLine $"Checks run: {totalChecks}"
+        appendLine $"Issues: {result.TotalIssues} ({result.TotalErrors} errors, {result.TotalWarnings} warnings)"
+
+        for r in result.ProjectionResults do
+            if not r.Issues.IsEmpty then
+                appendLine ""
+                appendLine $"  {r.ResourceRoute}:"
+
+                for issue in r.Issues do
+                    let prefix =
+                        match issue.Severity with
+                        | ProjectionValidator.Severity.Error -> red "ERROR"
+                        | ProjectionValidator.Severity.Warning -> yellow "WARN"
+
+                    let checkName = ProjectionValidator.ProjectionCheckKind.toString issue.Check
+                    appendLine $"    [%s{prefix}] %s{checkName}: %s{issue.Message}"
+
+        if result.FromCache then
+            appendLine ""
+            appendLine "(from cache)"
+
+        sb.ToString()
 
     let formatUnifiedExtractResult (result: UnifiedExtractCommand.UnifiedExtractResult) : string =
         let sb = System.Text.StringBuilder()
@@ -314,8 +374,7 @@ module TextOutput =
 
             match resource.Statechart with
             | None ->
-                let methods =
-                    resource.HttpCapabilities |> List.map _.Method |> String.concat ", "
+                let methods = resource.HttpCapabilities |> List.map _.Method |> String.concat ", "
 
                 appendLine $"    Methods: {methods}"
             | Some sc ->

--- a/src/Frank.Cli/Program.fs
+++ b/src/Frank.Cli/Program.fs
@@ -10,8 +10,7 @@ open Frank.Cli.Core.Unified
 
 [<EntryPoint>]
 let main args =
-    let root =
-        RootCommand("frank: Semantic resource extraction for Frank applications")
+    let root = RootCommand("frank: Semantic resource extraction for Frank applications")
 
     // ── semantic (parent) ──
     let semanticCmd = Command("semantic")
@@ -361,8 +360,10 @@ let main args =
             Environment.ExitCode <- 1
 
             let output =
-                if format = "json" then JsonOutput.formatStatechartError e
-                else TextOutput.formatStatechartError e
+                if format = "json" then
+                    JsonOutput.formatStatechartError e
+                else
+                    TextOutput.formatStatechartError e
 
             Console.Error.WriteLine(output))
 
@@ -413,7 +414,11 @@ let main args =
 
         let genBaseUri =
             let v = parseResult.GetValue(scGenBaseUriOpt)
-            if String.IsNullOrEmpty v then "http://localhost:5000/alps" else v
+
+            if String.IsNullOrEmpty v then
+                "http://localhost:5000/alps"
+            else
+                v
 
         let outputFormat = parseResult.GetValue(scGenOutputFormatOpt)
 
@@ -425,8 +430,7 @@ let main args =
         | Ok r ->
             // If affordance-map JSON is present, output it directly
             match r.AffordanceMapJson with
-            | Some json ->
-                Console.WriteLine(json)
+            | Some json -> Console.WriteLine(json)
             | None ->
                 if outputDir.IsNone then
                     for artifact in r.Artifacts do
@@ -446,14 +450,17 @@ let main args =
             // Report generation errors
             if not r.GenerationErrors.IsEmpty then
                 Environment.ExitCode <- 1
+
                 for err in r.GenerationErrors do
                     Console.Error.WriteLine(StatechartError.formatError err)
         | Error e ->
             Environment.ExitCode <- 1
 
             let output =
-                if outputFormat = "json" then JsonOutput.formatStatechartError e
-                else TextOutput.formatStatechartError e
+                if outputFormat = "json" then
+                    JsonOutput.formatStatechartError e
+                else
+                    TextOutput.formatStatechartError e
 
             Console.Error.WriteLine(output))
 
@@ -495,8 +502,10 @@ let main args =
             Environment.ExitCode <- 1
 
             let output =
-                if format = "json" then JsonOutput.formatStatechartError e
-                else TextOutput.formatStatechartError e
+                if format = "json" then
+                    JsonOutput.formatStatechartError e
+                else
+                    TextOutput.formatStatechartError e
 
             Console.Error.WriteLine(output))
 
@@ -511,7 +520,10 @@ let main args =
     scParseCmd.Arguments.Add(scParseFileArg)
 
     let scParseFormatOpt = Option<string>("--format")
-    scParseFormatOpt.Description <- "Notation format override (wsd|alps|scxml|smcat|xstate) for ambiguous file extensions"
+
+    scParseFormatOpt.Description <-
+        "Notation format override (wsd|alps|scxml|smcat|xstate) for ambiguous file extensions"
+
     scParseCmd.Options.Add(scParseFormatOpt)
 
     let scParseOutputFormatOpt = Option<string>("--output-format")
@@ -532,7 +544,9 @@ let main args =
         match result with
         | Ok r ->
             // Parse output is always JSON (the document IS the content)
-            let output = StatechartDocumentJson.serializeParseResultWithFormat r.ParseResult r.Format
+            let output =
+                StatechartDocumentJson.serializeParseResultWithFormat r.ParseResult r.Format
+
             Console.WriteLine(output)
 
             if r.HasErrors then
@@ -541,8 +555,10 @@ let main args =
             Environment.ExitCode <- 1
 
             let output =
-                if outputFormat = "json" then JsonOutput.formatStatechartError e
-                else TextOutput.formatStatechartError e
+                if outputFormat = "json" then
+                    JsonOutput.formatStatechartError e
+                else
+                    TextOutput.formatStatechartError e
 
             Console.Error.WriteLine(output))
 
@@ -550,7 +566,9 @@ let main args =
 
     // ── extract (top-level, unified) ──
     let uniExtractCmd = Command("extract")
-    uniExtractCmd.Description <- "Extract unified resource descriptions from F# source (replaces semantic extract + statechart extract)"
+
+    uniExtractCmd.Description <-
+        "Extract unified resource descriptions from F# source (replaces semantic extract + statechart extract)"
 
     let uniExtractProjectOpt = Option<string>("--project")
     uniExtractProjectOpt.Description <- "Path to .fsproj file"
@@ -601,7 +619,9 @@ let main args =
 
     // ── generate (top-level, unified) ──
     let uniGenCmd = Command("generate")
-    uniGenCmd.Description <- "Generate format artifacts from unified extraction (wsd, alps, scxml, smcat, xstate, affordance-map, all)"
+
+    uniGenCmd.Description <-
+        "Generate format artifacts from unified extraction (wsd, alps, scxml, smcat, xstate, affordance-map, all)"
 
     let uniGenProjectOpt = Option<string>("--project")
     uniGenProjectOpt.Description <- "Path to .fsproj file"
@@ -651,6 +671,62 @@ let main args =
             Console.Error.WriteLine(StatechartError.formatError e))
 
     root.Subcommands.Add(uniGenCmd)
+
+    // ── validate (top-level, unified) ──
+    let uniValCmd = Command("validate")
+
+    uniValCmd.Description <- "Validate projection consistency for stateful resources with roles"
+
+    let uniValProjectOpt = Option<string>("--project")
+    uniValProjectOpt.Description <- "Path to .fsproj file"
+    uniValProjectOpt.Required <- true
+    let uniValCheckProjectionOpt = Option<bool>("--check-projection")
+
+    uniValCheckProjectionOpt.Description <-
+        "Run projection consistency checks (connectedness, mixed-choice, completeness, deadlock)"
+
+    uniValCheckProjectionOpt.DefaultValueFactory <- (fun _ -> false)
+    let uniValForceOpt = Option<bool>("--force")
+    uniValForceOpt.Description <- "Force re-extraction, bypassing cache"
+    uniValForceOpt.DefaultValueFactory <- (fun _ -> false)
+    let uniValFormatOpt = Option<string>("--output-format")
+    uniValFormatOpt.Description <- "Output format (text|json)"
+    uniValFormatOpt.DefaultValueFactory <- (fun _ -> "text")
+    uniValCmd.Options.Add(uniValProjectOpt)
+    uniValCmd.Options.Add(uniValCheckProjectionOpt)
+    uniValCmd.Options.Add(uniValForceOpt)
+    uniValCmd.Options.Add(uniValFormatOpt)
+
+    uniValCmd.SetAction(fun parseResult ->
+        let project = parseResult.GetValue(uniValProjectOpt)
+        let checkProjection = parseResult.GetValue(uniValCheckProjectionOpt)
+        let force = parseResult.GetValue(uniValForceOpt)
+        let format = parseResult.GetValue(uniValFormatOpt)
+
+        if not checkProjection then
+            Console.Error.WriteLine("No checks specified. Available flags: --check-projection")
+
+            Environment.ExitCode <- 1
+        else
+            let result = UnifiedValidateCommand.execute project force |> Async.RunSynchronously
+
+            match result with
+            | Ok valResult ->
+                let output =
+                    if format = "json" then
+                        JsonOutput.formatUnifiedValidateResult valResult
+                    else
+                        TextOutput.formatUnifiedValidateResult valResult
+
+                Console.WriteLine(output)
+
+                if valResult.TotalErrors > 0 then
+                    Environment.ExitCode <- 1
+            | Error e ->
+                Environment.ExitCode <- 1
+                Console.Error.WriteLine(StatechartError.formatError e))
+
+    root.Subcommands.Add(uniValCmd)
 
     // ── status (top-level) ──
     let statusCmd = Command("status")

--- a/src/Frank.Statecharts/Analysis/ProjectionValidator.fs
+++ b/src/Frank.Statecharts/Analysis/ProjectionValidator.fs
@@ -1,0 +1,141 @@
+module Frank.Statecharts.Analysis.ProjectionValidator
+
+open Frank.Resources.Model
+
+[<RequireQualifiedAccess>]
+type Severity =
+    | Error
+    | Warning
+
+type ProjectionCheckKind =
+    | Connectedness
+    | MixedChoice
+    | Completeness
+    | Deadlock
+
+module ProjectionCheckKind =
+    let toString =
+        function
+        | Connectedness -> "connectedness"
+        | MixedChoice -> "mixed-choice"
+        | Completeness -> "completeness"
+        | Deadlock -> "deadlock"
+
+type ProjectionIssue =
+    { Check: ProjectionCheckKind
+      Severity: Severity
+      Message: string }
+
+type ProjectionCheckResult =
+    { Issues: ProjectionIssue list
+      ChecksRun: int
+      ResourceRoute: string }
+
+/// Pre-projection: every transition must be reachable by at least one role.
+/// RestrictedTo [] means no role can trigger it; stale role names are flagged.
+let checkConnectedness (statechart: ExtractedStatechart) : ProjectionIssue list =
+    let knownRoles = statechart.Roles |> List.map _.Name |> Set.ofList
+
+    statechart.Transitions
+    |> List.collect (fun t ->
+        match t.Constraint with
+        | Unrestricted -> []
+        | RestrictedTo [] ->
+            [ { Check = Connectedness
+                Severity = Severity.Error
+                Message =
+                  $"Transition '%s{t.Event}' (%s{t.Source} -> %s{t.Target}) has no role assignment (RestrictedTo [])" } ]
+        | RestrictedTo roles ->
+            roles
+            |> List.choose (fun role ->
+                if Set.contains role knownRoles then
+                    None
+                else
+                    Some
+                        { Check = Connectedness
+                          Severity = Severity.Error
+                          Message =
+                            $"Transition '%s{t.Event}' (%s{t.Source} -> %s{t.Target}) references unknown role '%s{role}'" }))
+
+/// Pre-projection: warn when different roles have exclusive transitions from the same state.
+/// Only RestrictedTo transitions contribute; Unrestricted transitions are fine.
+let checkMixedChoice (statechart: ExtractedStatechart) : ProjectionIssue list =
+    statechart.Transitions
+    |> List.choose (fun t ->
+        match t.Constraint with
+        | RestrictedTo roles when not roles.IsEmpty -> Some(t.Source, roles)
+        | _ -> None)
+    |> List.groupBy fst
+    |> List.collect (fun (source, entries) ->
+        let distinctRoles = entries |> List.collect snd |> List.distinct
+
+        if distinctRoles.Length > 1 then
+            let roleNames = String.concat ", " distinctRoles
+
+            [ { Check = MixedChoice
+                Severity = Severity.Warning
+                Message = $"State '%s{source}' has restricted transitions from multiple roles: %s{roleNames}" } ]
+        else
+            [])
+
+/// Post-projection: every pruned global transition must appear in at least one role's projection.
+let checkCompleteness
+    (projections: Map<string, ExtractedStatechart>)
+    (pruned: ExtractedStatechart)
+    : ProjectionIssue list =
+    let orphans = Projection.findOrphanedTransitions pruned projections
+
+    orphans
+    |> List.map (fun t ->
+        { Check = Completeness
+          Severity = Severity.Error
+          Message = $"Transition '%s{t.Event}' (%s{t.Source} -> %s{t.Target}) is not covered by any role's projection" })
+
+/// Post-projection: warn when a reachable non-final state has no outgoing transitions
+/// in any role's projection. This checks whether *any* role can advance the state machine
+/// (sufficient for HTTP where state is server-side), not per-role progress (which is #108).
+let checkDeadlock (projections: Map<string, ExtractedStatechart>) (pruned: ExtractedStatechart) : ProjectionIssue list =
+    let isFinal state =
+        pruned.StateMetadata
+        |> Map.tryFind state
+        |> Option.map _.IsFinal
+        |> Option.defaultValue false
+
+    let roleOutgoing =
+        projections
+        |> Map.values
+        |> Seq.collect _.Transitions
+        |> Seq.map _.Source
+        |> Set.ofSeq
+
+    pruned.StateNames
+    |> List.choose (fun state ->
+        if isFinal state then
+            None
+        elif Set.contains state roleOutgoing then
+            None
+        else
+            Some
+                { Check = Deadlock
+                  Severity = Severity.Warning
+                  Message = $"State '%s{state}' is reachable but no role has outgoing transitions from it" })
+
+/// Run all 4 projection checks. Returns 0 checks if statechart has no roles.
+let validateProjection (resourceRoute: string) (statechart: ExtractedStatechart) : ProjectionCheckResult =
+    if statechart.Roles.IsEmpty then
+        { Issues = []
+          ChecksRun = 0
+          ResourceRoute = resourceRoute }
+    else
+        let projections = Projection.projectAll statechart
+        let pruned = Projection.pruneUnreachableStates statechart
+
+        let issues =
+            [ yield! checkConnectedness statechart
+              yield! checkMixedChoice statechart
+              yield! checkCompleteness projections pruned
+              yield! checkDeadlock projections pruned ]
+
+        { Issues = issues
+          ChecksRun = 4
+          ResourceRoute = resourceRoute }

--- a/src/Frank.Statecharts/Frank.Statecharts.fsproj
+++ b/src/Frank.Statecharts/Frank.Statecharts.fsproj
@@ -47,6 +47,8 @@
     <Compile Include="Validation/StringDistance.fs" />
     <Compile Include="Validation/Validator.fs" />
     <Compile Include="Validation/Pipeline.fs" />
+    <!-- Projection analysis -->
+    <Compile Include="Analysis/ProjectionValidator.fs" />
     <!-- Builder and generators (depend on both core types and format types) -->
     <Compile Include="StatechartFeature.fs" />
     <Compile Include="RoleFeature.fs" />

--- a/test/Frank.Statecharts.Tests/Analysis/ProjectionValidatorTests.fs
+++ b/test/Frank.Statecharts.Tests/Analysis/ProjectionValidatorTests.fs
@@ -1,0 +1,229 @@
+module Frank.Statecharts.Tests.Analysis.ProjectionValidatorTests
+
+open Expecto
+open Frank.Resources.Model
+open Frank.Statecharts.Analysis.ProjectionValidator
+
+// -- Test fixtures --
+
+let private mkTransition event source target guard roleConstraint =
+    { Event = event
+      Source = source
+      Target = target
+      Guard = guard
+      Constraint = roleConstraint }
+
+let private ticTacToeChart: ExtractedStatechart =
+    { RouteTemplate = "/games/{gameId}"
+      StateNames = [ "XTurn"; "OTurn"; "XWins"; "OWins"; "Draw" ]
+      InitialStateKey = "XTurn"
+      GuardNames = [ "TurnGuard" ]
+      StateMetadata =
+        Map.ofList
+            [ "XTurn", { AllowedMethods = [ "GET"; "PUT" ]; IsFinal = false; Description = None }
+              "OTurn", { AllowedMethods = [ "GET"; "PUT" ]; IsFinal = false; Description = None }
+              "XWins", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None }
+              "OWins", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None }
+              "Draw", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None } ]
+      Roles =
+        [ { Name = "PlayerX"; Description = Some "Player X" }
+          { Name = "PlayerO"; Description = Some "Player O" }
+          { Name = "Spectator"; Description = Some "Observer" } ]
+      Transitions =
+        [ mkTransition "getGame" "XTurn" "XTurn" None Unrestricted
+          mkTransition "getGame" "OTurn" "OTurn" None Unrestricted
+          mkTransition "getGame" "XWins" "XWins" None Unrestricted
+          mkTransition "getGame" "OWins" "OWins" None Unrestricted
+          mkTransition "getGame" "Draw" "Draw" None Unrestricted
+          mkTransition "makeMove" "XTurn" "OTurn" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "XTurn" "XWins" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "XTurn" "Draw" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "OTurn" "XTurn" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ])
+          mkTransition "makeMove" "OTurn" "OWins" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ])
+          mkTransition "makeMove" "OTurn" "Draw" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ]) ] }
+
+let private deadTransitionChart: ExtractedStatechart =
+    { RouteTemplate = "/items"
+      StateNames = [ "Active"; "Archived" ]
+      InitialStateKey = "Active"
+      GuardNames = [ "DeadGuard" ]
+      StateMetadata =
+        Map.ofList
+            [ "Active", { AllowedMethods = [ "GET" ]; IsFinal = false; Description = None }
+              "Archived", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None } ]
+      Roles = [ { Name = "Admin"; Description = None } ]
+      Transitions =
+        [ mkTransition "getItem" "Active" "Active" None Unrestricted
+          mkTransition "archive" "Active" "Archived" (Some "DeadGuard") (RestrictedTo []) ] }
+
+let private mixedChoiceChart: ExtractedStatechart =
+    { RouteTemplate = "/orders/{orderId}"
+      StateNames = [ "Pending"; "Approved"; "Rejected" ]
+      InitialStateKey = "Pending"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "Pending", { AllowedMethods = [ "GET"; "PUT" ]; IsFinal = false; Description = None }
+              "Approved", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None }
+              "Rejected", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None } ]
+      Roles =
+        [ { Name = "Manager"; Description = None }
+          { Name = "Clerk"; Description = None } ]
+      Transitions =
+        [ mkTransition "view" "Pending" "Pending" None Unrestricted
+          mkTransition "approve" "Pending" "Approved" None (RestrictedTo [ "Manager" ])
+          mkTransition "reject" "Pending" "Rejected" None (RestrictedTo [ "Clerk" ]) ] }
+
+let private deadlockChart: ExtractedStatechart =
+    { RouteTemplate = "/tasks/{taskId}"
+      StateNames = [ "Open"; "Blocked"; "Done" ]
+      InitialStateKey = "Open"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "Open", { AllowedMethods = [ "GET"; "PUT" ]; IsFinal = false; Description = None }
+              "Blocked", { AllowedMethods = [ "GET" ]; IsFinal = false; Description = None }
+              "Done", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None } ]
+      Roles =
+        [ { Name = "Worker"; Description = None }
+          { Name = "Reviewer"; Description = None } ]
+      Transitions =
+        [ mkTransition "view" "Open" "Open" None Unrestricted
+          mkTransition "block" "Open" "Blocked" None (RestrictedTo [ "Worker" ])
+          mkTransition "complete" "Open" "Done" None (RestrictedTo [ "Worker" ]) ] }
+
+let private staleRoleChart: ExtractedStatechart =
+    { RouteTemplate = "/docs/{docId}"
+      StateNames = [ "Draft"; "Published" ]
+      InitialStateKey = "Draft"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "Draft", { AllowedMethods = [ "GET"; "PUT" ]; IsFinal = false; Description = None }
+              "Published", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None } ]
+      Roles = [ { Name = "Editor"; Description = None } ]
+      Transitions =
+        [ mkTransition "view" "Draft" "Draft" None Unrestricted
+          mkTransition "publish" "Draft" "Published" None (RestrictedTo [ "Ghost" ]) ] }
+
+// -- Tests --
+
+[<Tests>]
+let connectednessTests =
+    testList
+        "ProjectionValidator.checkConnectedness"
+        [ testCase "TicTacToe has no connectedness issues"
+          <| fun _ ->
+              let issues = checkConnectedness ticTacToeChart
+              Expect.isEmpty issues "All transitions have roles"
+
+          testCase "RestrictedTo [] produces error"
+          <| fun _ ->
+              let issues = checkConnectedness deadTransitionChart
+              Expect.equal issues.Length 1 "One dead transition"
+              Expect.equal issues[0].Severity Severity.Error "Severity is Error"
+              Expect.stringContains issues[0].Message "archive" "Mentions the transition"
+
+          testCase "stale role reference produces error"
+          <| fun _ ->
+              let issues = checkConnectedness staleRoleChart
+              Expect.equal issues.Length 1 "One stale reference"
+              Expect.stringContains issues[0].Message "Ghost" "Mentions the unknown role" ]
+
+[<Tests>]
+let mixedChoiceTests =
+    testList
+        "ProjectionValidator.checkMixedChoice"
+        [ testCase "TicTacToe has no mixed choice"
+          <| fun _ ->
+              let issues = checkMixedChoice ticTacToeChart
+              Expect.isEmpty issues "Each state has only one role's restricted transitions"
+
+          testCase "different roles from same state produces warning"
+          <| fun _ ->
+              let issues = checkMixedChoice mixedChoiceChart
+              Expect.equal issues.Length 1 "One mixed-choice warning"
+              Expect.equal issues[0].Severity Severity.Warning "Severity is Warning"
+              Expect.stringContains issues[0].Message "Pending" "Mentions the state"
+
+          testCase "only unrestricted transitions produce no warnings"
+          <| fun _ ->
+              let chart =
+                  { ticTacToeChart with
+                      Transitions =
+                          ticTacToeChart.Transitions
+                          |> List.filter (fun t -> t.Constraint = Unrestricted) }
+
+              let issues = checkMixedChoice chart
+              Expect.isEmpty issues "Unrestricted transitions don't count" ]
+
+[<Tests>]
+let completenessTests =
+    testList
+        "ProjectionValidator.checkCompleteness"
+        [ testCase "TicTacToe is fully covered"
+          <| fun _ ->
+              let projections = Projection.projectAll ticTacToeChart
+              let pruned = Projection.pruneUnreachableStates ticTacToeChart
+              let issues = checkCompleteness projections pruned
+              Expect.isEmpty issues "All transitions covered"
+
+          testCase "dead transition is orphaned"
+          <| fun _ ->
+              let projections = Projection.projectAll deadTransitionChart
+              let pruned = Projection.pruneUnreachableStates deadTransitionChart
+              let issues = checkCompleteness projections pruned
+              Expect.equal issues.Length 1 "One orphaned transition"
+              Expect.stringContains issues[0].Message "archive" "Mentions the transition"
+              Expect.equal issues[0].Severity Severity.Error "Severity is Error" ]
+
+[<Tests>]
+let deadlockTests =
+    testList
+        "ProjectionValidator.checkDeadlock"
+        [ testCase "TicTacToe has no deadlocks"
+          <| fun _ ->
+              let projections = Projection.projectAll ticTacToeChart
+              let pruned = Projection.pruneUnreachableStates ticTacToeChart
+              let issues = checkDeadlock projections pruned
+              Expect.isEmpty issues "All non-final states have role transitions"
+
+          testCase "non-final state with no role outgoing is flagged"
+          <| fun _ ->
+              let projections = Projection.projectAll deadlockChart
+              let pruned = Projection.pruneUnreachableStates deadlockChart
+              let issues = checkDeadlock projections pruned
+              Expect.equal issues.Length 1 "One deadlock"
+              Expect.stringContains issues[0].Message "Blocked" "Mentions the state"
+              Expect.equal issues[0].Severity Severity.Warning "Severity is Warning"
+
+          testCase "final states are not flagged"
+          <| fun _ ->
+              let projections = Projection.projectAll ticTacToeChart
+              let pruned = Projection.pruneUnreachableStates ticTacToeChart
+              let issues = checkDeadlock projections pruned
+              let finalIssues = issues |> List.filter (fun i -> i.Message.Contains("Wins") || i.Message.Contains("Draw"))
+              Expect.isEmpty finalIssues "Final states not flagged" ]
+
+[<Tests>]
+let validateProjectionTests =
+    testList
+        "ProjectionValidator.validateProjection"
+        [ testCase "no roles returns 0 checks"
+          <| fun _ ->
+              let chart = { ticTacToeChart with Roles = [] }
+              let result = validateProjection chart.RouteTemplate chart
+              Expect.equal result.ChecksRun 0 "No checks for roleless chart"
+              Expect.isEmpty result.Issues "No issues"
+
+          testCase "TicTacToe returns 4 checks, 0 issues"
+          <| fun _ ->
+              let result = validateProjection ticTacToeChart.RouteTemplate ticTacToeChart
+              Expect.equal result.ChecksRun 4 "All 4 checks run"
+              Expect.isEmpty result.Issues "No issues"
+
+          testCase "dead transition chart has issues"
+          <| fun _ ->
+              let result = validateProjection deadTransitionChart.RouteTemplate deadTransitionChart
+              Expect.equal result.ChecksRun 4 "All 4 checks run"
+              Expect.isGreaterThan result.Issues.Length 0 "Has issues" ]

--- a/test/Frank.Statecharts.Tests/Frank.Statecharts.Tests.fsproj
+++ b/test/Frank.Statecharts.Tests/Frank.Statecharts.Tests.fsproj
@@ -55,6 +55,8 @@
     <Compile Include="Validation/PipelineIntegrationTests.fs" />
     <Compile Include="Validation/NearMatchTests.fs" />
     <Compile Include="Validation/MergeTests.fs" />
+    <!-- Analysis tests -->
+    <Compile Include="Analysis/ProjectionValidatorTests.fs" />
     <!-- Affordance tests (merged from Frank.Affordances.Tests) -->
     <Compile Include="Affordances/AffordanceMiddlewareTests.fs" />
     <Compile Include="Affordances/ProfileMiddlewareTests.fs" />


### PR DESCRIPTION
## Summary

- Implements Wadler's 4 multi-party session type checks for validating projection consistency of role-based statecharts
- **Connectedness** (pre-projection, error): every transition must be reachable by at least one role
- **Mixed choice** (pre-projection, warning): different roles racing from the same state
- **Completeness** (post-projection, error): union of all projections covers every global transition
- **Deadlock** (post-projection, warning): reachable non-final state where no role can act
- CLI: `frank validate --project <path> --check-projection`
- 14 tests covering all checks plus orchestrator

## New files

| File | Purpose |
|------|---------|
| `src/Frank.Statecharts/Analysis/ProjectionValidator.fs` | Pure validation functions (4 checks + orchestrator) |
| `src/Frank.Cli.Core/Commands/UnifiedValidateCommand.fs` | CLI command orchestrating checks over extraction state |
| `test/Frank.Statecharts.Tests/Analysis/ProjectionValidatorTests.fs` | 14 tests |

## Design decisions

- **Standalone result type** (`ProjectionCheckResult`) rather than reusing `ValidationRule` — different input types (`ExtractedStatechart` vs `FormatArtifact list`)
- **`[<RequireQualifiedAccess>] Severity`** DU avoids prefix stutter (expert review: Don Syme)
- **Completeness uses pruned chart** — projections are built from pruned chart, so completeness must compare against pruned global too (expert review: David Harel)
- **Deadlock is global** (any role can advance) not per-role — correct for HTTP where state is server-side; per-role progress is #108
- **`--check-projection` flag** defaults to false — additive design for #108 merge (adds `--check-progress`)

## Merge coordination with #108

Both #108 and #133 create `UnifiedValidateCommand.fs`. Analysis modules are fully separate:
- #133: `Frank.Statecharts/Analysis/ProjectionValidator.fs`
- #108: `Frank.Resources.Model/ProgressAnalysis.fs`

First-merge-wins on the CLI file; second branch rebases and adds its flag.

## Follow-up issues

- #175 — Livelock detection (self-loop-only states)
- #176 — ALPS profile validation (rt targets, link integrity, descriptor types)

## Test plan

- [x] `dotnet build Frank.sln` — 0 errors
- [x] `dotnet test Frank.sln --filter "FullyQualifiedName!~Sample"` — 2077 tests, 0 failures
- [x] `dotnet test test/Frank.Tests/` — 89/89 pass
- [x] `dotnet fantomas --check` — clean on all changed files
- [x] `/simplify` — code reuse, quality, efficiency review
- [x] `/expert-review` — Harel, Miller, Syme, Seemann

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)