### PR TITLE
feat: add progress analysis — deadlock and starvation detection

### DIFF
--- a/PROMPT.md
+++ b/PROMPT.md
@@ -1,0 +1,22 @@
+Implement #108: Progress Analysis — Deadlock and Starvation Detection.
+
+`gh issue view 108` has full details. Projection-only scope (no dual features — deferred to v7.4.0).
+
+PR #172 just landed the projection operator. Key inputs:
+- `Projection.projectAll : ExtractedStatechart -> Map<string, ExtractedStatechart>` in src/Frank.Resources.Model/Projection.fs
+- `TransitionSpec` with `RoleConstraint` (Unrestricted | RestrictedTo) in src/Frank.Resources.Model/ResourceTypes.fs
+- `ExtractedStatechart.Transitions` and `.States` for reachability analysis
+
+What to build:
+1. New module `src/Frank.Statecharts/Analysis/ProgressAnalysis.fs` — pure functions: `detectDeadlocks`, `detectStarvation`, `analyzeProgress`
+2. Types: `ProgressDiagnostic` DU (Deadlock of state | Starvation of role * states | ReadOnlyRole of role) and `ProgressReport`
+3. Deadlock: for each non-final state, check if ANY role has an unsafe/idempotent transition. No role can act = deadlock.
+4. Starvation: for each role, build reachability graph. Find SCCs where role has no transitions. Find terminal paths where role is excluded.
+5. CLI integration: add `--check-progress` flag to `src/Frank.Cli.Core/Commands/UnifiedValidateCommand.fs`
+6. Tests in `test/Frank.Statecharts.Tests/Analysis/ProgressAnalysisTests.fs`
+
+Wadler's guidance: completeness check already exists in #107 (`findOrphanedTransitions`). This issue adds deadlock + starvation. Connectedness and mixed choice go to #133.
+
+Expert reviewers for this PR: Wadler (MPST liveness), Harel (statechart reachability).
+
+Start with /brainstorm, then implement. Run `dotnet build Frank.sln` and `dotnet test Frank.sln --filter "FullyQualifiedName!~Sample"` before claiming complete. PR must include `Closes #108`. Run /simplify then /expert-review before creating the PR.

--- a/docs/superpowers/plans/2026-03-24-progress-analysis.md
+++ b/docs/superpowers/plans/2026-03-24-progress-analysis.md
@@ -1,0 +1,1313 @@
+# Progress Analysis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add deadlock and starvation detection to the Frank spec pipeline, providing the progress guarantee from MPST theory.
+
+**Architecture:** Pure analysis functions in `Frank.Resources.Model` operate on `ExtractedStatechart`. Hybrid approach: projections classify per-state role activity, global graph BFS determines starvation reachability. CLI exposes via top-level `validate --check-progress` command.
+
+**Tech Stack:** F#, Expecto tests, System.CommandLine CLI, System.Text.Json output
+
+**Spec:** `docs/superpowers/specs/2026-03-24-progress-analysis-design.md`
+
+---
+
+### Task 1: Scaffold types and predicates
+
+**Files:**
+- Create: `src/Frank.Resources.Model/ProgressAnalysis.fs`
+- Modify: `src/Frank.Resources.Model/Frank.Resources.Model.fsproj`
+
+- [ ] **Step 1: Create ProgressAnalysis.fs with types only**
+
+```fsharp
+namespace Frank.Resources.Model
+
+/// Progress analysis for statechart protocols.
+/// Detects deadlocks (no role can advance) and starvation (role permanently excluded).
+/// All functions are pure, total, and format-agnostic.
+module ProgressAnalysis =
+
+    /// A transition that advances the protocol (Source <> Target).
+    /// Self-loops (getGame: XTurn -> XTurn) are observations, not progress.
+    /// Assumption: operates on flat extracted statechart where hierarchy is resolved.
+    let isAdvancing (t: TransitionSpec) : bool = t.Source <> t.Target
+
+    /// A transition that at least one role can trigger.
+    /// RestrictedTo [] = dead transition (no role can fire it).
+    let isLive (t: TransitionSpec) : bool =
+        match t.Constraint with
+        | RestrictedTo [] -> false
+        | _ -> true
+
+    type ProgressDiagnostic =
+        /// Non-final state where no role has an advancing+live transition. Error severity.
+        | Deadlock of state: string * selfLoopEvents: string list
+        /// Role permanently excluded on ALL forward paths from a reachable state. Warning severity.
+        | Starvation of role: string * excludedAfter: string * excludedStates: string list
+        /// Role with zero advancing transitions in any state. Info severity (expected for observers).
+        | ReadOnlyRole of role: string
+
+    module ProgressDiagnostic =
+        let severity =
+            function
+            | Deadlock _ -> "error"
+            | Starvation _ -> "warning"
+            | ReadOnlyRole _ -> "info"
+
+    type ProgressReport =
+        { Route: string
+          Diagnostics: ProgressDiagnostic list
+          HasErrors: bool
+          HasWarnings: bool
+          StatesAnalyzed: int
+          RolesAnalyzed: string list }
+```
+
+- [ ] **Step 2: Add to fsproj compile order**
+
+In `src/Frank.Resources.Model/Frank.Resources.Model.fsproj`, add after the `Projection.fs` line:
+
+```xml
+    <Compile Include="ProgressAnalysis.fs" />
+```
+
+So the ItemGroup reads:
+```xml
+    <Compile Include="TypeAnalysis.fs" />
+    <Compile Include="ResourceTypes.fs" />
+    <Compile Include="Projection.fs" />
+    <Compile Include="ProgressAnalysis.fs" />
+    <Compile Include="RuntimeTypes.fs" />
+    <Compile Include="AffordanceTypes.fs" />
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `dotnet build src/Frank.Resources.Model/Frank.Resources.Model.fsproj`
+Expected: Build succeeded.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Frank.Resources.Model/ProgressAnalysis.fs src/Frank.Resources.Model/Frank.Resources.Model.fsproj
+git commit -m "feat(progress): add ProgressAnalysis types and predicates
+
+Scaffold for #108 — types only, no logic yet.
+- isAdvancing/isLive predicates
+- ProgressDiagnostic DU (Deadlock|Starvation|ReadOnlyRole)
+- ProgressReport record"
+```
+
+---
+
+### Task 2: Test scaffolding with fixtures
+
+**Files:**
+- Create: `test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs`
+- Modify: `test/Frank.Resources.Model.Tests/Frank.Resources.Model.Tests.fsproj`
+
+- [ ] **Step 1: Create test file with all fixtures**
+
+```fsharp
+module Frank.Resources.Model.Tests.ProgressAnalysisTests
+
+open Expecto
+open Frank.Resources.Model
+
+// -- Helpers --
+
+let private mkTransition event source target guard roleConstraint =
+    { Event = event
+      Source = source
+      Target = target
+      Guard = guard
+      Constraint = roleConstraint }
+
+let private mkState isFinal =
+    { AllowedMethods = [ "GET" ]
+      IsFinal = isFinal
+      Description = None }
+
+// -- Fixtures --
+
+/// TicTacToe: 2 players + spectator. No deadlocks, no starvation.
+/// Spectator is read-only. Turn-taking is weak starvation (no warning).
+let private ticTacToeChart: ExtractedStatechart =
+    { RouteTemplate = "/games/{gameId}"
+      StateNames = [ "XTurn"; "OTurn"; "XWins"; "OWins"; "Draw" ]
+      InitialStateKey = "XTurn"
+      GuardNames = [ "TurnGuard" ]
+      StateMetadata =
+        Map.ofList
+            [ "XTurn", mkState false
+              "OTurn", mkState false
+              "XWins", mkState true
+              "OWins", mkState true
+              "Draw", mkState true ]
+      Roles =
+        [ { Name = "PlayerX"; Description = Some "Player X" }
+          { Name = "PlayerO"; Description = Some "Player O" }
+          { Name = "Spectator"; Description = Some "Observer" } ]
+      Transitions =
+        [ mkTransition "getGame" "XTurn" "XTurn" None Unrestricted
+          mkTransition "getGame" "OTurn" "OTurn" None Unrestricted
+          mkTransition "getGame" "XWins" "XWins" None Unrestricted
+          mkTransition "getGame" "OWins" "OWins" None Unrestricted
+          mkTransition "getGame" "Draw" "Draw" None Unrestricted
+          mkTransition "makeMove" "XTurn" "OTurn" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "XTurn" "XWins" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "XTurn" "Draw" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "OTurn" "XTurn" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ])
+          mkTransition "makeMove" "OTurn" "OWins" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ])
+          mkTransition "makeMove" "OTurn" "Draw" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ]) ] }
+
+/// Non-final state with only self-loops for all roles.
+let private deadlockSelfLoopChart: ExtractedStatechart =
+    { RouteTemplate = "/stuck"
+      StateNames = [ "Stuck"; "Done" ]
+      InitialStateKey = "Stuck"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList [ "Stuck", mkState false; "Done", mkState true ]
+      Roles = [ { Name = "Admin"; Description = None } ]
+      Transitions =
+        [ mkTransition "refresh" "Stuck" "Stuck" None Unrestricted ] }
+
+/// Only advancing transition is RestrictedTo [] (dead).
+let private deadTransitionDeadlockChart: ExtractedStatechart =
+    { RouteTemplate = "/dead"
+      StateNames = [ "Active"; "Archived" ]
+      InitialStateKey = "Active"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList [ "Active", mkState false; "Archived", mkState true ]
+      Roles = [ { Name = "Admin"; Description = None } ]
+      Transitions =
+        [ mkTransition "view" "Active" "Active" None Unrestricted
+          mkTransition "archive" "Active" "Archived" None (RestrictedTo []) ] }
+
+/// Role permanently excluded after a state on all forward paths.
+/// Admin acts in Phase1, transitions to Phase2. Worker never has advancing transitions.
+let private starvationChart: ExtractedStatechart =
+    { RouteTemplate = "/workflow"
+      StateNames = [ "Phase1"; "Phase2"; "Phase3"; "Done" ]
+      InitialStateKey = "Phase1"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "Phase1", mkState false
+              "Phase2", mkState false
+              "Phase3", mkState false
+              "Done", mkState true ]
+      Roles =
+        [ { Name = "Admin"; Description = None }
+          { Name = "Worker"; Description = None } ]
+      Transitions =
+        [ mkTransition "start" "Phase1" "Phase2" None (RestrictedTo [ "Admin" ])
+          mkTransition "advance" "Phase2" "Phase3" None (RestrictedTo [ "Admin" ])
+          mkTransition "complete" "Phase3" "Done" None (RestrictedTo [ "Admin" ])
+          mkTransition "view" "Phase1" "Phase1" None Unrestricted
+          mkTransition "view" "Phase2" "Phase2" None Unrestricted
+          mkTransition "view" "Phase3" "Phase3" None Unrestricted ] }
+
+/// Recovery path only via dead transition — must still report starved.
+let private deadTransitionForwardPathChart: ExtractedStatechart =
+    { RouteTemplate = "/dead-path"
+      StateNames = [ "Start"; "Middle"; "Recovery"; "End" ]
+      InitialStateKey = "Start"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "Start", mkState false
+              "Middle", mkState false
+              "Recovery", mkState false
+              "End", mkState true ]
+      Roles =
+        [ { Name = "RoleA"; Description = None }
+          { Name = "RoleB"; Description = None } ]
+      Transitions =
+        [ mkTransition "go" "Start" "Middle" None (RestrictedTo [ "RoleA" ])
+          // Only path from Middle to Recovery is dead — no one can fire it
+          mkTransition "recover" "Middle" "Recovery" None (RestrictedTo [])
+          mkTransition "act" "Recovery" "End" None (RestrictedTo [ "RoleB" ])
+          mkTransition "finish" "Middle" "End" None (RestrictedTo [ "RoleA" ]) ] }
+
+/// All transitions unrestricted — no starvation possible.
+let private allUnrestrictedChart: ExtractedStatechart =
+    { RouteTemplate = "/open"
+      StateNames = [ "A"; "B"; "Done" ]
+      InitialStateKey = "A"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList [ "A", mkState false; "B", mkState false; "Done", mkState true ]
+      Roles =
+        [ { Name = "User"; Description = None }
+          { Name = "Admin"; Description = None } ]
+      Transitions =
+        [ mkTransition "step1" "A" "B" None Unrestricted
+          mkTransition "step2" "B" "Done" None Unrestricted ] }
+
+/// Single final state — empty report.
+let private singleFinalChart: ExtractedStatechart =
+    { RouteTemplate = "/final"
+      StateNames = [ "Done" ]
+      InitialStateKey = "Done"
+      GuardNames = []
+      StateMetadata = Map.ofList [ "Done", mkState true ]
+      Roles = [ { Name = "User"; Description = None } ]
+      Transitions = [] }
+
+/// Initial state only, no transitions — deadlock.
+let private emptyTransitionsChart: ExtractedStatechart =
+    { RouteTemplate = "/empty"
+      StateNames = [ "Idle" ]
+      InitialStateKey = "Idle"
+      GuardNames = []
+      StateMetadata = Map.ofList [ "Idle", mkState false ]
+      Roles = [ { Name = "User"; Description = None } ]
+      Transitions = [] }
+
+/// Non-terminating cycle, all roles active — no deadlock, no starvation.
+let private cycleNoFinalChart: ExtractedStatechart =
+    { RouteTemplate = "/cycle"
+      StateNames = [ "A"; "B" ]
+      InitialStateKey = "A"
+      GuardNames = []
+      StateMetadata = Map.ofList [ "A", mkState false; "B", mkState false ]
+      Roles = [ { Name = "User"; Description = None } ]
+      Transitions =
+        [ mkTransition "forward" "A" "B" None Unrestricted
+          mkTransition "back" "B" "A" None Unrestricted ] }
+
+/// Diamond: two paths reconverge at active state.
+/// RoleB inactive at B and C, but both paths reach D where RoleB can act.
+let private diamondChart: ExtractedStatechart =
+    { RouteTemplate = "/diamond"
+      StateNames = [ "A"; "B"; "C"; "D"; "Done" ]
+      InitialStateKey = "A"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "A", mkState false
+              "B", mkState false
+              "C", mkState false
+              "D", mkState false
+              "Done", mkState true ]
+      Roles =
+        [ { Name = "RoleA"; Description = None }
+          { Name = "RoleB"; Description = None } ]
+      Transitions =
+        [ mkTransition "left" "A" "B" None (RestrictedTo [ "RoleA" ])
+          mkTransition "right" "A" "C" None (RestrictedTo [ "RoleA" ])
+          mkTransition "converge1" "B" "D" None (RestrictedTo [ "RoleA" ])
+          mkTransition "converge2" "C" "D" None (RestrictedTo [ "RoleA" ])
+          mkTransition "finish" "D" "Done" None (RestrictedTo [ "RoleB" ])
+          mkTransition "act" "A" "A" None (RestrictedTo [ "RoleB" ]) ] }
+
+/// Non-initial non-final state with no outgoing transitions — deadlock.
+let private reachableDeadEndChart: ExtractedStatechart =
+    { RouteTemplate = "/deadend"
+      StateNames = [ "Start"; "DeadEnd"; "Done" ]
+      InitialStateKey = "Start"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "Start", mkState false
+              "DeadEnd", mkState false
+              "Done", mkState true ]
+      Roles = [ { Name = "User"; Description = None } ]
+      Transitions =
+        [ mkTransition "enter" "Start" "DeadEnd" None Unrestricted
+          mkTransition "skip" "Start" "Done" None Unrestricted ] }
+
+/// Same role excluded from two independent states — two diagnostics.
+let private multipleStarvationChart: ExtractedStatechart =
+    { RouteTemplate = "/multi-starve"
+      StateNames = [ "Start"; "Branch1"; "Branch2"; "End1"; "End2" ]
+      InitialStateKey = "Start"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "Start", mkState false
+              "Branch1", mkState false
+              "Branch2", mkState false
+              "End1", mkState true
+              "End2", mkState true ]
+      Roles =
+        [ { Name = "RoleA"; Description = None }
+          { Name = "RoleB"; Description = None } ]
+      Transitions =
+        [ mkTransition "go1" "Start" "Branch1" None (RestrictedTo [ "RoleA" ])
+          mkTransition "go2" "Start" "Branch2" None (RestrictedTo [ "RoleA" ])
+          mkTransition "end1" "Branch1" "End1" None (RestrictedTo [ "RoleA" ])
+          mkTransition "end2" "Branch2" "End2" None (RestrictedTo [ "RoleA" ]) ] }
+
+/// Disconnected chart — unreachable non-final state should not produce false deadlock.
+let private disconnectedChart: ExtractedStatechart =
+    { RouteTemplate = "/disconnected"
+      StateNames = [ "Start"; "Done"; "Orphan" ]
+      InitialStateKey = "Start"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "Start", mkState false
+              "Done", mkState true
+              "Orphan", mkState false ]
+      Roles = [ { Name = "User"; Description = None } ]
+      Transitions =
+        [ mkTransition "finish" "Start" "Done" None Unrestricted
+          mkTransition "orphanAct" "Orphan" "Start" None Unrestricted ] }
+
+// -- Placeholder test lists (to be filled in subsequent tasks) --
+
+[<Tests>]
+let predicateTests =
+    testList
+        "predicates"
+        [ testCase "isAdvancing returns true for state-changing transition"
+          <| fun _ ->
+              let t = mkTransition "go" "A" "B" None Unrestricted
+              Expect.isTrue (ProgressAnalysis.isAdvancing t) "A->B is advancing"
+
+          testCase "isAdvancing returns false for self-loop"
+          <| fun _ ->
+              let t = mkTransition "view" "A" "A" None Unrestricted
+              Expect.isFalse (ProgressAnalysis.isAdvancing t) "A->A is not advancing"
+
+          testCase "isLive returns true for unrestricted"
+          <| fun _ ->
+              let t = mkTransition "go" "A" "B" None Unrestricted
+              Expect.isTrue (ProgressAnalysis.isLive t) "Unrestricted is live"
+
+          testCase "isLive returns true for non-empty RestrictedTo"
+          <| fun _ ->
+              let t = mkTransition "go" "A" "B" None (RestrictedTo [ "R" ])
+              Expect.isTrue (ProgressAnalysis.isLive t) "RestrictedTo [R] is live"
+
+          testCase "isLive returns false for empty RestrictedTo"
+          <| fun _ ->
+              let t = mkTransition "go" "A" "B" None (RestrictedTo [])
+              Expect.isFalse (ProgressAnalysis.isLive t) "RestrictedTo [] is dead" ]
+```
+
+- [ ] **Step 2: Add to test fsproj compile order**
+
+In `test/Frank.Resources.Model.Tests/Frank.Resources.Model.Tests.fsproj`, add after `ProjectionTests.fs`:
+
+```xml
+    <Compile Include="ProgressAnalysisTests.fs" />
+```
+
+So the ItemGroup reads:
+```xml
+    <Compile Include="ResourceSlugTests.fs" />
+    <Compile Include="AffordanceMapTests.fs" />
+    <Compile Include="ProjectionTests.fs" />
+    <Compile Include="ProgressAnalysisTests.fs" />
+    <Compile Include="Program.fs" />
+```
+
+- [ ] **Step 3: Verify tests compile and predicate tests pass**
+
+Run: `dotnet test test/Frank.Resources.Model.Tests/ --filter "predicates"`
+Expected: 5 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs test/Frank.Resources.Model.Tests/Frank.Resources.Model.Tests.fsproj
+git commit -m "test(progress): add test fixtures and predicate tests
+
+13 test fixtures covering all scenarios from spec.
+5 predicate tests for isAdvancing and isLive."
+```
+
+---
+
+### Task 3: TDD identifyReadOnlyRoles
+
+**Files:**
+- Modify: `test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs`
+- Modify: `src/Frank.Resources.Model/ProgressAnalysis.fs`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `ProgressAnalysisTests.fs`:
+
+```fsharp
+[<Tests>]
+let readOnlyRoleTests =
+    testList
+        "identifyReadOnlyRoles"
+        [ testCase "Spectator in TicTacToe is read-only"
+          <| fun _ ->
+              let projections = Projection.projectAll ticTacToeChart
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              Expect.contains readOnly "Spectator" "Spectator is read-only"
+
+          testCase "PlayerX in TicTacToe is not read-only"
+          <| fun _ ->
+              let projections = Projection.projectAll ticTacToeChart
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              Expect.isFalse (List.contains "PlayerX" readOnly) "PlayerX is not read-only"
+
+          testCase "all-unrestricted chart has no read-only roles"
+          <| fun _ ->
+              let projections = Projection.projectAll allUnrestrictedChart
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              Expect.isEmpty readOnly "No read-only roles when all unrestricted"
+
+          testCase "role with only dead transitions is read-only"
+          <| fun _ ->
+              let projections = Projection.projectAll deadTransitionDeadlockChart
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              Expect.contains readOnly "Admin" "Admin with only dead advancing transition is read-only" ]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test test/Frank.Resources.Model.Tests/ --filter "identifyReadOnlyRoles"`
+Expected: FAIL — `identifyReadOnlyRoles` not defined.
+
+- [ ] **Step 3: Implement identifyReadOnlyRoles**
+
+Add to `ProgressAnalysis` module in `src/Frank.Resources.Model/ProgressAnalysis.fs`, after the types:
+
+```fsharp
+    /// Identify roles with zero advancing+live transitions in any state.
+    /// These are read-only observers (e.g., Spectator) — info, not a problem.
+    let identifyReadOnlyRoles (projections: Map<string, ExtractedStatechart>) : string list =
+        projections
+        |> Map.toList
+        |> List.choose (fun (role, chart) ->
+            let hasAdvancing =
+                chart.Transitions
+                |> List.exists (fun t -> isAdvancing t && isLive t)
+
+            if hasAdvancing then None else Some role)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test test/Frank.Resources.Model.Tests/ --filter "identifyReadOnlyRoles"`
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Frank.Resources.Model/ProgressAnalysis.fs test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
+git commit -m "feat(progress): implement identifyReadOnlyRoles
+
+Classifies roles with zero advancing+live transitions as read-only.
+Used to exclude observers from starvation analysis."
+```
+
+---
+
+### Task 4: TDD detectDeadlocks
+
+**Files:**
+- Modify: `test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs`
+- Modify: `src/Frank.Resources.Model/ProgressAnalysis.fs`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `ProgressAnalysisTests.fs`:
+
+```fsharp
+[<Tests>]
+let deadlockTests =
+    testList
+        "detectDeadlocks"
+        [ testCase "TicTacToe has no deadlocks"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates ticTacToeChart
+              let deadlocks = ProgressAnalysis.detectDeadlocks pruned
+              Expect.isEmpty deadlocks "TicTacToe has no deadlocks"
+
+          testCase "self-loop-only state is deadlock with selfLoopEvents"
+          <| fun _ ->
+              let deadlocks = ProgressAnalysis.detectDeadlocks deadlockSelfLoopChart
+
+              Expect.hasLength deadlocks 1 "One deadlock"
+
+              match deadlocks.[0] with
+              | ProgressAnalysis.Deadlock(state, selfLoops) ->
+                  Expect.equal state "Stuck" "Deadlock at Stuck"
+                  Expect.contains selfLoops "refresh" "Self-loop event reported"
+              | _ -> failtest "Expected Deadlock diagnostic"
+
+          testCase "dead transition state is deadlock"
+          <| fun _ ->
+              let deadlocks = ProgressAnalysis.detectDeadlocks deadTransitionDeadlockChart
+
+              Expect.hasLength deadlocks 1 "One deadlock"
+
+              match deadlocks.[0] with
+              | ProgressAnalysis.Deadlock(state, selfLoops) ->
+                  Expect.equal state "Active" "Deadlock at Active"
+                  Expect.contains selfLoops "view" "Self-loop reported"
+              | _ -> failtest "Expected Deadlock diagnostic"
+
+          testCase "final state with no transitions is not deadlock"
+          <| fun _ ->
+              let deadlocks = ProgressAnalysis.detectDeadlocks singleFinalChart
+              Expect.isEmpty deadlocks "Final state is not a deadlock"
+
+          testCase "empty transitions from initial is deadlock"
+          <| fun _ ->
+              let deadlocks = ProgressAnalysis.detectDeadlocks emptyTransitionsChart
+
+              Expect.hasLength deadlocks 1 "One deadlock"
+
+              match deadlocks.[0] with
+              | ProgressAnalysis.Deadlock(state, selfLoops) ->
+                  Expect.equal state "Idle" "Deadlock at Idle"
+                  Expect.isEmpty selfLoops "No self-loops"
+              | _ -> failtest "Expected Deadlock diagnostic"
+
+          testCase "reachable dead-end is deadlock"
+          <| fun _ ->
+              let deadlocks = ProgressAnalysis.detectDeadlocks reachableDeadEndChart
+
+              let deadEndDiags =
+                  deadlocks
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.Deadlock(s, _) when s = "DeadEnd" -> Some d
+                      | _ -> None)
+
+              Expect.hasLength deadEndDiags 1 "DeadEnd is a deadlock"
+
+          testCase "cycle without final states is NOT deadlock"
+          <| fun _ ->
+              let deadlocks = ProgressAnalysis.detectDeadlocks cycleNoFinalChart
+              Expect.isEmpty deadlocks "Cycle with advancing transitions is not deadlock" ]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test test/Frank.Resources.Model.Tests/ --filter "detectDeadlocks"`
+Expected: FAIL — `detectDeadlocks` not defined.
+
+- [ ] **Step 3: Implement detectDeadlocks**
+
+Add to `ProgressAnalysis` module:
+
+```fsharp
+    /// Detect non-final states where no role has an advancing+live transition.
+    /// Operates on the global chart (not projections).
+    /// States not in StateMetadata are treated as non-final (conservative).
+    let detectDeadlocks (statechart: ExtractedStatechart) : ProgressDiagnostic list =
+        let isFinal state =
+            statechart.StateMetadata
+            |> Map.tryFind state
+            |> Option.map (fun si -> si.IsFinal)
+            |> Option.defaultValue false
+
+        let transitionsBySource =
+            statechart.Transitions
+            |> List.groupBy (fun t -> t.Source)
+            |> Map.ofList
+
+        statechart.StateNames
+        |> List.choose (fun state ->
+            if isFinal state then
+                None
+            else
+                let transitions =
+                    transitionsBySource
+                    |> Map.tryFind state
+                    |> Option.defaultValue []
+
+                let advancingLive =
+                    transitions |> List.filter (fun t -> isAdvancing t && isLive t)
+
+                if List.isEmpty advancingLive then
+                    let selfLoopEvents =
+                        transitions
+                        |> List.filter (fun t -> t.Source = t.Target)
+                        |> List.map (fun t -> t.Event)
+                        |> List.distinct
+
+                    Some(Deadlock(state, selfLoopEvents))
+                else
+                    None)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test test/Frank.Resources.Model.Tests/ --filter "detectDeadlocks"`
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Frank.Resources.Model/ProgressAnalysis.fs test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
+git commit -m "feat(progress): implement detectDeadlocks
+
+Non-final state with no advancing+live transitions = deadlock.
+Reports self-loop events for diagnostics."
+```
+
+---
+
+### Task 5: TDD detectStarvation
+
+**Files:**
+- Modify: `test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs`
+- Modify: `src/Frank.Resources.Model/ProgressAnalysis.fs`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `ProgressAnalysisTests.fs`:
+
+```fsharp
+[<Tests>]
+let starvationTests =
+    testList
+        "detectStarvation"
+        [ testCase "TicTacToe PlayerX in OTurn is NOT starvation"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates ticTacToeChart
+              let projections = Projection.projectAll pruned
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+              Expect.isEmpty starvation "Turn-taking is not starvation"
+
+          testCase "Worker permanently excluded is starvation"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates starvationChart
+              let projections = Projection.projectAll pruned
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+
+              let workerDiags =
+                  starvation
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.Starvation(r, _, _) when r = "Worker" -> Some d
+                      | _ -> None)
+
+              Expect.isNonEmpty workerDiags "Worker is starved"
+
+          testCase "read-only roles excluded from analysis"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates ticTacToeChart
+              let projections = Projection.projectAll pruned
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+
+              let spectatorDiags =
+                  starvation
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.Starvation(r, _, _) when r = "Spectator" -> Some d
+                      | _ -> None)
+
+              Expect.isEmpty spectatorDiags "Spectator excluded from starvation analysis"
+
+          testCase "all-unrestricted has no starvation"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates allUnrestrictedChart
+              let projections = Projection.projectAll pruned
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+              Expect.isEmpty starvation "All-unrestricted has no starvation"
+
+          testCase "dead transition in forward path still reports starvation"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates deadTransitionForwardPathChart
+              let projections = Projection.projectAll pruned
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+
+              let roleBDiags =
+                  starvation
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.Starvation(r, _, _) when r = "RoleB" -> Some d
+                      | _ -> None)
+
+              Expect.isNonEmpty roleBDiags "RoleB starved — recovery only via dead transition"
+
+          testCase "diamond topology is NOT starvation"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates diamondChart
+              let projections = Projection.projectAll pruned
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+
+              let roleBDiags =
+                  starvation
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.Starvation(r, _, _) when r = "RoleB" -> Some d
+                      | _ -> None)
+
+              Expect.isEmpty roleBDiags "RoleB recovers at D via diamond paths"
+
+          testCase "multiple starvation entry points emit two diagnostics"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates multipleStarvationChart
+              let projections = Projection.projectAll pruned
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+
+              let roleBDiags =
+                  starvation
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.Starvation(r, _, _) when r = "RoleB" -> Some d
+                      | _ -> None)
+
+              Expect.isGreaterThanOrEqual
+                  (List.length roleBDiags)
+                  2
+                  "RoleB starved from both Branch1 and Branch2" ]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test test/Frank.Resources.Model.Tests/ --filter "detectStarvation"`
+Expected: FAIL — `detectStarvation` not defined.
+
+- [ ] **Step 3: Implement forwardReachable helper and detectStarvation**
+
+Add to `ProgressAnalysis` module (before `detectDeadlocks`):
+
+```fsharp
+    /// Build adjacency map from live transitions only.
+    /// Dead transitions (RestrictedTo []) excluded — they inflate reachability
+    /// and produce false negatives in starvation detection.
+    let private buildLiveAdjacency (transitions: TransitionSpec list) : Map<string, string list> =
+        transitions
+        |> List.filter isLive
+        |> List.groupBy (fun t -> t.Source)
+        |> List.map (fun (k, ts) -> k, ts |> List.map (fun t -> t.Target) |> List.distinct)
+        |> Map.ofList
+
+    /// Forward reachability via BFS from a start state.
+    let private forwardReachable (adjacency: Map<string, string list>) (start: string) : Set<string> =
+        let rec bfs (visited: Set<string>) (frontier: string list) =
+            match frontier with
+            | [] -> visited
+            | state :: rest ->
+                if Set.contains state visited then
+                    bfs visited rest
+                else
+                    let visited' = Set.add state visited
+
+                    let neighbors =
+                        adjacency
+                        |> Map.tryFind state
+                        |> Option.defaultValue []
+                        |> List.filter (fun s -> not (Set.contains s visited'))
+
+                    bfs visited' (neighbors @ rest)
+
+        bfs Set.empty [ start ]
+```
+
+Then add `detectStarvation`:
+
+```fsharp
+    /// Detect roles permanently excluded on ALL forward paths from reachable states.
+    /// Uses ALL live global transitions for reachability (Harel correction).
+    /// Excludes dead transitions from BFS (Harel soundness fix).
+    let detectStarvation
+        (statechart: ExtractedStatechart)
+        (projections: Map<string, ExtractedStatechart>)
+        (readOnlyRoles: string list)
+        : ProgressDiagnostic list =
+        let isFinal state =
+            statechart.StateMetadata
+            |> Map.tryFind state
+            |> Option.map (fun si -> si.IsFinal)
+            |> Option.defaultValue false
+
+        let adjacency = buildLiveAdjacency statechart.Transitions
+
+        let roleNames =
+            projections
+            |> Map.keys
+            |> Seq.filter (fun r -> not (List.contains r readOnlyRoles))
+            |> Seq.toList
+
+        roleNames
+        |> List.collect (fun role ->
+            let roleChart =
+                projections
+                |> Map.tryFind role
+                |> Option.defaultValue statechart
+
+            let activeStates =
+                roleChart.Transitions
+                |> List.filter isAdvancing
+                |> List.map (fun t -> t.Source)
+                |> Set.ofList
+
+            let nonFinalStates =
+                statechart.StateNames
+                |> List.filter (fun s -> not (isFinal s))
+
+            nonFinalStates
+            |> List.choose (fun state ->
+                if Set.contains state activeStates then
+                    None
+                else
+                    let reachable = forwardReachable adjacency state
+
+                    if Set.intersect reachable activeStates |> Set.isEmpty then
+                        let excludedStates =
+                            reachable
+                            |> Set.toList
+                            |> List.filter (fun s -> s <> state && not (isFinal s) && not (Set.contains s activeStates))
+
+                        Some(Starvation(role, state, excludedStates))
+                    else
+                        None))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test test/Frank.Resources.Model.Tests/ --filter "detectStarvation"`
+Expected: 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Frank.Resources.Model/ProgressAnalysis.fs test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
+git commit -m "feat(progress): implement detectStarvation
+
+Forward BFS on live-only global graph (Harel soundness fix).
+Uses ALL roles' transitions for reachability (Harel correction).
+Only strong starvation reported — weak (turn-taking) excluded."
+```
+
+---
+
+### Task 6: TDD analyzeProgress
+
+**Files:**
+- Modify: `test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs`
+- Modify: `src/Frank.Resources.Model/ProgressAnalysis.fs`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `ProgressAnalysisTests.fs`:
+
+```fsharp
+[<Tests>]
+let analyzeProgressTests =
+    testList
+        "analyzeProgress"
+        [ testCase "TicTacToe: no errors, no warnings, 1 read-only"
+          <| fun _ ->
+              let report = ProgressAnalysis.analyzeProgress ticTacToeChart
+              Expect.isFalse report.HasErrors "No errors"
+              Expect.isFalse report.HasWarnings "No warnings"
+              Expect.equal report.StatesAnalyzed 5 "5 states analyzed"
+              Expect.equal report.Route "/games/{gameId}" "Route preserved"
+
+              let readOnlyDiags =
+                  report.Diagnostics
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.ReadOnlyRole r -> Some r
+                      | _ -> None)
+
+              Expect.equal readOnlyDiags [ "Spectator" ] "Spectator is read-only"
+
+          testCase "deadlock chart has errors"
+          <| fun _ ->
+              let report = ProgressAnalysis.analyzeProgress deadlockSelfLoopChart
+              Expect.isTrue report.HasErrors "Has errors"
+
+          testCase "starvation chart has warnings"
+          <| fun _ ->
+              let report = ProgressAnalysis.analyzeProgress starvationChart
+              Expect.isTrue report.HasWarnings "Has warnings"
+
+          testCase "disconnected chart: pruning prevents false deadlock"
+          <| fun _ ->
+              let report = ProgressAnalysis.analyzeProgress disconnectedChart
+
+              let orphanDeadlocks =
+                  report.Diagnostics
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.Deadlock(s, _) when s = "Orphan" -> Some s
+                      | _ -> None)
+
+              Expect.isEmpty orphanDeadlocks "Orphan state pruned, no false deadlock"
+
+          testCase "RolesAnalyzed populated correctly"
+          <| fun _ ->
+              let report = ProgressAnalysis.analyzeProgress ticTacToeChart
+              Expect.hasLength report.RolesAnalyzed 3 "3 roles"
+              Expect.contains report.RolesAnalyzed "PlayerX" "PlayerX in list"
+              Expect.contains report.RolesAnalyzed "Spectator" "Spectator in list" ]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test test/Frank.Resources.Model.Tests/ --filter "analyzeProgress"`
+Expected: FAIL — `analyzeProgress` not defined.
+
+- [ ] **Step 3: Implement analyzeProgress**
+
+Add to `ProgressAnalysis` module:
+
+```fsharp
+    /// Orchestrator: prune, project, classify, detect, assemble report.
+    /// Single entry point — caller passes ExtractedStatechart; projections computed internally.
+    let analyzeProgress (statechart: ExtractedStatechart) : ProgressReport =
+        let pruned = Projection.pruneUnreachableStates statechart
+        let projections = Projection.projectAll pruned
+
+        let readOnlyRoles = identifyReadOnlyRoles projections
+        let deadlocks = detectDeadlocks pruned
+        let starvation = detectStarvation pruned projections readOnlyRoles
+
+        let readOnlyDiagnostics =
+            readOnlyRoles |> List.map ReadOnlyRole
+
+        let allDiagnostics =
+            deadlocks @ starvation @ readOnlyDiagnostics
+
+        { Route = statechart.RouteTemplate
+          Diagnostics = allDiagnostics
+          HasErrors = deadlocks |> List.isEmpty |> not
+          HasWarnings = starvation |> List.isEmpty |> not
+          StatesAnalyzed = pruned.StateNames.Length
+          RolesAnalyzed = statechart.Roles |> List.map (fun r -> r.Name) }
+```
+
+- [ ] **Step 4: Run ALL tests to verify everything passes**
+
+Run: `dotnet test test/Frank.Resources.Model.Tests/`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Frank.Resources.Model/ProgressAnalysis.fs test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
+git commit -m "feat(progress): implement analyzeProgress orchestrator
+
+Composes prune → projectAll → identifyReadOnlyRoles →
+detectDeadlocks → detectStarvation → ProgressReport.
+All analysis tests passing."
+```
+
+---
+
+### Task 7: CLI integration
+
+**Files:**
+- Create: `src/Frank.Cli.Core/Commands/UnifiedValidateCommand.fs`
+- Modify: `src/Frank.Cli.Core/Frank.Cli.Core.fsproj`
+- Modify: `src/Frank.Cli.Core/Output/TextOutput.fs`
+- Modify: `src/Frank.Cli.Core/Output/JsonOutput.fs`
+- Modify: `src/Frank.Cli/Program.fs`
+
+- [ ] **Step 1: Create UnifiedValidateCommand.fs**
+
+```fsharp
+module Frank.Cli.Core.Commands.UnifiedValidateCommand
+
+open System.IO
+open Frank.Resources.Model
+open Frank.Cli.Core.Unified
+open Frank.Cli.Core.Statechart.StatechartError
+
+type UnifiedValidateResult =
+    { Reports: ProgressAnalysis.ProgressReport list
+      HasErrors: bool
+      FromCache: bool }
+
+let execute (projectPath: string) : Async<Result<UnifiedValidateResult, StatechartError>> =
+    async {
+        if not (File.Exists projectPath) then
+            return Error(FileNotFound projectPath)
+        else
+            let projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath))
+            let cacheResult = UnifiedCache.tryLoadFresh projectDir false
+
+            match cacheResult with
+            | Error _ ->
+                return
+                    Error(
+                        CodeTruthExtractionFailed
+                            "No extraction cache found. Run 'frank extract --project ...' first."
+                    )
+            | Ok cachedState ->
+                let reports =
+                    cachedState.Resources
+                    |> List.choose (fun r ->
+                        r.Statechart
+                        |> Option.map ProgressAnalysis.analyzeProgress)
+
+                let hasErrors =
+                    reports |> List.exists (fun r -> r.HasErrors)
+
+                return
+                    Ok
+                        { Reports = reports
+                          HasErrors = hasErrors
+                          FromCache = true }
+    }
+```
+
+- [ ] **Step 2: Add to Frank.Cli.Core.fsproj**
+
+Add after `Commands/UnifiedGenerateCommand.fs`:
+
+```xml
+    <Compile Include="Commands/UnifiedValidateCommand.fs" />
+```
+
+- [ ] **Step 3: Add formatProgressReport to TextOutput.fs**
+
+Add at the end of the `TextOutput` module (before the closing of the module):
+
+```fsharp
+    let formatProgressReport (report: ProgressAnalysis.ProgressReport) : string =
+        let sb = System.Text.StringBuilder()
+
+        sb.AppendLine(
+            bold (
+                sprintf
+                    "Progress analysis for %s (%d states, %d roles)"
+                    report.Route
+                    report.StatesAnalyzed
+                    (List.length report.RolesAnalyzed)
+            )
+        )
+        |> ignore
+
+        if List.isEmpty report.Diagnostics then
+            sb.AppendLine(green "  No progress issues detected") |> ignore
+        else
+            for diag in report.Diagnostics do
+                match diag with
+                | ProgressAnalysis.Deadlock(state, selfLoops) ->
+                    let loopInfo =
+                        if List.isEmpty selfLoops then
+                            ""
+                        else
+                            sprintf " (self-loops: %s)" (String.concat ", " selfLoops)
+
+                    sb.AppendLine(red (sprintf "  [error] Deadlock: state %s has no advancing transitions%s" state loopInfo))
+                    |> ignore
+                | ProgressAnalysis.Starvation(role, excludedAfter, excludedStates) ->
+                    let statesInfo =
+                        if List.isEmpty excludedStates then
+                            ""
+                        else
+                            sprintf " (excluded from: %s)" (String.concat ", " excludedStates)
+
+                    sb.AppendLine(
+                        yellow (sprintf "  [warn]  Starvation: role %s excluded after state %s%s" role excludedAfter statesInfo)
+                    )
+                    |> ignore
+                | ProgressAnalysis.ReadOnlyRole role ->
+                    sb.AppendLine(sprintf "  [info]  Read-only role: %s (expected for observers)" role)
+                    |> ignore
+
+        sb.ToString()
+
+    let formatUnifiedValidateResult (result: UnifiedValidateCommand.UnifiedValidateResult) : string =
+        let sb = System.Text.StringBuilder()
+
+        for report in result.Reports do
+            sb.Append(formatProgressReport report) |> ignore
+            sb.AppendLine() |> ignore
+
+        if List.isEmpty result.Reports then
+            sb.AppendLine("No stateful resources found.") |> ignore
+
+        sb.ToString()
+```
+
+- [ ] **Step 4: Add formatProgressReport to JsonOutput.fs**
+
+Add at the end of the `JsonOutput` module:
+
+```fsharp
+    let formatUnifiedValidateResult (result: UnifiedValidateCommand.UnifiedValidateResult) : string =
+        use stream = new MemoryStream()
+        use writer = new Utf8JsonWriter(stream, JsonWriterOptions(Indented = true))
+
+        writer.WriteStartObject()
+        writeString writer "status" (if result.HasErrors then "error" else "ok")
+        writer.WriteBoolean("fromCache", result.FromCache)
+        writer.WriteBoolean("hasErrors", result.HasErrors)
+
+        writer.WriteStartArray("reports")
+
+        for report in result.Reports do
+            writer.WriteStartObject()
+            writeString writer "route" report.Route
+            writeNumber writer "statesAnalyzed" report.StatesAnalyzed
+            writer.WriteBoolean("hasErrors", report.HasErrors)
+            writer.WriteBoolean("hasWarnings", report.HasWarnings)
+
+            writer.WriteStartArray("rolesAnalyzed")
+
+            for role in report.RolesAnalyzed do
+                writer.WriteStringValue(role)
+
+            writer.WriteEndArray()
+
+            writer.WriteStartArray("diagnostics")
+
+            for diag in report.Diagnostics do
+                writer.WriteStartObject()
+                writeString writer "severity" (ProgressAnalysis.ProgressDiagnostic.severity diag)
+
+                match diag with
+                | ProgressAnalysis.Deadlock(state, selfLoops) ->
+                    writeString writer "kind" "deadlock"
+                    writeString writer "state" state
+
+                    writer.WriteStartArray("selfLoopEvents")
+
+                    for ev in selfLoops do
+                        writer.WriteStringValue(ev)
+
+                    writer.WriteEndArray()
+                | ProgressAnalysis.Starvation(role, excludedAfter, excludedStates) ->
+                    writeString writer "kind" "starvation"
+                    writeString writer "role" role
+                    writeString writer "excludedAfter" excludedAfter
+
+                    writer.WriteStartArray("excludedStates")
+
+                    for s in excludedStates do
+                        writer.WriteStringValue(s)
+
+                    writer.WriteEndArray()
+                | ProgressAnalysis.ReadOnlyRole role ->
+                    writeString writer "kind" "readOnlyRole"
+                    writeString writer "role" role
+
+                writer.WriteEndObject()
+
+            writer.WriteEndArray()
+            writer.WriteEndObject()
+
+        writer.WriteEndArray()
+        writer.WriteEndObject()
+        writer.Flush()
+
+        Encoding.UTF8.GetString(stream.ToArray())
+```
+
+- [ ] **Step 5: Register validate command in Program.fs**
+
+Add before the `// ── status (top-level) ──` section (after the `generate` block around line 653):
+
+```fsharp
+    // ── validate (top-level, unified) ──
+    let uniValidateCmd = Command("validate")
+
+    uniValidateCmd.Description <-
+        "Validate stateful resources for progress properties (deadlock, starvation)"
+
+    let uniValProjectOpt = Option<string>("--project")
+    uniValProjectOpt.Description <- "Path to .fsproj file"
+    uniValProjectOpt.Required <- true
+    let uniValCheckProgressOpt = Option<bool>("--check-progress")
+
+    uniValCheckProgressOpt.Description <-
+        "Run deadlock and starvation analysis on per-role projections"
+
+    uniValCheckProgressOpt.DefaultValueFactory <- (fun _ -> false)
+    let uniValFormatOpt = Option<string>("--output-format")
+    uniValFormatOpt.Description <- "Output format (text|json)"
+    uniValFormatOpt.DefaultValueFactory <- (fun _ -> "text")
+    uniValidateCmd.Options.Add(uniValProjectOpt)
+    uniValidateCmd.Options.Add(uniValCheckProgressOpt)
+    uniValidateCmd.Options.Add(uniValFormatOpt)
+
+    uniValidateCmd.SetAction(fun parseResult ->
+        let project = parseResult.GetValue(uniValProjectOpt)
+        let checkProgress = parseResult.GetValue(uniValCheckProgressOpt)
+        let format = parseResult.GetValue(uniValFormatOpt)
+
+        if checkProgress then
+            let result =
+                UnifiedValidateCommand.execute project
+                |> Async.RunSynchronously
+
+            match result with
+            | Ok r ->
+                let output =
+                    if format = "json" then
+                        JsonOutput.formatUnifiedValidateResult r
+                    else
+                        TextOutput.formatUnifiedValidateResult r
+
+                Console.WriteLine(output)
+
+                if r.HasErrors then
+                    Environment.ExitCode <- 1
+            | Error e ->
+                Environment.ExitCode <- 1
+                Console.Error.WriteLine(StatechartError.formatError e)
+        else
+            Console.WriteLine("No validation flags specified. Use --check-progress to run progress analysis."))
+
+    root.Subcommands.Add(uniValidateCmd)
+```
+
+- [ ] **Step 6: Verify build**
+
+Run: `dotnet build Frank.sln`
+Expected: Build succeeded.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Frank.Cli.Core/Commands/UnifiedValidateCommand.fs src/Frank.Cli.Core/Frank.Cli.Core.fsproj src/Frank.Cli.Core/Output/TextOutput.fs src/Frank.Cli.Core/Output/JsonOutput.fs src/Frank.Cli/Program.fs
+git commit -m "feat(progress): add validate --check-progress CLI command
+
+Top-level 'validate' command with --check-progress flag.
+Reads from extraction cache (requires prior 'frank extract').
+Text and JSON output formatting for ProgressReport.
+Exit code 1 on deadlocks (errors), 0 on warnings/info."
+```
+
+---
+
+### Task 8: Full verification
+
+- [ ] **Step 1: Build everything**
+
+Run: `dotnet build Frank.sln`
+Expected: Build succeeded.
+
+- [ ] **Step 2: Run all tests**
+
+Run: `dotnet test Frank.sln --filter "FullyQualifiedName!~Sample"`
+Expected: All tests pass.
+
+- [ ] **Step 3: Run progress analysis tests specifically**
+
+Run: `dotnet test test/Frank.Resources.Model.Tests/ -v normal`
+Expected: All progress analysis tests pass with names visible.
+
+- [ ] **Step 4: Verify no Fantomas issues**
+
+Run: `dotnet fantomas --check src/Frank.Resources.Model/ProgressAnalysis.fs`
+Expected: No formatting issues (or fix any that arise).
+
+- [ ] **Step 5: Final commit if any formatting fixes needed**
+
+Only if Fantomas required changes:
+```bash
+git add -A
+git commit -m "style: apply Fantomas formatting to ProgressAnalysis"
+```

--- a/docs/superpowers/specs/2026-03-24-progress-analysis-design.md
+++ b/docs/superpowers/specs/2026-03-24-progress-analysis-design.md
@@ -1,0 +1,279 @@
+# Progress Analysis — Deadlock and Starvation Detection
+
+**Issue:** #108
+**Milestone:** v7.3.0
+**Expert reviewers:** Wadler (MPST liveness), Harel (statechart reachability)
+
+## Context
+
+Safety (no invalid actions) is enforced at runtime by Frank's middleware. Progress (no stuck states) is a property of the protocol design that can only be verified statically — middleware handling one request at a time cannot detect that no future request will ever advance the protocol.
+
+PR #172 landed the projection operator (`Projection.projectAll`). PR #107 added completeness checking (`findOrphanedTransitions`). This issue adds the remaining liveness properties: deadlock detection and starvation detection.
+
+Scope is projection-only — no dual/complementary features (deferred to v7.4.0). Connectedness and mixed choice deferred to #133. Livelock detection (non-terminating cycles) deferred — non-terminating protocols are valid designs (long-running services); requires SCC which changes algorithm complexity.
+
+## Types
+
+New file: `src/Frank.Resources.Model/ProgressAnalysis.fs`
+Namespace: `Frank.Resources.Model`
+
+### Predicates
+
+```fsharp
+/// A transition that advances the protocol (Source <> Target).
+/// Self-loops (getGame: XTurn -> XTurn) are observations, not progress.
+/// Assumption: operates on flat extracted statechart where hierarchy is resolved.
+let isAdvancing (t: TransitionSpec) : bool = t.Source <> t.Target
+
+/// A transition that at least one role can trigger.
+/// RestrictedTo [] = dead transition (no role can fire it).
+let isLive (t: TransitionSpec) : bool =
+    match t.Constraint with
+    | RestrictedTo [] -> false
+    | _ -> true
+```
+
+### Diagnostics
+
+```fsharp
+type ProgressDiagnostic =
+    /// Non-final state where no role has an advancing+live transition. Error severity.
+    | Deadlock of state: string * selfLoopEvents: string list
+    /// Role permanently excluded on ALL forward paths from a reachable state. Warning severity.
+    | Starvation of role: string * excludedAfter: string * excludedStates: string list
+    /// Role with zero advancing transitions in any state. Info severity (expected for observers).
+    | ReadOnlyRole of role: string
+
+type ProgressReport =
+    { /// Route template identifying which statechart this report covers.
+      Route: string
+      Diagnostics: ProgressDiagnostic list
+      /// True if any Deadlock diagnostic exists.
+      HasErrors: bool
+      /// True if any Starvation diagnostic exists.
+      HasWarnings: bool
+      /// Number of states examined.
+      StatesAnalyzed: int
+      /// Role names examined.
+      RolesAnalyzed: string list }
+```
+
+No separate `ProgressSeverity` type — severity is implicit in the DU case. If needed downstream:
+
+```fsharp
+module ProgressDiagnostic =
+    let severity = function
+        | Deadlock _ -> "error"
+        | Starvation _ -> "warning"
+        | ReadOnlyRole _ -> "info"
+```
+
+## Algorithms
+
+### Execution Order
+
+1. `identifyReadOnlyRoles` — classify first to exclude from starvation analysis
+2. `detectDeadlocks` — global chart only, no projections needed
+3. `detectStarvation` — projections for classification, global graph for reachability
+4. `analyzeProgress` — orchestrator composing 1-3
+
+### identifyReadOnlyRoles
+
+```
+identifyReadOnlyRoles : Map<string, ExtractedStatechart> -> string list
+
+For each role R in projections:
+    If R's projection has zero transitions where (isAdvancing && isLive):
+        Include R in result
+```
+
+### detectDeadlocks
+
+```
+detectDeadlocks : ExtractedStatechart -> ProgressDiagnostic list
+
+For each state S where StateMetadata[S].IsFinal = false:
+    advancingLive = transitions from S where (isAdvancing && isLive)
+    If advancingLive is empty:
+        selfLoops = transitions from S where Source = Target, map to distinct Event names
+        Emit Deadlock(S, selfLoops)
+```
+
+Operates on global chart. A non-final state with no advancing+live transitions is a deadlock regardless of role distribution. States not in `StateMetadata` are treated as non-final (conservative — errs toward reporting).
+
+### detectStarvation
+
+```
+detectStarvation :
+    ExtractedStatechart -> Map<string, ExtractedStatechart> -> string list -> ProgressDiagnostic list
+
+Input: global chart, per-role projections, read-only role names (to exclude)
+
+For each non-read-only role R:
+    activeStates(R) = { S | R's projection has any transition from S where isAdvancing }
+    For each non-final state S where S not in activeStates(R):
+        forwardReachable = BFS from S using ALL global live transitions (isLive only)
+        If forwardReachable intersect activeStates(R) is empty:
+            excludedStates = forwardReachable states that are non-final and not in activeStates(R)
+            Emit Starvation(R, S, excludedStates)
+```
+
+**Critical design decisions:**
+1. **Uses ALL roles' transitions for reachability, not excluding R's.** Harel's correction — excluding R's transitions severs legitimate recovery paths where R acts at intermediate states.
+2. **Excludes dead transitions (`RestrictedTo []`) from BFS adjacency.** Harel's soundness fix — dead transitions are edges no participant can fire. Including them inflates the reachable set, producing false negatives (claiming a role isn't starved because BFS reached a recovery state through an unfirable transition). Note: `Projection.pruneUnreachableStates` includes dead transitions in its adjacency, which is defensible there (retains states for deadlock reporting). The asymmetry is intentional.
+
+**Strong vs weak starvation:** Only strong starvation (excluded on ALL forward paths) is reported. Weak starvation (excluded on some paths but not all) is normal turn-taking — e.g., PlayerX can't act in OTurn but recovers when PlayerO advances to XTurn. No warning emitted.
+
+### analyzeProgress
+
+```
+analyzeProgress : ExtractedStatechart -> ProgressReport
+
+1. pruned = Projection.pruneUnreachableStates(statechart)
+2. projections = Projection.projectAll(pruned)
+3. readOnlyRoles = identifyReadOnlyRoles(projections)
+4. deadlocks = detectDeadlocks(pruned)
+5. starvation = detectStarvation(pruned, projections, readOnlyRoles)
+6. readOnlyDiagnostics = readOnlyRoles |> map ReadOnlyRole
+7. all = deadlocks @ starvation @ readOnlyDiagnostics
+8. Return ProgressReport with Route, HasErrors, HasWarnings, StatesAnalyzed, RolesAnalyzed
+```
+
+Single entry point. Caller passes `ExtractedStatechart`; projections computed internally.
+
+### Reachability Helper
+
+Private `forwardReachable` function within `ProgressAnalysis`. Builds `Map<string, string list>` adjacency from **live transitions only** (`isLive`), recursive BFS from a start state. Same pattern as `Projection.pruneUnreachableStates` but filters dead transitions — intentional asymmetry (see detectStarvation notes).
+
+## Module Placement
+
+`src/Frank.Resources.Model/ProgressAnalysis.fs` — expert consensus (Syme, Seemann, Wlaschin, Wadler, Harel: 5/7).
+
+Rationale: all input types and helper functions (`Projection.*`) are in this assembly. Zero dependency on parsers, ASTs, or `Frank.Statecharts`. Consistent with `findOrphanedTransitions` precedent. Keeps the leaf assembly self-contained — any consumer gets progress analysis without pulling in parsers.
+
+### fsproj Compile Order
+
+```xml
+<Compile Include="TypeAnalysis.fs" />
+<Compile Include="ResourceTypes.fs" />
+<Compile Include="Projection.fs" />
+<Compile Include="ProgressAnalysis.fs" />   <!-- NEW -->
+<Compile Include="RuntimeTypes.fs" />
+<Compile Include="AffordanceTypes.fs" />
+```
+
+## CLI Integration
+
+### New Command
+
+`src/Frank.Cli.Core/Commands/UnifiedValidateCommand.fs`
+
+Top-level `validate` command registered alongside `extract` and `generate` in `Program.fs`.
+
+```
+frank validate --project game.fsproj --check-progress [--output-format text|json]
+```
+
+Follows `UnifiedExtractCommand` pattern:
+- `--project` option (required)
+- `--check-progress` flag (bool, default false)
+- `--output-format` option (text|json, default text)
+- Loads extraction state via `UnifiedCache.tryLoadFresh`
+- For each `UnifiedResource` with `Statechart`, calls `analyzeProgress`
+- Exit code 1 if any report has `HasErrors` (deadlocks)
+- Warnings and info print but don't fail the process
+
+### Output Formatting
+
+Add `formatProgressReport` to `TextOutput.fs` and `JsonOutput.fs`.
+
+Text output example:
+```
+Progress analysis for /games/{gameId} (5 states, 3 roles)
+  [error] Deadlock: state Stuck has no advancing transitions (self-loops: getGame)
+  [warn]  Starvation: role Admin excluded after state Phase2 (excluded from: Phase3, Phase4)
+  [info]  Read-only role: Spectator (expected for observers)
+```
+
+### Merge Strategy with #133
+
+Both #108 and #133 create `UnifiedValidateCommand.fs` with different flags (`--check-progress` and `--check-projection`). Different code paths, no logic overlap. Whichever merges first wins the file structure; second rebases and adds its flag. Analysis modules in separate assemblies — zero conflict on analysis code.
+
+## Tests
+
+New file: `test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs`
+
+### fsproj Compile Order
+
+After `ProjectionTests.fs`, before `Program.fs`.
+
+### Fixtures
+
+| Fixture | Purpose |
+|---------|---------|
+| TicTacToe chart | No deadlocks, no starvation, Spectator is read-only. Turn-taking (weak starvation) produces no warnings. |
+| Deadlock chart | Non-final state with only self-loops for all roles |
+| Dead transition deadlock | Non-final state where only advancing transition is `RestrictedTo []` |
+| Starvation chart | Role permanently excluded after a state on all forward paths |
+| Dead transition in forward path | Starvation regression: recovery path only via dead transition — must still report starved |
+| All-unrestricted chart | No starvation possible (fast path) |
+| Single final state | Empty report |
+| Empty transitions chart | Initial state only, no transitions — deadlock |
+| Cycle without final states | Non-terminating cycle, all roles active — no deadlock, no starvation (valid design) |
+| Diamond topology | Two paths reconverge at active state — BFS finds recovery through inactive intermediates |
+| Reachable dead-end | Non-initial non-final state with no outgoing transitions — deadlock |
+| Multiple starvation entry points | Same role excluded from S1 and S2 independently — two diagnostics emitted |
+| Disconnected chart via analyzeProgress | Pruning prevents false deadlocks from unreachable non-final states |
+
+### Test Structure
+
+```fsharp
+module Frank.Resources.Model.Tests.ProgressAnalysisTests
+
+[<Tests>]
+let readOnlyRoleTests = testList "identifyReadOnlyRoles" [
+    // Spectator in TicTacToe = read-only
+    // PlayerX in TicTacToe = not read-only
+    // All-unrestricted = no read-only roles
+    // Role with only dead transitions (RestrictedTo []) = read-only
+]
+
+[<Tests>]
+let deadlockTests = testList "detectDeadlocks" [
+    // TicTacToe = no deadlocks
+    // Self-loop-only state = deadlock with selfLoopEvents
+    // Dead transition state = deadlock (RestrictedTo [] not live)
+    // Final state with no transitions = not deadlock
+    // Empty transitions from initial = deadlock
+    // Reachable dead-end (non-initial, non-final, no outgoing) = deadlock
+    // Cycle without final states = NOT deadlock (advancing transitions exist)
+]
+
+[<Tests>]
+let starvationTests = testList "detectStarvation" [
+    // TicTacToe PlayerX in OTurn = NOT starvation (weak, recovers via PlayerO)
+    // Synthetic permanent exclusion = starvation with excludedStates
+    // Read-only roles excluded from analysis
+    // All-unrestricted = no starvation
+    // Dead transition in forward path = starvation (BFS excludes dead edges)
+    // Diamond topology = NOT starvation (BFS finds recovery through inactive intermediates)
+    // Multiple entry points for same role = two distinct diagnostics
+]
+
+[<Tests>]
+let analyzeProgressTests = testList "analyzeProgress" [
+    // TicTacToe: HasErrors=false, HasWarnings=false, 1 ReadOnlyRole diagnostic
+    // Deadlock chart: HasErrors=true
+    // Starvation chart: HasWarnings=true
+    // Disconnected chart: pruning prevents false deadlocks from unreachable states
+    // Integration: correct Route, StatesAnalyzed, RolesAnalyzed
+]
+```
+
+## Verification
+
+1. `dotnet build Frank.sln` — compiles all projects
+2. `dotnet test Frank.sln --filter "FullyQualifiedName!~Sample"` — all tests pass
+3. `dotnet test test/Frank.Resources.Model.Tests/` — progress analysis tests specifically
+4. Manual: verify TicTacToe produces clean report (no deadlocks, no starvation, Spectator=read-only)
+5. Manual: verify synthetic deadlock/starvation fixtures produce correct diagnostics

--- a/src/Frank.Cli.Core/Commands/UnifiedValidateCommand.fs
+++ b/src/Frank.Cli.Core/Commands/UnifiedValidateCommand.fs
@@ -12,9 +12,15 @@ type UnifiedValidateResult =
       TotalErrors: int
       TotalWarnings: int
       ResourcesChecked: int
+      ProgressReports: ProgressAnalysis.ProgressReport list
+      HasProgressErrors: bool
       FromCache: bool }
 
-let private buildResult (fromCache: bool) (resources: UnifiedResource list) : UnifiedValidateResult =
+let private buildResult
+    (fromCache: bool)
+    (resources: UnifiedResource list)
+    (checkProgress: bool)
+    : UnifiedValidateResult =
     let withRoles =
         resources
         |> List.choose (fun r ->
@@ -33,14 +39,29 @@ let private buildResult (fromCache: bool) (resources: UnifiedResource list) : Un
         results
         |> List.sumBy (fun r -> r.Issues |> List.filter (fun i -> i.Severity = Severity.Warning) |> List.length)
 
+    let progressReports =
+        if checkProgress then
+            resources
+            |> List.choose (fun r -> r.Statechart |> Option.map ProgressAnalysis.analyzeProgress)
+        else
+            []
+
+    let hasProgressErrors = progressReports |> List.exists (fun r -> r.HasErrors)
+
     { ProjectionResults = results
       TotalIssues = totalIssues
       TotalErrors = totalErrors
       TotalWarnings = totalWarnings
       ResourcesChecked = withRoles.Length
+      ProgressReports = progressReports
+      HasProgressErrors = hasProgressErrors
       FromCache = fromCache }
 
-let execute (projectPath: string) (force: bool) : Async<Result<UnifiedValidateResult, StatechartError>> =
+let execute
+    (projectPath: string)
+    (force: bool)
+    (checkProgress: bool)
+    : Async<Result<UnifiedValidateResult, StatechartError>> =
     async {
         if not (File.Exists projectPath) then
             return Error(FileNotFound projectPath)
@@ -48,9 +69,9 @@ let execute (projectPath: string) (force: bool) : Async<Result<UnifiedValidateRe
             let projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath))
 
             match UnifiedCache.tryLoadFresh projectDir force with
-            | Ok state -> return Ok(buildResult true state.Resources)
+            | Ok state -> return Ok(buildResult true state.Resources checkProgress)
             | Error _ ->
                 match! UnifiedExtractor.extract projectPath with
                 | Error e -> return Error e
-                | Ok resources -> return Ok(buildResult false resources)
+                | Ok resources -> return Ok(buildResult false resources checkProgress)
     }

--- a/src/Frank.Cli.Core/Commands/UnifiedValidateCommand.fs
+++ b/src/Frank.Cli.Core/Commands/UnifiedValidateCommand.fs
@@ -47,7 +47,10 @@ let private buildResult
     let progressReports =
         if checkProgress then
             resources
-            |> List.choose (fun r -> r.Statechart |> Option.map ProgressAnalysis.analyzeProgress)
+            |> List.choose (fun r ->
+                r.Statechart
+                |> Option.bind (fun sc -> if sc.Roles.IsEmpty then None else Some sc)
+                |> Option.map ProgressAnalysis.analyzeProgress)
         else
             []
 

--- a/src/Frank.Cli.Core/Commands/UnifiedValidateCommand.fs
+++ b/src/Frank.Cli.Core/Commands/UnifiedValidateCommand.fs
@@ -19,6 +19,7 @@ type UnifiedValidateResult =
 let private buildResult
     (fromCache: bool)
     (resources: UnifiedResource list)
+    (checkProjection: bool)
     (checkProgress: bool)
     : UnifiedValidateResult =
     let withRoles =
@@ -27,7 +28,11 @@ let private buildResult
             r.Statechart
             |> Option.bind (fun sc -> if sc.Roles.IsEmpty then None else Some(r.RouteTemplate, sc)))
 
-    let results = withRoles |> List.map (fun (route, sc) -> validateProjection route sc)
+    let results =
+        if checkProjection then
+            withRoles |> List.map (fun (route, sc) -> validateProjection route sc)
+        else
+            []
 
     let totalIssues = results |> List.sumBy (fun r -> r.Issues.Length)
 
@@ -60,6 +65,7 @@ let private buildResult
 let execute
     (projectPath: string)
     (force: bool)
+    (checkProjection: bool)
     (checkProgress: bool)
     : Async<Result<UnifiedValidateResult, StatechartError>> =
     async {
@@ -69,9 +75,9 @@ let execute
             let projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath))
 
             match UnifiedCache.tryLoadFresh projectDir force with
-            | Ok state -> return Ok(buildResult true state.Resources checkProgress)
+            | Ok state -> return Ok(buildResult true state.Resources checkProjection checkProgress)
             | Error _ ->
                 match! UnifiedExtractor.extract projectPath with
                 | Error e -> return Error e
-                | Ok resources -> return Ok(buildResult false resources checkProgress)
+                | Ok resources -> return Ok(buildResult false resources checkProjection checkProgress)
     }

--- a/src/Frank.Cli.Core/Output/JsonOutput.fs
+++ b/src/Frank.Cli.Core/Output/JsonOutput.fs
@@ -459,13 +459,21 @@ module JsonOutput =
         use stream = new MemoryStream()
         use writer = new Utf8JsonWriter(stream, JsonWriterOptions(Indented = true))
         writer.WriteStartObject()
-        writeString writer "status" (if result.TotalErrors > 0 then "fail" else "ok")
+
+        writeString
+            writer
+            "status"
+            (if result.TotalErrors > 0 || result.HasProgressErrors then
+                 "fail"
+             else
+                 "ok")
+
         writer.WriteBoolean("fromCache", result.FromCache)
         writeNumber writer "resourcesChecked" result.ResourcesChecked
         writeNumber writer "totalIssues" result.TotalIssues
         writeNumber writer "totalErrors" result.TotalErrors
         writeNumber writer "totalWarnings" result.TotalWarnings
-        writer.WriteStartArray("results")
+        writer.WriteStartArray("projectionResults")
 
         for r in result.ProjectionResults do
             writer.WriteStartObject()
@@ -494,8 +502,66 @@ module JsonOutput =
             writer.WriteEndObject()
 
         writer.WriteEndArray()
+
+        writer.WriteBoolean("hasProgressErrors", result.HasProgressErrors)
+        writer.WriteStartArray("progressReports")
+
+        for report in result.ProgressReports do
+            writer.WriteStartObject()
+            writeString writer "route" report.Route
+            writeNumber writer "statesAnalyzed" report.StatesAnalyzed
+            writer.WriteBoolean("hasErrors", report.HasErrors)
+            writer.WriteBoolean("hasWarnings", report.HasWarnings)
+
+            writer.WriteStartArray("rolesAnalyzed")
+
+            for role in report.RolesAnalyzed do
+                writer.WriteStringValue(role)
+
+            writer.WriteEndArray()
+
+            writer.WriteStartArray("diagnostics")
+
+            for diag in report.Diagnostics do
+                writer.WriteStartObject()
+
+                writeString writer "severity" (Frank.Resources.Model.ProgressAnalysis.ProgressDiagnostic.severity diag)
+
+                match diag with
+                | Frank.Resources.Model.ProgressAnalysis.Deadlock(state, selfLoops) ->
+                    writeString writer "kind" "deadlock"
+                    writeString writer "state" state
+
+                    writer.WriteStartArray("selfLoopEvents")
+
+                    for ev in selfLoops do
+                        writer.WriteStringValue(ev)
+
+                    writer.WriteEndArray()
+                | Frank.Resources.Model.ProgressAnalysis.Starvation(role, excludedAfter, excludedStates) ->
+                    writeString writer "kind" "starvation"
+                    writeString writer "role" role
+                    writeString writer "excludedAfter" excludedAfter
+
+                    writer.WriteStartArray("excludedStates")
+
+                    for s in excludedStates do
+                        writer.WriteStringValue(s)
+
+                    writer.WriteEndArray()
+                | Frank.Resources.Model.ProgressAnalysis.ReadOnlyRole role ->
+                    writeString writer "kind" "readOnlyRole"
+                    writeString writer "role" role
+
+                writer.WriteEndObject()
+
+            writer.WriteEndArray()
+            writer.WriteEndObject()
+
+        writer.WriteEndArray()
         writer.WriteEndObject()
         writer.Flush()
+
         Encoding.UTF8.GetString(stream.ToArray())
 
     let formatUnifiedExtractResult (result: UnifiedExtractCommand.UnifiedExtractResult) : string =

--- a/src/Frank.Cli.Core/Output/TextOutput.fs
+++ b/src/Frank.Cli.Core/Output/TextOutput.fs
@@ -316,6 +316,59 @@ module TextOutput =
 
             sb.ToString()
 
+    let formatProgressReport (report: Frank.Resources.Model.ProgressAnalysis.ProgressReport) : string =
+        let sb = System.Text.StringBuilder()
+
+        sb.AppendLine(
+            bold (
+                sprintf
+                    "Progress analysis for %s (%d states, %d roles)"
+                    report.Route
+                    report.StatesAnalyzed
+                    (List.length report.RolesAnalyzed)
+            )
+        )
+        |> ignore
+
+        if List.isEmpty report.Diagnostics then
+            sb.AppendLine(green "  No progress issues detected") |> ignore
+        else
+            for diag in report.Diagnostics do
+                match diag with
+                | Frank.Resources.Model.ProgressAnalysis.Deadlock(state, selfLoops) ->
+                    let loopInfo =
+                        if List.isEmpty selfLoops then
+                            ""
+                        else
+                            sprintf " (self-loops: %s)" (String.concat ", " selfLoops)
+
+                    sb.AppendLine(
+                        red (sprintf "  [error] Deadlock: state %s has no advancing transitions%s" state loopInfo)
+                    )
+                    |> ignore
+                | Frank.Resources.Model.ProgressAnalysis.Starvation(role, excludedAfter, excludedStates) ->
+                    let statesInfo =
+                        if List.isEmpty excludedStates then
+                            ""
+                        else
+                            sprintf " (excluded from: %s)" (String.concat ", " excludedStates)
+
+                    sb.AppendLine(
+                        yellow (
+                            sprintf
+                                "  [warn]  Starvation: role %s excluded after state %s%s"
+                                role
+                                excludedAfter
+                                statesInfo
+                        )
+                    )
+                    |> ignore
+                | Frank.Resources.Model.ProgressAnalysis.ReadOnlyRole role ->
+                    sb.AppendLine(sprintf "  [info]  Read-only role: %s (expected for observers)" role)
+                    |> ignore
+
+        sb.ToString()
+
     let formatUnifiedValidateResult (result: UnifiedValidateCommand.UnifiedValidateResult) : string =
         let sb = System.Text.StringBuilder()
         let appendLine (s: string) = sb.AppendLine(s) |> ignore
@@ -344,6 +397,12 @@ module TextOutput =
 
                     let checkName = ProjectionValidator.ProjectionCheckKind.toString issue.Check
                     appendLine $"    [%s{prefix}] %s{checkName}: %s{issue.Message}"
+
+        if not (List.isEmpty result.ProgressReports) then
+            appendLine ""
+
+            for report in result.ProgressReports do
+                sb.Append(formatProgressReport report: string) |> ignore
 
         if result.FromCache then
             appendLine ""

--- a/src/Frank.Cli/Program.fs
+++ b/src/Frank.Cli/Program.fs
@@ -675,7 +675,7 @@ let main args =
     // ── validate (top-level, unified) ──
     let uniValCmd = Command("validate")
 
-    uniValCmd.Description <- "Validate projection consistency for stateful resources with roles"
+    uniValCmd.Description <- "Validate stateful resources: projection consistency and progress properties"
 
     let uniValProjectOpt = Option<string>("--project")
     uniValProjectOpt.Description <- "Path to .fsproj file"
@@ -686,6 +686,11 @@ let main args =
         "Run projection consistency checks (connectedness, mixed-choice, completeness, deadlock)"
 
     uniValCheckProjectionOpt.DefaultValueFactory <- (fun _ -> false)
+    let uniValCheckProgressOpt = Option<bool>("--check-progress")
+
+    uniValCheckProgressOpt.Description <- "Run deadlock and starvation analysis on per-role projections"
+
+    uniValCheckProgressOpt.DefaultValueFactory <- (fun _ -> false)
     let uniValForceOpt = Option<bool>("--force")
     uniValForceOpt.Description <- "Force re-extraction, bypassing cache"
     uniValForceOpt.DefaultValueFactory <- (fun _ -> false)
@@ -694,21 +699,25 @@ let main args =
     uniValFormatOpt.DefaultValueFactory <- (fun _ -> "text")
     uniValCmd.Options.Add(uniValProjectOpt)
     uniValCmd.Options.Add(uniValCheckProjectionOpt)
+    uniValCmd.Options.Add(uniValCheckProgressOpt)
     uniValCmd.Options.Add(uniValForceOpt)
     uniValCmd.Options.Add(uniValFormatOpt)
 
     uniValCmd.SetAction(fun parseResult ->
         let project = parseResult.GetValue(uniValProjectOpt)
         let checkProjection = parseResult.GetValue(uniValCheckProjectionOpt)
+        let checkProgress = parseResult.GetValue(uniValCheckProgressOpt)
         let force = parseResult.GetValue(uniValForceOpt)
         let format = parseResult.GetValue(uniValFormatOpt)
 
-        if not checkProjection then
-            Console.Error.WriteLine("No checks specified. Available flags: --check-projection")
+        if not checkProjection && not checkProgress then
+            Console.Error.WriteLine("No checks specified. Available flags: --check-projection, --check-progress")
 
             Environment.ExitCode <- 1
         else
-            let result = UnifiedValidateCommand.execute project force |> Async.RunSynchronously
+            let result =
+                UnifiedValidateCommand.execute project force checkProgress
+                |> Async.RunSynchronously
 
             match result with
             | Ok valResult ->
@@ -720,7 +729,7 @@ let main args =
 
                 Console.WriteLine(output)
 
-                if valResult.TotalErrors > 0 then
+                if valResult.TotalErrors > 0 || valResult.HasProgressErrors then
                     Environment.ExitCode <- 1
             | Error e ->
                 Environment.ExitCode <- 1

--- a/src/Frank.Cli/Program.fs
+++ b/src/Frank.Cli/Program.fs
@@ -716,7 +716,7 @@ let main args =
             Environment.ExitCode <- 1
         else
             let result =
-                UnifiedValidateCommand.execute project force checkProgress
+                UnifiedValidateCommand.execute project force checkProjection checkProgress
                 |> Async.RunSynchronously
 
             match result with

--- a/src/Frank.Resources.Model/Frank.Resources.Model.fsproj
+++ b/src/Frank.Resources.Model/Frank.Resources.Model.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="TypeAnalysis.fs" />
     <Compile Include="ResourceTypes.fs" />
     <Compile Include="Projection.fs" />
+    <Compile Include="ProgressAnalysis.fs" />
     <Compile Include="RuntimeTypes.fs" />
     <Compile Include="AffordanceTypes.fs" />
   </ItemGroup>

--- a/src/Frank.Resources.Model/ProgressAnalysis.fs
+++ b/src/Frank.Resources.Model/ProgressAnalysis.fs
@@ -40,6 +40,43 @@ module ProgressAnalysis =
           StatesAnalyzed: int
           RolesAnalyzed: string list }
 
+    /// Non-final states where no role has an advancing+live transition out.
+    let detectDeadlocks (statechart: ExtractedStatechart) : ProgressDiagnostic list =
+        let isFinal state =
+            statechart.StateMetadata
+            |> Map.tryFind state
+            |> Option.map (fun si -> si.IsFinal)
+            |> Option.defaultValue false
+
+        let transitionsBySource =
+            statechart.Transitions
+            |> List.groupBy (fun t -> t.Source)
+            |> Map.ofList
+
+        statechart.StateNames
+        |> List.choose (fun state ->
+            if isFinal state then
+                None
+            else
+                let transitions =
+                    transitionsBySource
+                    |> Map.tryFind state
+                    |> Option.defaultValue []
+
+                let advancingLive =
+                    transitions |> List.filter (fun t -> isAdvancing t && isLive t)
+
+                if List.isEmpty advancingLive then
+                    let selfLoopEvents =
+                        transitions
+                        |> List.filter (fun t -> t.Source = t.Target)
+                        |> List.map (fun t -> t.Event)
+                        |> List.distinct
+
+                    Some(Deadlock(state, selfLoopEvents))
+                else
+                    None)
+
     /// Roles with zero advancing+live transitions — they can only observe, not advance.
     let identifyReadOnlyRoles (projections: Map<string, ExtractedStatechart>) : string list =
         projections

--- a/src/Frank.Resources.Model/ProgressAnalysis.fs
+++ b/src/Frank.Resources.Model/ProgressAnalysis.fs
@@ -91,7 +91,8 @@ module ProgressAnalysis =
         |> List.map (fun (k, ts) -> k, ts |> List.map (fun t -> t.Target) |> List.distinct)
         |> Map.ofList
 
-    /// BFS forward reachability from a start state using the given adjacency map.
+    /// Forward reachability from a start state using the given adjacency map.
+    /// Traversal order is immaterial — only the reachable set matters.
     let private forwardReachable (adjacency: Map<string, string list>) (start: string) : Set<string> =
         let rec bfs (visited: Set<string>) (frontier: string list) =
             match frontier with
@@ -134,7 +135,12 @@ module ProgressAnalysis =
 
         roleNames
         |> List.collect (fun role ->
-            let roleChart = projections |> Map.tryFind role |> Option.defaultValue statechart
+            // roleNames is drawn from projections keys, so tryFind always succeeds.
+            // Fallback to empty-transition chart ensures starvation is reported if invariant breaks.
+            let roleChart =
+                projections
+                |> Map.tryFind role
+                |> Option.defaultValue { statechart with Transitions = [] }
 
             let activeStates =
                 roleChart.Transitions
@@ -150,6 +156,7 @@ module ProgressAnalysis =
                     let reachable = forwardReachable adjacency state
 
                     if Set.intersect reachable activeStates |> Set.isEmpty then
+                        // reachable includes start state itself; exclude it since it's already named in excludedAfter
                         let excludedStates =
                             reachable
                             |> Set.toList
@@ -164,11 +171,7 @@ module ProgressAnalysis =
     /// Prunes unreachable states first to avoid false positives from disconnected fragments.
     let analyzeProgress (statechart: ExtractedStatechart) : ProgressReport =
         let pruned = Projection.pruneUnreachableStates statechart
-
-        let projections =
-            statechart.Roles
-            |> List.map (fun r -> r.Name, Projection.filterTransitionsByRole r.Name pruned)
-            |> Map.ofList
+        let projections = Projection.projectAll pruned
 
         let readOnlyRoles = identifyReadOnlyRoles projections
         let deadlocks = detectDeadlocks pruned

--- a/src/Frank.Resources.Model/ProgressAnalysis.fs
+++ b/src/Frank.Resources.Model/ProgressAnalysis.fs
@@ -1,0 +1,41 @@
+namespace Frank.Resources.Model
+
+/// Progress analysis for statechart protocols.
+/// Detects deadlocks (no role can advance) and starvation (role permanently excluded).
+/// All functions are pure, total, and format-agnostic.
+module ProgressAnalysis =
+
+    /// A transition that advances the protocol (Source <> Target).
+    /// Self-loops (getGame: XTurn -> XTurn) are observations, not progress.
+    /// Assumption: operates on flat extracted statechart where hierarchy is resolved.
+    let isAdvancing (t: TransitionSpec) : bool = t.Source <> t.Target
+
+    /// A transition that at least one role can trigger.
+    /// RestrictedTo [] = dead transition (no role can fire it).
+    let isLive (t: TransitionSpec) : bool =
+        match t.Constraint with
+        | RestrictedTo [] -> false
+        | _ -> true
+
+    type ProgressDiagnostic =
+        /// Non-final state where no role has an advancing+live transition. Error severity.
+        | Deadlock of state: string * selfLoopEvents: string list
+        /// Role permanently excluded on ALL forward paths from a reachable state. Warning severity.
+        | Starvation of role: string * excludedAfter: string * excludedStates: string list
+        /// Role with zero advancing transitions in any state. Info severity (expected for observers).
+        | ReadOnlyRole of role: string
+
+    module ProgressDiagnostic =
+        let severity =
+            function
+            | Deadlock _ -> "error"
+            | Starvation _ -> "warning"
+            | ReadOnlyRole _ -> "info"
+
+    type ProgressReport =
+        { Route: string
+          Diagnostics: ProgressDiagnostic list
+          HasErrors: bool
+          HasWarnings: bool
+          StatesAnalyzed: int
+          RolesAnalyzed: string list }

--- a/src/Frank.Resources.Model/ProgressAnalysis.fs
+++ b/src/Frank.Resources.Model/ProgressAnalysis.fs
@@ -174,3 +174,26 @@ module ProgressAnalysis =
                         Some(Starvation(role, state, excludedStates))
                     else
                         None))
+
+    /// Run all progress checks on a statechart.
+    /// Prunes unreachable states first to avoid false positives from disconnected fragments.
+    let analyzeProgress (statechart: ExtractedStatechart) : ProgressReport =
+        let pruned = Projection.pruneUnreachableStates statechart
+        let projections = Projection.projectAll pruned
+
+        let readOnlyRoles = identifyReadOnlyRoles projections
+        let deadlocks = detectDeadlocks pruned
+        let starvation = detectStarvation pruned projections readOnlyRoles
+
+        let readOnlyDiagnostics =
+            readOnlyRoles |> List.map ReadOnlyRole
+
+        let allDiagnostics =
+            deadlocks @ starvation @ readOnlyDiagnostics
+
+        { Route = statechart.RouteTemplate
+          Diagnostics = allDiagnostics
+          HasErrors = deadlocks |> List.isEmpty |> not
+          HasWarnings = starvation |> List.isEmpty |> not
+          StatesAnalyzed = pruned.StateNames.Length
+          RolesAnalyzed = statechart.Roles |> List.map (fun r -> r.Name) }

--- a/src/Frank.Resources.Model/ProgressAnalysis.fs
+++ b/src/Frank.Resources.Model/ProgressAnalysis.fs
@@ -87,3 +87,90 @@ module ProgressAnalysis =
                 |> List.exists (fun t -> isAdvancing t && isLive t)
 
             if hasAdvancing then None else Some role)
+
+    /// Build adjacency map using only live transitions (dead transitions excluded from BFS).
+    /// Harel soundness fix: dead transitions can't be traversed, so they don't count as escape paths.
+    let private buildLiveAdjacency (transitions: TransitionSpec list) : Map<string, string list> =
+        transitions
+        |> List.filter isLive
+        |> List.groupBy (fun t -> t.Source)
+        |> List.map (fun (k, ts) -> k, ts |> List.map (fun t -> t.Target) |> List.distinct)
+        |> Map.ofList
+
+    /// BFS forward reachability from a start state using the given adjacency map.
+    let private forwardReachable (adjacency: Map<string, string list>) (start: string) : Set<string> =
+        let rec bfs (visited: Set<string>) (frontier: string list) =
+            match frontier with
+            | [] -> visited
+            | state :: rest ->
+                if Set.contains state visited then
+                    bfs visited rest
+                else
+                    let visited' = Set.add state visited
+
+                    let neighbors =
+                        adjacency
+                        |> Map.tryFind state
+                        |> Option.defaultValue []
+                        |> List.filter (fun s -> not (Set.contains s visited'))
+
+                    bfs visited' (neighbors @ rest)
+
+        bfs Set.empty [ start ]
+
+    /// Roles permanently excluded on ALL forward paths from a non-final reachable state.
+    /// Only strong starvation reported: excluded on every path, not just some paths.
+    /// Read-only roles are excluded from analysis (they're expected observers).
+    let detectStarvation
+        (statechart: ExtractedStatechart)
+        (projections: Map<string, ExtractedStatechart>)
+        (readOnlyRoles: string list)
+        : ProgressDiagnostic list =
+        let isFinal state =
+            statechart.StateMetadata
+            |> Map.tryFind state
+            |> Option.map (fun si -> si.IsFinal)
+            |> Option.defaultValue false
+
+        let adjacency = buildLiveAdjacency statechart.Transitions
+
+        let roleNames =
+            projections
+            |> Map.keys
+            |> Seq.filter (fun r -> not (List.contains r readOnlyRoles))
+            |> Seq.toList
+
+        roleNames
+        |> List.collect (fun role ->
+            let roleChart =
+                projections
+                |> Map.tryFind role
+                |> Option.defaultValue statechart
+
+            let activeStates =
+                roleChart.Transitions
+                |> List.filter isAdvancing
+                |> List.map (fun t -> t.Source)
+                |> Set.ofList
+
+            let nonFinalStates =
+                statechart.StateNames
+                |> List.filter (fun s -> not (isFinal s))
+
+            nonFinalStates
+            |> List.choose (fun state ->
+                if Set.contains state activeStates then
+                    None
+                else
+                    let reachable = forwardReachable adjacency state
+
+                    if Set.intersect reachable activeStates |> Set.isEmpty then
+                        let excludedStates =
+                            reachable
+                            |> Set.toList
+                            |> List.filter (fun s ->
+                                s <> state && not (isFinal s) && not (Set.contains s activeStates))
+
+                        Some(Starvation(role, state, excludedStates))
+                    else
+                        None))

--- a/src/Frank.Resources.Model/ProgressAnalysis.fs
+++ b/src/Frank.Resources.Model/ProgressAnalysis.fs
@@ -40,21 +40,21 @@ module ProgressAnalysis =
           StatesAnalyzed: int
           RolesAnalyzed: string list }
 
+    let private isFinal (statechart: ExtractedStatechart) (state: string) : bool =
+        statechart.StateMetadata
+        |> Map.tryFind state
+        |> Option.map (fun si -> si.IsFinal)
+        |> Option.defaultValue false
+
     /// Non-final states where no role has an advancing+live transition out.
     /// Caller is responsible for pruning unreachable states first; see analyzeProgress.
     let detectDeadlocks (statechart: ExtractedStatechart) : ProgressDiagnostic list =
-        let isFinal state =
-            statechart.StateMetadata
-            |> Map.tryFind state
-            |> Option.map (fun si -> si.IsFinal)
-            |> Option.defaultValue false
-
         let transitionsBySource =
             statechart.Transitions |> List.groupBy (fun t -> t.Source) |> Map.ofList
 
         statechart.StateNames
         |> List.choose (fun state ->
-            if isFinal state then
+            if isFinal statechart state then
                 None
             else
                 let transitions = transitionsBySource |> Map.tryFind state |> Option.defaultValue []
@@ -120,18 +120,16 @@ module ProgressAnalysis =
         (projections: Map<string, ExtractedStatechart>)
         (readOnlyRoles: string list)
         : ProgressDiagnostic list =
-        let isFinal state =
-            statechart.StateMetadata
-            |> Map.tryFind state
-            |> Option.map (fun si -> si.IsFinal)
-            |> Option.defaultValue false
-
         let adjacency = buildLiveAdjacency statechart.Transitions
+        let readOnlySet = Set.ofList readOnlyRoles
+
+        let nonFinalStates =
+            statechart.StateNames |> List.filter (fun s -> not (isFinal statechart s))
 
         let roleNames =
             projections
             |> Map.keys
-            |> Seq.filter (fun r -> not (List.contains r readOnlyRoles))
+            |> Seq.filter (fun r -> not (Set.contains r readOnlySet))
             |> Seq.toList
 
         roleNames
@@ -143,8 +141,6 @@ module ProgressAnalysis =
                 |> List.filter (fun t -> isAdvancing t && isLive t)
                 |> List.map (fun t -> t.Source)
                 |> Set.ofList
-
-            let nonFinalStates = statechart.StateNames |> List.filter (fun s -> not (isFinal s))
 
             nonFinalStates
             |> List.choose (fun state ->
@@ -158,7 +154,7 @@ module ProgressAnalysis =
                             reachable
                             |> Set.toList
                             |> List.filter (fun s ->
-                                s <> state && not (isFinal s) && not (Set.contains s activeStates))
+                                s <> state && not (isFinal statechart s) && not (Set.contains s activeStates))
 
                         Some(Starvation(role, state, excludedStates))
                     else
@@ -168,7 +164,11 @@ module ProgressAnalysis =
     /// Prunes unreachable states first to avoid false positives from disconnected fragments.
     let analyzeProgress (statechart: ExtractedStatechart) : ProgressReport =
         let pruned = Projection.pruneUnreachableStates statechart
-        let projections = Projection.projectAll pruned
+
+        let projections =
+            statechart.Roles
+            |> List.map (fun r -> r.Name, Projection.filterTransitionsByRole r.Name pruned)
+            |> Map.ofList
 
         let readOnlyRoles = identifyReadOnlyRoles projections
         let deadlocks = detectDeadlocks pruned

--- a/src/Frank.Resources.Model/ProgressAnalysis.fs
+++ b/src/Frank.Resources.Model/ProgressAnalysis.fs
@@ -39,3 +39,14 @@ module ProgressAnalysis =
           HasWarnings: bool
           StatesAnalyzed: int
           RolesAnalyzed: string list }
+
+    /// Roles with zero advancing+live transitions — they can only observe, not advance.
+    let identifyReadOnlyRoles (projections: Map<string, ExtractedStatechart>) : string list =
+        projections
+        |> Map.toList
+        |> List.choose (fun (role, chart) ->
+            let hasAdvancing =
+                chart.Transitions
+                |> List.exists (fun t -> isAdvancing t && isLive t)
+
+            if hasAdvancing then None else Some role)

--- a/src/Frank.Resources.Model/ProgressAnalysis.fs
+++ b/src/Frank.Resources.Model/ProgressAnalysis.fs
@@ -41,6 +41,7 @@ module ProgressAnalysis =
           RolesAnalyzed: string list }
 
     /// Non-final states where no role has an advancing+live transition out.
+    /// Caller is responsible for pruning unreachable states first; see analyzeProgress.
     let detectDeadlocks (statechart: ExtractedStatechart) : ProgressDiagnostic list =
         let isFinal state =
             statechart.StateMetadata
@@ -49,22 +50,16 @@ module ProgressAnalysis =
             |> Option.defaultValue false
 
         let transitionsBySource =
-            statechart.Transitions
-            |> List.groupBy (fun t -> t.Source)
-            |> Map.ofList
+            statechart.Transitions |> List.groupBy (fun t -> t.Source) |> Map.ofList
 
         statechart.StateNames
         |> List.choose (fun state ->
             if isFinal state then
                 None
             else
-                let transitions =
-                    transitionsBySource
-                    |> Map.tryFind state
-                    |> Option.defaultValue []
+                let transitions = transitionsBySource |> Map.tryFind state |> Option.defaultValue []
 
-                let advancingLive =
-                    transitions |> List.filter (fun t -> isAdvancing t && isLive t)
+                let advancingLive = transitions |> List.filter (fun t -> isAdvancing t && isLive t)
 
                 if List.isEmpty advancingLive then
                     let selfLoopEvents =
@@ -83,8 +78,7 @@ module ProgressAnalysis =
         |> Map.toList
         |> List.choose (fun (role, chart) ->
             let hasAdvancing =
-                chart.Transitions
-                |> List.exists (fun t -> isAdvancing t && isLive t)
+                chart.Transitions |> List.exists (fun t -> isAdvancing t && isLive t)
 
             if hasAdvancing then None else Some role)
 
@@ -142,20 +136,15 @@ module ProgressAnalysis =
 
         roleNames
         |> List.collect (fun role ->
-            let roleChart =
-                projections
-                |> Map.tryFind role
-                |> Option.defaultValue statechart
+            let roleChart = projections |> Map.tryFind role |> Option.defaultValue statechart
 
             let activeStates =
                 roleChart.Transitions
-                |> List.filter isAdvancing
+                |> List.filter (fun t -> isAdvancing t && isLive t)
                 |> List.map (fun t -> t.Source)
                 |> Set.ofList
 
-            let nonFinalStates =
-                statechart.StateNames
-                |> List.filter (fun s -> not (isFinal s))
+            let nonFinalStates = statechart.StateNames |> List.filter (fun s -> not (isFinal s))
 
             nonFinalStates
             |> List.choose (fun state ->
@@ -185,11 +174,9 @@ module ProgressAnalysis =
         let deadlocks = detectDeadlocks pruned
         let starvation = detectStarvation pruned projections readOnlyRoles
 
-        let readOnlyDiagnostics =
-            readOnlyRoles |> List.map ReadOnlyRole
+        let readOnlyDiagnostics = readOnlyRoles |> List.map ReadOnlyRole
 
-        let allDiagnostics =
-            deadlocks @ starvation @ readOnlyDiagnostics
+        let allDiagnostics = deadlocks @ starvation @ readOnlyDiagnostics
 
         { Route = statechart.RouteTemplate
           Diagnostics = allDiagnostics

--- a/test/Frank.Resources.Model.Tests/Frank.Resources.Model.Tests.fsproj
+++ b/test/Frank.Resources.Model.Tests/Frank.Resources.Model.Tests.fsproj
@@ -6,6 +6,7 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="TestHelpers.fs" />
     <Compile Include="ResourceSlugTests.fs" />
     <Compile Include="AffordanceMapTests.fs" />
     <Compile Include="ProjectionTests.fs" />

--- a/test/Frank.Resources.Model.Tests/Frank.Resources.Model.Tests.fsproj
+++ b/test/Frank.Resources.Model.Tests/Frank.Resources.Model.Tests.fsproj
@@ -9,6 +9,7 @@
     <Compile Include="ResourceSlugTests.fs" />
     <Compile Include="AffordanceMapTests.fs" />
     <Compile Include="ProjectionTests.fs" />
+    <Compile Include="ProgressAnalysisTests.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
+++ b/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
@@ -249,6 +249,34 @@ let private disconnectedChart: ExtractedStatechart =
 // -- Tests --
 
 [<Tests>]
+let readOnlyRoleTests =
+    testList
+        "identifyReadOnlyRoles"
+        [ testCase "Spectator in TicTacToe is read-only"
+          <| fun _ ->
+              let projections = Projection.projectAll ticTacToeChart
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              Expect.contains readOnly "Spectator" "Spectator is read-only"
+
+          testCase "PlayerX in TicTacToe is not read-only"
+          <| fun _ ->
+              let projections = Projection.projectAll ticTacToeChart
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              Expect.isFalse (List.contains "PlayerX" readOnly) "PlayerX is not read-only"
+
+          testCase "all-unrestricted chart has no read-only roles"
+          <| fun _ ->
+              let projections = Projection.projectAll allUnrestrictedChart
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              Expect.isEmpty readOnly "No read-only roles when all unrestricted"
+
+          testCase "role with only dead transitions is read-only"
+          <| fun _ ->
+              let projections = Projection.projectAll deadTransitionDeadlockChart
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              Expect.contains readOnly "Admin" "Admin with only dead advancing transition is read-only" ]
+
+[<Tests>]
 let predicateTests =
     testList
         "predicates"

--- a/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
+++ b/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
@@ -34,9 +34,12 @@ let private ticTacToeChart: ExtractedStatechart =
               "OWins", mkState true
               "Draw", mkState true ]
       Roles =
-        [ { Name = "PlayerX"; Description = Some "Player X" }
-          { Name = "PlayerO"; Description = Some "Player O" }
-          { Name = "Spectator"; Description = Some "Observer" } ]
+        [ { Name = "PlayerX"
+            Description = Some "Player X" }
+          { Name = "PlayerO"
+            Description = Some "Player O" }
+          { Name = "Spectator"
+            Description = Some "Observer" } ]
       Transitions =
         [ mkTransition "getGame" "XTurn" "XTurn" None Unrestricted
           mkTransition "getGame" "OTurn" "OTurn" None Unrestricted
@@ -56,11 +59,9 @@ let private deadlockSelfLoopChart: ExtractedStatechart =
       StateNames = [ "Stuck"; "Done" ]
       InitialStateKey = "Stuck"
       GuardNames = []
-      StateMetadata =
-        Map.ofList [ "Stuck", mkState false; "Done", mkState true ]
+      StateMetadata = Map.ofList [ "Stuck", mkState false; "Done", mkState true ]
       Roles = [ { Name = "Admin"; Description = None } ]
-      Transitions =
-        [ mkTransition "refresh" "Stuck" "Stuck" None Unrestricted ] }
+      Transitions = [ mkTransition "refresh" "Stuck" "Stuck" None Unrestricted ] }
 
 /// Only advancing transition is RestrictedTo [] (dead).
 let private deadTransitionDeadlockChart: ExtractedStatechart =
@@ -68,8 +69,7 @@ let private deadTransitionDeadlockChart: ExtractedStatechart =
       StateNames = [ "Active"; "Archived" ]
       InitialStateKey = "Active"
       GuardNames = []
-      StateMetadata =
-        Map.ofList [ "Active", mkState false; "Archived", mkState true ]
+      StateMetadata = Map.ofList [ "Active", mkState false; "Archived", mkState true ]
       Roles = [ { Name = "Admin"; Description = None } ]
       Transitions =
         [ mkTransition "view" "Active" "Active" None Unrestricted
@@ -127,8 +127,7 @@ let private allUnrestrictedChart: ExtractedStatechart =
       StateNames = [ "A"; "B"; "Done" ]
       InitialStateKey = "A"
       GuardNames = []
-      StateMetadata =
-        Map.ofList [ "A", mkState false; "B", mkState false; "Done", mkState true ]
+      StateMetadata = Map.ofList [ "A", mkState false; "B", mkState false; "Done", mkState true ]
       Roles =
         [ { Name = "User"; Description = None }
           { Name = "Admin"; Description = None } ]
@@ -199,11 +198,7 @@ let private reachableDeadEndChart: ExtractedStatechart =
       StateNames = [ "Start"; "DeadEnd"; "Done" ]
       InitialStateKey = "Start"
       GuardNames = []
-      StateMetadata =
-        Map.ofList
-            [ "Start", mkState false
-              "DeadEnd", mkState false
-              "Done", mkState true ]
+      StateMetadata = Map.ofList [ "Start", mkState false; "DeadEnd", mkState false; "Done", mkState true ]
       Roles = [ { Name = "User"; Description = None } ]
       Transitions =
         [ mkTransition "enter" "Start" "DeadEnd" None Unrestricted
@@ -238,11 +233,7 @@ let private disconnectedChart: ExtractedStatechart =
       StateNames = [ "Start"; "Done"; "Orphan" ]
       InitialStateKey = "Start"
       GuardNames = []
-      StateMetadata =
-        Map.ofList
-            [ "Start", mkState false
-              "Done", mkState true
-              "Orphan", mkState false ]
+      StateMetadata = Map.ofList [ "Start", mkState false; "Done", mkState true; "Orphan", mkState false ]
       Roles = [ { Name = "User"; Description = None } ]
       Transitions =
         [ mkTransition "finish" "Start" "Done" None Unrestricted
@@ -321,6 +312,7 @@ let deadlockTests =
           <| fun _ ->
               let deadlocks = ProgressAnalysis.detectDeadlocks deadlockSelfLoopChart
               Expect.hasLength deadlocks 1 "One deadlock"
+
               match deadlocks.[0] with
               | ProgressAnalysis.Deadlock(state, selfLoops) ->
                   Expect.equal state "Stuck" "Deadlock at Stuck"
@@ -331,6 +323,7 @@ let deadlockTests =
           <| fun _ ->
               let deadlocks = ProgressAnalysis.detectDeadlocks deadTransitionDeadlockChart
               Expect.hasLength deadlocks 1 "One deadlock"
+
               match deadlocks.[0] with
               | ProgressAnalysis.Deadlock(state, selfLoops) ->
                   Expect.equal state "Active" "Deadlock at Active"
@@ -346,6 +339,7 @@ let deadlockTests =
           <| fun _ ->
               let deadlocks = ProgressAnalysis.detectDeadlocks emptyTransitionsChart
               Expect.hasLength deadlocks 1 "One deadlock"
+
               match deadlocks.[0] with
               | ProgressAnalysis.Deadlock(state, selfLoops) ->
                   Expect.equal state "Idle" "Deadlock at Idle"
@@ -355,12 +349,14 @@ let deadlockTests =
           testCase "reachable dead-end is deadlock"
           <| fun _ ->
               let deadlocks = ProgressAnalysis.detectDeadlocks reachableDeadEndChart
+
               let deadEndDiags =
                   deadlocks
                   |> List.choose (fun d ->
                       match d with
                       | ProgressAnalysis.Deadlock(s, _) when s = "DeadEnd" -> Some d
                       | _ -> None)
+
               Expect.hasLength deadEndDiags 1 "DeadEnd is a deadlock"
 
           testCase "cycle without final states is NOT deadlock"
@@ -386,12 +382,14 @@ let starvationTests =
               let projections = Projection.projectAll pruned
               let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
               let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+
               let workerDiags =
                   starvation
                   |> List.choose (fun d ->
                       match d with
                       | ProgressAnalysis.Starvation(r, _, _) when r = "Worker" -> Some d
                       | _ -> None)
+
               Expect.isNonEmpty workerDiags "Worker is starved"
 
           testCase "read-only roles excluded from analysis"
@@ -400,12 +398,14 @@ let starvationTests =
               let projections = Projection.projectAll pruned
               let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
               let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+
               let spectatorDiags =
                   starvation
                   |> List.choose (fun d ->
                       match d with
                       | ProgressAnalysis.Starvation(r, _, _) when r = "Spectator" -> Some d
                       | _ -> None)
+
               Expect.isEmpty spectatorDiags "Spectator excluded from starvation analysis"
 
           testCase "all-unrestricted has no starvation"
@@ -422,12 +422,14 @@ let starvationTests =
               let projections = Projection.projectAll pruned
               let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
               let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+
               let roleBDiags =
                   starvation
                   |> List.choose (fun d ->
                       match d with
                       | ProgressAnalysis.Starvation(r, _, _) when r = "RoleB" -> Some d
                       | _ -> None)
+
               Expect.isNonEmpty roleBDiags "RoleB starved — recovery only via dead transition"
 
           testCase "diamond topology is NOT starvation"
@@ -436,12 +438,14 @@ let starvationTests =
               let projections = Projection.projectAll pruned
               let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
               let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+
               let roleBDiags =
                   starvation
                   |> List.choose (fun d ->
                       match d with
                       | ProgressAnalysis.Starvation(r, _, _) when r = "RoleB" -> Some d
                       | _ -> None)
+
               Expect.isEmpty roleBDiags "RoleB recovers at D via diamond paths"
 
           testCase "multiple starvation entry points emit two diagnostics"
@@ -450,16 +454,15 @@ let starvationTests =
               let projections = Projection.projectAll pruned
               let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
               let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+
               let roleBDiags =
                   starvation
                   |> List.choose (fun d ->
                       match d with
                       | ProgressAnalysis.Starvation(r, _, _) when r = "RoleB" -> Some d
                       | _ -> None)
-              Expect.isGreaterThanOrEqual
-                  (List.length roleBDiags)
-                  2
-                  "RoleB starved from both Branch1 and Branch2" ]
+
+              Expect.isGreaterThanOrEqual (List.length roleBDiags) 2 "RoleB starved from both Branch1 and Branch2" ]
 
 [<Tests>]
 let analyzeProgressTests =
@@ -472,12 +475,14 @@ let analyzeProgressTests =
               Expect.isFalse report.HasWarnings "No warnings"
               Expect.equal report.StatesAnalyzed 5 "5 states analyzed"
               Expect.equal report.Route "/games/{gameId}" "Route preserved"
+
               let readOnlyDiags =
                   report.Diagnostics
                   |> List.choose (fun d ->
                       match d with
                       | ProgressAnalysis.ReadOnlyRole r -> Some r
                       | _ -> None)
+
               Expect.equal readOnlyDiags [ "Spectator" ] "Spectator is read-only"
 
           testCase "deadlock chart has errors"
@@ -493,12 +498,14 @@ let analyzeProgressTests =
           testCase "disconnected chart: pruning prevents false deadlock"
           <| fun _ ->
               let report = ProgressAnalysis.analyzeProgress disconnectedChart
+
               let orphanDeadlocks =
                   report.Diagnostics
                   |> List.choose (fun d ->
                       match d with
                       | ProgressAnalysis.Deadlock(s, _) when s = "Orphan" -> Some s
                       | _ -> None)
+
               Expect.isEmpty orphanDeadlocks "Orphan state pruned, no false deadlock"
 
           testCase "RolesAnalyzed populated correctly"

--- a/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
+++ b/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
@@ -460,3 +460,50 @@ let starvationTests =
                   (List.length roleBDiags)
                   2
                   "RoleB starved from both Branch1 and Branch2" ]
+
+[<Tests>]
+let analyzeProgressTests =
+    testList
+        "analyzeProgress"
+        [ testCase "TicTacToe: no errors, no warnings, 1 read-only"
+          <| fun _ ->
+              let report = ProgressAnalysis.analyzeProgress ticTacToeChart
+              Expect.isFalse report.HasErrors "No errors"
+              Expect.isFalse report.HasWarnings "No warnings"
+              Expect.equal report.StatesAnalyzed 5 "5 states analyzed"
+              Expect.equal report.Route "/games/{gameId}" "Route preserved"
+              let readOnlyDiags =
+                  report.Diagnostics
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.ReadOnlyRole r -> Some r
+                      | _ -> None)
+              Expect.equal readOnlyDiags [ "Spectator" ] "Spectator is read-only"
+
+          testCase "deadlock chart has errors"
+          <| fun _ ->
+              let report = ProgressAnalysis.analyzeProgress deadlockSelfLoopChart
+              Expect.isTrue report.HasErrors "Has errors"
+
+          testCase "starvation chart has warnings"
+          <| fun _ ->
+              let report = ProgressAnalysis.analyzeProgress starvationChart
+              Expect.isTrue report.HasWarnings "Has warnings"
+
+          testCase "disconnected chart: pruning prevents false deadlock"
+          <| fun _ ->
+              let report = ProgressAnalysis.analyzeProgress disconnectedChart
+              let orphanDeadlocks =
+                  report.Diagnostics
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.Deadlock(s, _) when s = "Orphan" -> Some s
+                      | _ -> None)
+              Expect.isEmpty orphanDeadlocks "Orphan state pruned, no false deadlock"
+
+          testCase "RolesAnalyzed populated correctly"
+          <| fun _ ->
+              let report = ProgressAnalysis.analyzeProgress ticTacToeChart
+              Expect.hasLength report.RolesAnalyzed 3 "3 roles"
+              Expect.contains report.RolesAnalyzed "PlayerX" "PlayerX in list"
+              Expect.contains report.RolesAnalyzed "Spectator" "Spectator in list" ]

--- a/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
+++ b/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
@@ -75,7 +75,8 @@ let private deadTransitionDeadlockChart: ExtractedStatechart =
         [ mkTransition "view" "Active" "Active" None Unrestricted
           mkTransition "archive" "Active" "Archived" None (RestrictedTo []) ] }
 
-/// Role permanently excluded after a state on all forward paths.
+/// Role permanently excluded after Phase1 on all forward paths.
+/// Worker can initiate (Phase1→Phase2 unrestricted) but is locked out of Phase2 onward.
 let private starvationChart: ExtractedStatechart =
     { RouteTemplate = "/workflow"
       StateNames = [ "Phase1"; "Phase2"; "Phase3"; "Done" ]
@@ -91,7 +92,7 @@ let private starvationChart: ExtractedStatechart =
         [ { Name = "Admin"; Description = None }
           { Name = "Worker"; Description = None } ]
       Transitions =
-        [ mkTransition "start" "Phase1" "Phase2" None (RestrictedTo [ "Admin" ])
+        [ mkTransition "start" "Phase1" "Phase2" None Unrestricted
           mkTransition "advance" "Phase2" "Phase3" None (RestrictedTo [ "Admin" ])
           mkTransition "complete" "Phase3" "Done" None (RestrictedTo [ "Admin" ])
           mkTransition "view" "Phase1" "Phase1" None Unrestricted
@@ -208,7 +209,8 @@ let private reachableDeadEndChart: ExtractedStatechart =
         [ mkTransition "enter" "Start" "DeadEnd" None Unrestricted
           mkTransition "skip" "Start" "Done" None Unrestricted ] }
 
-/// Same role excluded from two independent states — two diagnostics.
+/// Same role excluded from two independent branch states — two starvation diagnostics.
+/// RoleB can join the workflow at Start (unrestricted entry) but both branches exclude it.
 let private multipleStarvationChart: ExtractedStatechart =
     { RouteTemplate = "/multi-starve"
       StateNames = [ "Start"; "Branch1"; "Branch2"; "End1"; "End2" ]
@@ -225,8 +227,8 @@ let private multipleStarvationChart: ExtractedStatechart =
         [ { Name = "RoleA"; Description = None }
           { Name = "RoleB"; Description = None } ]
       Transitions =
-        [ mkTransition "go1" "Start" "Branch1" None (RestrictedTo [ "RoleA" ])
-          mkTransition "go2" "Start" "Branch2" None (RestrictedTo [ "RoleA" ])
+        [ mkTransition "go1" "Start" "Branch1" None Unrestricted
+          mkTransition "go2" "Start" "Branch2" None Unrestricted
           mkTransition "end1" "Branch1" "End1" None (RestrictedTo [ "RoleA" ])
           mkTransition "end2" "Branch2" "End2" None (RestrictedTo [ "RoleA" ]) ] }
 
@@ -365,3 +367,96 @@ let deadlockTests =
           <| fun _ ->
               let deadlocks = ProgressAnalysis.detectDeadlocks cycleNoFinalChart
               Expect.isEmpty deadlocks "Cycle with advancing transitions is not deadlock" ]
+
+[<Tests>]
+let starvationTests =
+    testList
+        "detectStarvation"
+        [ testCase "TicTacToe PlayerX in OTurn is NOT starvation"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates ticTacToeChart
+              let projections = Projection.projectAll pruned
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+              Expect.isEmpty starvation "Turn-taking is not starvation"
+
+          testCase "Worker permanently excluded is starvation"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates starvationChart
+              let projections = Projection.projectAll pruned
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+              let workerDiags =
+                  starvation
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.Starvation(r, _, _) when r = "Worker" -> Some d
+                      | _ -> None)
+              Expect.isNonEmpty workerDiags "Worker is starved"
+
+          testCase "read-only roles excluded from analysis"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates ticTacToeChart
+              let projections = Projection.projectAll pruned
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+              let spectatorDiags =
+                  starvation
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.Starvation(r, _, _) when r = "Spectator" -> Some d
+                      | _ -> None)
+              Expect.isEmpty spectatorDiags "Spectator excluded from starvation analysis"
+
+          testCase "all-unrestricted has no starvation"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates allUnrestrictedChart
+              let projections = Projection.projectAll pruned
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+              Expect.isEmpty starvation "All-unrestricted has no starvation"
+
+          testCase "dead transition in forward path still reports starvation"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates deadTransitionForwardPathChart
+              let projections = Projection.projectAll pruned
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+              let roleBDiags =
+                  starvation
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.Starvation(r, _, _) when r = "RoleB" -> Some d
+                      | _ -> None)
+              Expect.isNonEmpty roleBDiags "RoleB starved — recovery only via dead transition"
+
+          testCase "diamond topology is NOT starvation"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates diamondChart
+              let projections = Projection.projectAll pruned
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+              let roleBDiags =
+                  starvation
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.Starvation(r, _, _) when r = "RoleB" -> Some d
+                      | _ -> None)
+              Expect.isEmpty roleBDiags "RoleB recovers at D via diamond paths"
+
+          testCase "multiple starvation entry points emit two diagnostics"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates multipleStarvationChart
+              let projections = Projection.projectAll pruned
+              let readOnly = ProgressAnalysis.identifyReadOnlyRoles projections
+              let starvation = ProgressAnalysis.detectStarvation pruned projections readOnly
+              let roleBDiags =
+                  starvation
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.Starvation(r, _, _) when r = "RoleB" -> Some d
+                      | _ -> None)
+              Expect.isGreaterThanOrEqual
+                  (List.length roleBDiags)
+                  2
+                  "RoleB starved from both Branch1 and Branch2" ]

--- a/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
+++ b/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
@@ -304,3 +304,64 @@ let predicateTests =
           <| fun _ ->
               let t = mkTransition "go" "A" "B" None (RestrictedTo [])
               Expect.isFalse (ProgressAnalysis.isLive t) "RestrictedTo [] is dead" ]
+
+[<Tests>]
+let deadlockTests =
+    testList
+        "detectDeadlocks"
+        [ testCase "TicTacToe has no deadlocks"
+          <| fun _ ->
+              let pruned = Projection.pruneUnreachableStates ticTacToeChart
+              let deadlocks = ProgressAnalysis.detectDeadlocks pruned
+              Expect.isEmpty deadlocks "TicTacToe has no deadlocks"
+
+          testCase "self-loop-only state is deadlock with selfLoopEvents"
+          <| fun _ ->
+              let deadlocks = ProgressAnalysis.detectDeadlocks deadlockSelfLoopChart
+              Expect.hasLength deadlocks 1 "One deadlock"
+              match deadlocks.[0] with
+              | ProgressAnalysis.Deadlock(state, selfLoops) ->
+                  Expect.equal state "Stuck" "Deadlock at Stuck"
+                  Expect.contains selfLoops "refresh" "Self-loop event reported"
+              | _ -> failtest "Expected Deadlock diagnostic"
+
+          testCase "dead transition state is deadlock"
+          <| fun _ ->
+              let deadlocks = ProgressAnalysis.detectDeadlocks deadTransitionDeadlockChart
+              Expect.hasLength deadlocks 1 "One deadlock"
+              match deadlocks.[0] with
+              | ProgressAnalysis.Deadlock(state, selfLoops) ->
+                  Expect.equal state "Active" "Deadlock at Active"
+                  Expect.contains selfLoops "view" "Self-loop reported"
+              | _ -> failtest "Expected Deadlock diagnostic"
+
+          testCase "final state with no transitions is not deadlock"
+          <| fun _ ->
+              let deadlocks = ProgressAnalysis.detectDeadlocks singleFinalChart
+              Expect.isEmpty deadlocks "Final state is not a deadlock"
+
+          testCase "empty transitions from initial is deadlock"
+          <| fun _ ->
+              let deadlocks = ProgressAnalysis.detectDeadlocks emptyTransitionsChart
+              Expect.hasLength deadlocks 1 "One deadlock"
+              match deadlocks.[0] with
+              | ProgressAnalysis.Deadlock(state, selfLoops) ->
+                  Expect.equal state "Idle" "Deadlock at Idle"
+                  Expect.isEmpty selfLoops "No self-loops"
+              | _ -> failtest "Expected Deadlock diagnostic"
+
+          testCase "reachable dead-end is deadlock"
+          <| fun _ ->
+              let deadlocks = ProgressAnalysis.detectDeadlocks reachableDeadEndChart
+              let deadEndDiags =
+                  deadlocks
+                  |> List.choose (fun d ->
+                      match d with
+                      | ProgressAnalysis.Deadlock(s, _) when s = "DeadEnd" -> Some d
+                      | _ -> None)
+              Expect.hasLength deadEndDiags 1 "DeadEnd is a deadlock"
+
+          testCase "cycle without final states is NOT deadlock"
+          <| fun _ ->
+              let deadlocks = ProgressAnalysis.detectDeadlocks cycleNoFinalChart
+              Expect.isEmpty deadlocks "Cycle with advancing transitions is not deadlock" ]

--- a/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
+++ b/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
@@ -1,0 +1,278 @@
+module Frank.Resources.Model.Tests.ProgressAnalysisTests
+
+open Expecto
+open Frank.Resources.Model
+
+// -- Helpers --
+
+let private mkTransition event source target guard roleConstraint =
+    { Event = event
+      Source = source
+      Target = target
+      Guard = guard
+      Constraint = roleConstraint }
+
+let private mkState isFinal =
+    { AllowedMethods = [ "GET" ]
+      IsFinal = isFinal
+      Description = None }
+
+// -- Fixtures --
+
+/// TicTacToe: 2 players + spectator. No deadlocks, no starvation.
+/// Spectator is read-only. Turn-taking is weak starvation (no warning).
+let private ticTacToeChart: ExtractedStatechart =
+    { RouteTemplate = "/games/{gameId}"
+      StateNames = [ "XTurn"; "OTurn"; "XWins"; "OWins"; "Draw" ]
+      InitialStateKey = "XTurn"
+      GuardNames = [ "TurnGuard" ]
+      StateMetadata =
+        Map.ofList
+            [ "XTurn", mkState false
+              "OTurn", mkState false
+              "XWins", mkState true
+              "OWins", mkState true
+              "Draw", mkState true ]
+      Roles =
+        [ { Name = "PlayerX"; Description = Some "Player X" }
+          { Name = "PlayerO"; Description = Some "Player O" }
+          { Name = "Spectator"; Description = Some "Observer" } ]
+      Transitions =
+        [ mkTransition "getGame" "XTurn" "XTurn" None Unrestricted
+          mkTransition "getGame" "OTurn" "OTurn" None Unrestricted
+          mkTransition "getGame" "XWins" "XWins" None Unrestricted
+          mkTransition "getGame" "OWins" "OWins" None Unrestricted
+          mkTransition "getGame" "Draw" "Draw" None Unrestricted
+          mkTransition "makeMove" "XTurn" "OTurn" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "XTurn" "XWins" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "XTurn" "Draw" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "OTurn" "XTurn" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ])
+          mkTransition "makeMove" "OTurn" "OWins" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ])
+          mkTransition "makeMove" "OTurn" "Draw" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ]) ] }
+
+/// Non-final state with only self-loops for all roles.
+let private deadlockSelfLoopChart: ExtractedStatechart =
+    { RouteTemplate = "/stuck"
+      StateNames = [ "Stuck"; "Done" ]
+      InitialStateKey = "Stuck"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList [ "Stuck", mkState false; "Done", mkState true ]
+      Roles = [ { Name = "Admin"; Description = None } ]
+      Transitions =
+        [ mkTransition "refresh" "Stuck" "Stuck" None Unrestricted ] }
+
+/// Only advancing transition is RestrictedTo [] (dead).
+let private deadTransitionDeadlockChart: ExtractedStatechart =
+    { RouteTemplate = "/dead"
+      StateNames = [ "Active"; "Archived" ]
+      InitialStateKey = "Active"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList [ "Active", mkState false; "Archived", mkState true ]
+      Roles = [ { Name = "Admin"; Description = None } ]
+      Transitions =
+        [ mkTransition "view" "Active" "Active" None Unrestricted
+          mkTransition "archive" "Active" "Archived" None (RestrictedTo []) ] }
+
+/// Role permanently excluded after a state on all forward paths.
+let private starvationChart: ExtractedStatechart =
+    { RouteTemplate = "/workflow"
+      StateNames = [ "Phase1"; "Phase2"; "Phase3"; "Done" ]
+      InitialStateKey = "Phase1"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "Phase1", mkState false
+              "Phase2", mkState false
+              "Phase3", mkState false
+              "Done", mkState true ]
+      Roles =
+        [ { Name = "Admin"; Description = None }
+          { Name = "Worker"; Description = None } ]
+      Transitions =
+        [ mkTransition "start" "Phase1" "Phase2" None (RestrictedTo [ "Admin" ])
+          mkTransition "advance" "Phase2" "Phase3" None (RestrictedTo [ "Admin" ])
+          mkTransition "complete" "Phase3" "Done" None (RestrictedTo [ "Admin" ])
+          mkTransition "view" "Phase1" "Phase1" None Unrestricted
+          mkTransition "view" "Phase2" "Phase2" None Unrestricted
+          mkTransition "view" "Phase3" "Phase3" None Unrestricted ] }
+
+/// Recovery path only via dead transition — must still report starved.
+let private deadTransitionForwardPathChart: ExtractedStatechart =
+    { RouteTemplate = "/dead-path"
+      StateNames = [ "Start"; "Middle"; "Recovery"; "End" ]
+      InitialStateKey = "Start"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "Start", mkState false
+              "Middle", mkState false
+              "Recovery", mkState false
+              "End", mkState true ]
+      Roles =
+        [ { Name = "RoleA"; Description = None }
+          { Name = "RoleB"; Description = None } ]
+      Transitions =
+        [ mkTransition "go" "Start" "Middle" None (RestrictedTo [ "RoleA" ])
+          // Only path from Middle to Recovery is dead — no one can fire it
+          mkTransition "recover" "Middle" "Recovery" None (RestrictedTo [])
+          mkTransition "act" "Recovery" "End" None (RestrictedTo [ "RoleB" ])
+          mkTransition "finish" "Middle" "End" None (RestrictedTo [ "RoleA" ]) ] }
+
+/// All transitions unrestricted — no starvation possible.
+let private allUnrestrictedChart: ExtractedStatechart =
+    { RouteTemplate = "/open"
+      StateNames = [ "A"; "B"; "Done" ]
+      InitialStateKey = "A"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList [ "A", mkState false; "B", mkState false; "Done", mkState true ]
+      Roles =
+        [ { Name = "User"; Description = None }
+          { Name = "Admin"; Description = None } ]
+      Transitions =
+        [ mkTransition "step1" "A" "B" None Unrestricted
+          mkTransition "step2" "B" "Done" None Unrestricted ] }
+
+/// Single final state — empty report.
+let private singleFinalChart: ExtractedStatechart =
+    { RouteTemplate = "/final"
+      StateNames = [ "Done" ]
+      InitialStateKey = "Done"
+      GuardNames = []
+      StateMetadata = Map.ofList [ "Done", mkState true ]
+      Roles = [ { Name = "User"; Description = None } ]
+      Transitions = [] }
+
+/// Initial state only, no transitions — deadlock.
+let private emptyTransitionsChart: ExtractedStatechart =
+    { RouteTemplate = "/empty"
+      StateNames = [ "Idle" ]
+      InitialStateKey = "Idle"
+      GuardNames = []
+      StateMetadata = Map.ofList [ "Idle", mkState false ]
+      Roles = [ { Name = "User"; Description = None } ]
+      Transitions = [] }
+
+/// Non-terminating cycle, all roles active — no deadlock, no starvation.
+let private cycleNoFinalChart: ExtractedStatechart =
+    { RouteTemplate = "/cycle"
+      StateNames = [ "A"; "B" ]
+      InitialStateKey = "A"
+      GuardNames = []
+      StateMetadata = Map.ofList [ "A", mkState false; "B", mkState false ]
+      Roles = [ { Name = "User"; Description = None } ]
+      Transitions =
+        [ mkTransition "forward" "A" "B" None Unrestricted
+          mkTransition "back" "B" "A" None Unrestricted ] }
+
+/// Diamond: two paths reconverge at active state.
+/// RoleB inactive at B and C, but both paths reach D where RoleB can act.
+let private diamondChart: ExtractedStatechart =
+    { RouteTemplate = "/diamond"
+      StateNames = [ "A"; "B"; "C"; "D"; "Done" ]
+      InitialStateKey = "A"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "A", mkState false
+              "B", mkState false
+              "C", mkState false
+              "D", mkState false
+              "Done", mkState true ]
+      Roles =
+        [ { Name = "RoleA"; Description = None }
+          { Name = "RoleB"; Description = None } ]
+      Transitions =
+        [ mkTransition "left" "A" "B" None (RestrictedTo [ "RoleA" ])
+          mkTransition "right" "A" "C" None (RestrictedTo [ "RoleA" ])
+          mkTransition "converge1" "B" "D" None (RestrictedTo [ "RoleA" ])
+          mkTransition "converge2" "C" "D" None (RestrictedTo [ "RoleA" ])
+          mkTransition "finish" "D" "Done" None (RestrictedTo [ "RoleB" ])
+          mkTransition "act" "A" "A" None (RestrictedTo [ "RoleB" ]) ] }
+
+/// Non-initial non-final state with no outgoing transitions — deadlock.
+let private reachableDeadEndChart: ExtractedStatechart =
+    { RouteTemplate = "/deadend"
+      StateNames = [ "Start"; "DeadEnd"; "Done" ]
+      InitialStateKey = "Start"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "Start", mkState false
+              "DeadEnd", mkState false
+              "Done", mkState true ]
+      Roles = [ { Name = "User"; Description = None } ]
+      Transitions =
+        [ mkTransition "enter" "Start" "DeadEnd" None Unrestricted
+          mkTransition "skip" "Start" "Done" None Unrestricted ] }
+
+/// Same role excluded from two independent states — two diagnostics.
+let private multipleStarvationChart: ExtractedStatechart =
+    { RouteTemplate = "/multi-starve"
+      StateNames = [ "Start"; "Branch1"; "Branch2"; "End1"; "End2" ]
+      InitialStateKey = "Start"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "Start", mkState false
+              "Branch1", mkState false
+              "Branch2", mkState false
+              "End1", mkState true
+              "End2", mkState true ]
+      Roles =
+        [ { Name = "RoleA"; Description = None }
+          { Name = "RoleB"; Description = None } ]
+      Transitions =
+        [ mkTransition "go1" "Start" "Branch1" None (RestrictedTo [ "RoleA" ])
+          mkTransition "go2" "Start" "Branch2" None (RestrictedTo [ "RoleA" ])
+          mkTransition "end1" "Branch1" "End1" None (RestrictedTo [ "RoleA" ])
+          mkTransition "end2" "Branch2" "End2" None (RestrictedTo [ "RoleA" ]) ] }
+
+/// Disconnected chart — unreachable non-final state should not produce false deadlock.
+let private disconnectedChart: ExtractedStatechart =
+    { RouteTemplate = "/disconnected"
+      StateNames = [ "Start"; "Done"; "Orphan" ]
+      InitialStateKey = "Start"
+      GuardNames = []
+      StateMetadata =
+        Map.ofList
+            [ "Start", mkState false
+              "Done", mkState true
+              "Orphan", mkState false ]
+      Roles = [ { Name = "User"; Description = None } ]
+      Transitions =
+        [ mkTransition "finish" "Start" "Done" None Unrestricted
+          mkTransition "orphanAct" "Orphan" "Start" None Unrestricted ] }
+
+// -- Tests --
+
+[<Tests>]
+let predicateTests =
+    testList
+        "predicates"
+        [ testCase "isAdvancing returns true for state-changing transition"
+          <| fun _ ->
+              let t = mkTransition "go" "A" "B" None Unrestricted
+              Expect.isTrue (ProgressAnalysis.isAdvancing t) "A->B is advancing"
+
+          testCase "isAdvancing returns false for self-loop"
+          <| fun _ ->
+              let t = mkTransition "view" "A" "A" None Unrestricted
+              Expect.isFalse (ProgressAnalysis.isAdvancing t) "A->A is not advancing"
+
+          testCase "isLive returns true for unrestricted"
+          <| fun _ ->
+              let t = mkTransition "go" "A" "B" None Unrestricted
+              Expect.isTrue (ProgressAnalysis.isLive t) "Unrestricted is live"
+
+          testCase "isLive returns true for non-empty RestrictedTo"
+          <| fun _ ->
+              let t = mkTransition "go" "A" "B" None (RestrictedTo [ "R" ])
+              Expect.isTrue (ProgressAnalysis.isLive t) "RestrictedTo [R] is live"
+
+          testCase "isLive returns false for empty RestrictedTo"
+          <| fun _ ->
+              let t = mkTransition "go" "A" "B" None (RestrictedTo [])
+              Expect.isFalse (ProgressAnalysis.isLive t) "RestrictedTo [] is dead" ]

--- a/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
+++ b/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
@@ -2,15 +2,9 @@ module Frank.Resources.Model.Tests.ProgressAnalysisTests
 
 open Expecto
 open Frank.Resources.Model
+open Frank.Resources.Model.Tests.TestHelpers
 
 // -- Helpers --
-
-let private mkTransition event source target guard roleConstraint =
-    { Event = event
-      Source = source
-      Target = target
-      Guard = guard
-      Constraint = roleConstraint }
 
 let private mkState isFinal =
     { AllowedMethods = [ "GET" ]

--- a/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
+++ b/test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs
@@ -456,7 +456,8 @@ let starvationTests =
                       | ProgressAnalysis.Starvation(r, _, _) when r = "RoleB" -> Some d
                       | _ -> None)
 
-              Expect.isGreaterThanOrEqual (List.length roleBDiags) 2 "RoleB starved from both Branch1 and Branch2" ]
+              // RoleB can act at Start (go1/go2 are Unrestricted) but is excluded from Branch1 and Branch2
+              Expect.equal (List.length roleBDiags) 2 "RoleB starved from Branch1 and Branch2" ]
 
 [<Tests>]
 let analyzeProgressTests =

--- a/test/Frank.Resources.Model.Tests/ProjectionTests.fs
+++ b/test/Frank.Resources.Model.Tests/ProjectionTests.fs
@@ -2,15 +2,9 @@ module Frank.Resources.Model.Tests.ProjectionTests
 
 open Expecto
 open Frank.Resources.Model
+open Frank.Resources.Model.Tests.TestHelpers
 
 // -- Test fixtures --
-
-let private mkTransition event source target guard roleConstraint =
-    { Event = event
-      Source = source
-      Target = target
-      Guard = guard
-      Constraint = roleConstraint }
 
 /// TicTacToe-like statechart with two players and a spectator.
 let private ticTacToeChart: ExtractedStatechart =
@@ -20,15 +14,33 @@ let private ticTacToeChart: ExtractedStatechart =
       GuardNames = [ "TurnGuard" ]
       StateMetadata =
         Map.ofList
-            [ "XTurn", { AllowedMethods = [ "GET"; "PUT" ]; IsFinal = false; Description = None }
-              "OTurn", { AllowedMethods = [ "GET"; "PUT" ]; IsFinal = false; Description = None }
-              "XWins", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None }
-              "OWins", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None }
-              "Draw", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None } ]
+            [ "XTurn",
+              { AllowedMethods = [ "GET"; "PUT" ]
+                IsFinal = false
+                Description = None }
+              "OTurn",
+              { AllowedMethods = [ "GET"; "PUT" ]
+                IsFinal = false
+                Description = None }
+              "XWins",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = true
+                Description = None }
+              "OWins",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = true
+                Description = None }
+              "Draw",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = true
+                Description = None } ]
       Roles =
-        [ { Name = "PlayerX"; Description = Some "Player X" }
-          { Name = "PlayerO"; Description = Some "Player O" }
-          { Name = "Spectator"; Description = Some "Observer" } ]
+        [ { Name = "PlayerX"
+            Description = Some "Player X" }
+          { Name = "PlayerO"
+            Description = Some "Player O" }
+          { Name = "Spectator"
+            Description = Some "Observer" } ]
       Transitions =
         [ // Unguarded GET — all roles can observe
           mkTransition "getGame" "XTurn" "XTurn" None Unrestricted
@@ -52,8 +64,14 @@ let private deadTransitionChart: ExtractedStatechart =
       GuardNames = [ "DeadGuard" ]
       StateMetadata =
         Map.ofList
-            [ "Active", { AllowedMethods = [ "GET" ]; IsFinal = false; Description = None }
-              "Archived", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None } ]
+            [ "Active",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = false
+                Description = None }
+              "Archived",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = true
+                Description = None } ]
       Roles = [ { Name = "Admin"; Description = None } ]
       Transitions =
         [ mkTransition "getItem" "Active" "Active" None Unrestricted
@@ -67,9 +85,18 @@ let private disconnectedChart: ExtractedStatechart =
       GuardNames = []
       StateMetadata =
         Map.ofList
-            [ "Draft", { AllowedMethods = [ "GET"; "PUT" ]; IsFinal = false; Description = None }
-              "Published", { AllowedMethods = [ "GET" ]; IsFinal = true; Description = None }
-              "Orphan", { AllowedMethods = [ "GET" ]; IsFinal = false; Description = None } ]
+            [ "Draft",
+              { AllowedMethods = [ "GET"; "PUT" ]
+                IsFinal = false
+                Description = None }
+              "Published",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = true
+                Description = None }
+              "Orphan",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = false
+                Description = None } ]
       Roles = [ { Name = "Editor"; Description = None } ]
       Transitions =
         [ mkTransition "publish" "Draft" "Published" None Unrestricted
@@ -87,7 +114,10 @@ let filterTransitionsByRoleTests =
         [ testCase "keeps unrestricted transitions for all roles"
           <| fun _ ->
               let projected = Projection.filterTransitionsByRole "PlayerX" ticTacToeChart
-              let getTransitions = projected.Transitions |> List.filter (fun t -> t.Event = "getGame")
+
+              let getTransitions =
+                  projected.Transitions |> List.filter (fun t -> t.Event = "getGame")
+
               Expect.equal (List.length getTransitions) 5 "All 5 getGame transitions survive"
 
           testCase "keeps restricted transitions only for permitted roles"

--- a/test/Frank.Resources.Model.Tests/TestHelpers.fs
+++ b/test/Frank.Resources.Model.Tests/TestHelpers.fs
@@ -1,0 +1,10 @@
+module Frank.Resources.Model.Tests.TestHelpers
+
+open Frank.Resources.Model
+
+let mkTransition event source target guard roleConstraint =
+    { Event = event
+      Source = source
+      Target = target
+      Guard = guard
+      Constraint = roleConstraint }


### PR DESCRIPTION
## Summary

- Add `ProgressAnalysis` module to `Frank.Resources.Model` with deadlock detection, starvation detection, and read-only role identification
- Integrate with CLI via `validate --check-progress` flag (additive to #133's `--check-projection`)
- 28 new tests across 13 fixtures covering all edge cases from expert review

## Design

**Deadlock**: Non-final state where no role has an advancing (`Source ≠ Target`) + live (not `RestrictedTo []`) transition.

**Starvation**: Role permanently excluded on ALL forward paths from a reachable state. Forward BFS uses all live global transitions (Harel correction); dead transitions excluded from BFS adjacency (Harel soundness fix). Only strong starvation reported — weak starvation (turn-taking) is normal and not flagged.

**Read-only role**: Role with zero advancing+live transitions in any state (e.g., Spectator). Info severity, not a problem.

Expert reviewers: Wadler (MPST liveness), Harel (statechart reachability), Seemann (architecture), @7sharp9 (F# idioms).

## Files

| File | Change |
|------|--------|
| `src/Frank.Resources.Model/ProgressAnalysis.fs` | NEW — core analysis module (189 lines) |
| `test/Frank.Resources.Model.Tests/ProgressAnalysisTests.fs` | NEW — 28 tests, 13 fixtures |
| `test/Frank.Resources.Model.Tests/TestHelpers.fs` | NEW — shared `mkTransition` helper |
| `src/Frank.Cli.Core/Commands/UnifiedValidateCommand.fs` | Add `checkProjection`/`checkProgress` params |
| `src/Frank.Cli.Core/Output/TextOutput.fs` | Add `formatProgressReport` |
| `src/Frank.Cli.Core/Output/JsonOutput.fs` | Add progress report JSON output |
| `src/Frank.Cli/Program.fs` | Register `--check-progress` flag |

## Test plan

- [x] 53/53 tests passing (28 new + 25 pre-existing in assembly)
- [x] 1,498 total tests passing across all buildable projects (no regressions)
- [x] Fantomas clean on all files
- [x] Build succeeds with 0 errors, 0 warnings
- [x] Expert review findings addressed (Wadler, Harel, Seemann, @7sharp9)
- [ ] Manual: verify TicTacToe produces clean report via CLI

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)