### PR TITLE
feat: add frank project command with role projection

### DIFF
--- a/sample/Frank.TicTacToe.Sample/Program.fs
+++ b/sample/Frank.TicTacToe.Sample/Program.fs
@@ -90,6 +90,9 @@ let gameResource =
     statefulResource "/games/{gameId}" {
         machine gameMachine
         resolveInstanceId (fun ctx -> ctx.Request.RouteValues["gameId"] :?> string)
+        role "PlayerX" (fun user -> user.HasClaim("player", "X"))
+        role "PlayerO" (fun user -> user.HasClaim("player", "O"))
+        role "Spectator" (fun _user -> true)
         inState (forState XTurn [ StateHandlerBuilder.get getGameState; StateHandlerBuilder.post handleMove ])
         inState (forState OTurn [ StateHandlerBuilder.get getGameState; StateHandlerBuilder.post handleMove ])
         inState (forState (Won "X") [ StateHandlerBuilder.get getGameState ])

--- a/sample/Frank.TicTacToe.Sample/specs/tictactoe.alps.json
+++ b/sample/Frank.TicTacToe.Sample/specs/tictactoe.alps.json
@@ -37,9 +37,9 @@
             ]
           },
           {
-            "id": "makeMove-XTurn-XWins",
+            "id": "makeMove-XTurn-Won",
             "type": "unsafe",
-            "rt": "#XWins",
+            "rt": "#Won",
             "doc": { "format": "text", "value": "Player X makes a winning move" },
             "descriptor": [
               { "href": "#position" },
@@ -90,9 +90,9 @@
             ]
           },
           {
-            "id": "makeMove-OTurn-OWins",
+            "id": "makeMove-OTurn-Won",
             "type": "unsafe",
-            "rt": "#OWins",
+            "rt": "#Won",
             "doc": { "format": "text", "value": "Player O makes a winning move" },
             "descriptor": [
               { "href": "#position" },
@@ -123,17 +123,9 @@
         ]
       },
       {
-        "id": "XWins",
+        "id": "Won",
         "type": "semantic",
-        "doc": { "format": "text", "value": "State: Player X has won" },
-        "descriptor": [
-          { "href": "#getGame" }
-        ]
-      },
-      {
-        "id": "OWins",
-        "type": "semantic",
-        "doc": { "format": "text", "value": "State: Player O has won" },
+        "doc": { "format": "text", "value": "State: Game over — a player has won" },
         "descriptor": [
           { "href": "#getGame" }
         ]

--- a/sample/Frank.TicTacToe.Sample/specs/tictactoe.smcat
+++ b/sample/Frank.TicTacToe.Sample/specs/tictactoe.smcat
@@ -1,20 +1,19 @@
 # Tic-Tac-Toe state machine with role-based transitions
 initial => XTurn;
-XTurn, OTurn, XWins, OWins, Draw;
+XTurn, OTurn, Won, Draw;
 
 # getGame: self-loop on all states (unguarded, all roles)
 XTurn => XTurn: getGame;
 OTurn => OTurn: getGame;
-XWins => XWins: getGame;
-OWins => OWins: getGame;
+Won => Won: getGame;
 Draw => Draw: getGame;
 
 # makeMove from XTurn (role=PlayerX, guard=TurnGuard)
 XTurn => OTurn: makeMove [TurnGuard];
-XTurn => XWins: makeMove [TurnGuard];
+XTurn => Won: makeMove [TurnGuard];
 XTurn => Draw: makeMove [TurnGuard];
 
 # makeMove from OTurn (role=PlayerO, guard=TurnGuard)
 OTurn => XTurn: makeMove [TurnGuard];
-OTurn => OWins: makeMove [TurnGuard];
+OTurn => Won: makeMove [TurnGuard];
 OTurn => Draw: makeMove [TurnGuard];

--- a/sample/Frank.TicTacToe.Sample/specs/tictactoe.wsd
+++ b/sample/Frank.TicTacToe.Sample/specs/tictactoe.wsd
@@ -2,25 +2,23 @@ title Tic-Tac-Toe State Machine
 
 participant XTurn
 participant OTurn
-participant XWins
-participant OWins
+participant Won
 participant Draw
 
 # getGame: self-loop on all states (unguarded, all roles can observe)
 XTurn->XTurn: getGame
 OTurn->OTurn: getGame
-XWins->XWins: getGame
-OWins->OWins: getGame
+Won->Won: getGame
 Draw->Draw: getGame
 
 # makeMove from XTurn (role=PlayerX, guarded by TurnGuard)
 note over XTurn: [guard: role=PlayerX, guard=TurnGuard]
 XTurn->OTurn: makeMove(position, player)
-XTurn->XWins: makeMove(position, player)
+XTurn->Won: makeMove(position, player)
 XTurn->Draw: makeMove(position, player)
 
 # makeMove from OTurn (role=PlayerO, guarded by TurnGuard)
 note over OTurn: [guard: role=PlayerO, guard=TurnGuard]
 OTurn->XTurn: makeMove(position, player)
-OTurn->OWins: makeMove(position, player)
+OTurn->Won: makeMove(position, player)
 OTurn->Draw: makeMove(position, player)

--- a/src/Frank.Cli.Core/Commands/ExtractResourcesCommand.fs
+++ b/src/Frank.Cli.Core/Commands/ExtractResourcesCommand.fs
@@ -1,4 +1,4 @@
-module Frank.Cli.Core.Commands.UnifiedExtractCommand
+module Frank.Cli.Core.Commands.ExtractResourcesCommand
 
 open System
 open System.IO
@@ -6,7 +6,7 @@ open Frank.Resources.Model
 open Frank.Cli.Core.Unified
 open Frank.Cli.Core.Statechart.StatechartError
 
-type UnifiedExtractResult =
+type ExtractResult =
     { ResourceCount: int
       StatefulResourceCount: int
       PlainResourceCount: int
@@ -36,7 +36,7 @@ let execute
     (baseUri: string)
     (vocabularies: string list)
     (force: bool)
-    : Async<Result<UnifiedExtractResult, StatechartError>> =
+    : Async<Result<ExtractResult, StatechartError>> =
     async {
         if not (File.Exists projectPath) then
             return Error(FileNotFound projectPath)

--- a/src/Frank.Cli.Core/Commands/GenerateArtifactsCommand.fs
+++ b/src/Frank.Cli.Core/Commands/GenerateArtifactsCommand.fs
@@ -1,4 +1,4 @@
-module Frank.Cli.Core.Commands.UnifiedGenerateCommand
+module Frank.Cli.Core.Commands.GenerateArtifactsCommand
 
 open System.IO
 open System.Text.Json

--- a/src/Frank.Cli.Core/Commands/GenerateArtifactsCommand.fs
+++ b/src/Frank.Cli.Core/Commands/GenerateArtifactsCommand.fs
@@ -86,21 +86,6 @@ let private generateAffordanceMapJson (resources: UnifiedResource list) (baseUri
     writer.Flush()
     System.Text.Encoding.UTF8.GetString(stream.ToArray())
 
-let private getResources
-    (projectPath: string)
-    (force: bool)
-    : Async<Result<UnifiedResource list * bool, StatechartError>> =
-    async {
-        let projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath))
-
-        match UnifiedCache.tryLoadFresh projectDir force with
-        | Ok state -> return Ok(state.Resources, true)
-        | Error _ ->
-            match! UnifiedExtractor.extract projectPath with
-            | Ok resources -> return Ok(resources, false)
-            | Error e -> return Error e
-    }
-
 let execute
     (projectPath: string)
     (format: string)
@@ -110,7 +95,7 @@ let execute
     : Async<Result<GenerateResult, StatechartError>> =
     async {
         if isAffordanceMapFormat format then
-            match! getResources projectPath force with
+            match! UnifiedExtractor.loadOrExtract projectPath force with
             | Error e -> return Error e
             | Ok(resources, fromCache) ->
                 let mapContent = generateAffordanceMapJson resources ""
@@ -130,7 +115,7 @@ let execute
             match parseFormat format with
             | Error e -> return Error e
             | Ok formats ->
-                match! getResources projectPath force with
+                match! UnifiedExtractor.loadOrExtract projectPath force with
                 | Error e -> return Error e
                 | Ok(resources, fromCache) ->
                     let machines = resources |> List.choose (fun r -> r.Statechart)

--- a/src/Frank.Cli.Core/Commands/ProjectCommand.fs
+++ b/src/Frank.Cli.Core/Commands/ProjectCommand.fs
@@ -25,17 +25,7 @@ let execute
     (force: bool)
     : Async<Result<ProjectResult, StatechartError>> =
     async {
-        let projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath))
-
-        let! resourcesResult =
-            async {
-                match UnifiedCache.tryLoadFresh projectDir force with
-                | Ok state -> return Ok(state.Resources, true)
-                | Error _ ->
-                    match! UnifiedExtractor.extract projectPath with
-                    | Ok resources -> return Ok(resources, false)
-                    | Error e -> return Error e
-            }
+        let! resourcesResult = UnifiedExtractor.loadOrExtract projectPath force
 
         match resourcesResult with
         | Error e -> return Error e

--- a/src/Frank.Cli.Core/Commands/ProjectCommand.fs
+++ b/src/Frank.Cli.Core/Commands/ProjectCommand.fs
@@ -1,0 +1,112 @@
+module Frank.Cli.Core.Commands.ProjectCommand
+
+open System.IO
+open Frank.Cli.Core.Unified
+open Frank.Cli.Core.Unified.ProjectionPipeline
+open Frank.Cli.Core.Statechart.StatechartError
+
+type ProjectedArtifact =
+    { Slug: string
+      Content: string
+      FilePath: string option
+      IsGlobalOverride: bool }
+
+type ProjectResult =
+    { Artifacts: ProjectedArtifact list
+      OrphanWarnings: string list
+      Errors: string list
+      OutputDirectory: string option
+      FromCache: bool }
+
+let execute
+    (projectPath: string)
+    (outputDir: string option)
+    (resourceFilter: string option)
+    (force: bool)
+    : Async<Result<ProjectResult, StatechartError>> =
+    async {
+        let projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath))
+
+        let! resourcesResult =
+            async {
+                match UnifiedCache.tryLoadFresh projectDir force with
+                | Ok state -> return Ok(state.Resources, true)
+                | Error _ ->
+                    match! UnifiedExtractor.extract projectPath with
+                    | Ok resources -> return Ok(resources, false)
+                    | Error e -> return Error e
+            }
+
+        match resourcesResult with
+        | Error e -> return Error e
+        | Ok(resources, fromCache) ->
+            let filtered =
+                match resourceFilter with
+                | None -> resources
+                | Some name ->
+                    resources
+                    |> List.filter (fun r ->
+                        r.ResourceSlug = name || r.RouteTemplate.Contains(name))
+
+            match resourceFilter, filtered with
+            | Some name, [] ->
+                let available = resources |> List.map _.ResourceSlug
+                return Error(ResourceNotFound(name, available))
+            | _ ->
+                let batchResult, projectionResults = projectAllResources filtered ""
+
+                let orphanWarnings =
+                    [ for result in projectionResults do
+                          for orphan in result.Orphans do
+                              $"Warning: transition '{orphan.Event}' ({orphan.Source} -> {orphan.Target}) is not covered by any role projection" ]
+
+                let errors =
+                    [ for result in projectionResults do
+                          yield! result.Errors ]
+
+                let roleArtifacts =
+                    [ for result in projectionResults do
+                          for KeyValue(slug, content) in result.RoleProfiles do
+                              { Slug = slug
+                                Content = content
+                                FilePath = None
+                                IsGlobalOverride = false } ]
+
+                let globalArtifacts =
+                    batchResult.GlobalProfileOverrides
+                    |> Map.toList
+                    |> List.map (fun (slug, content) ->
+                        { Slug = slug
+                          Content = content
+                          FilePath = None
+                          IsGlobalOverride = true })
+
+                let allArtifacts = roleArtifacts @ globalArtifacts
+
+                match outputDir with
+                | None ->
+                    return
+                        Ok
+                            { Artifacts = allArtifacts
+                              OrphanWarnings = orphanWarnings
+                              Errors = errors
+                              OutputDirectory = None
+                              FromCache = fromCache }
+                | Some dir ->
+                    Directory.CreateDirectory(dir) |> ignore
+
+                    let written =
+                        allArtifacts
+                        |> List.map (fun a ->
+                            let filePath = Path.Combine(dir, $"{a.Slug}.alps.json")
+                            File.WriteAllText(filePath, a.Content)
+                            { a with FilePath = Some filePath })
+
+                    return
+                        Ok
+                            { Artifacts = written
+                              OrphanWarnings = orphanWarnings
+                              Errors = errors
+                              OutputDirectory = Some dir
+                              FromCache = fromCache }
+    }

--- a/src/Frank.Cli.Core/Commands/ValidateResourcesCommand.fs
+++ b/src/Frank.Cli.Core/Commands/ValidateResourcesCommand.fs
@@ -1,4 +1,4 @@
-module Frank.Cli.Core.Commands.UnifiedValidateCommand
+module Frank.Cli.Core.Commands.ValidateResourcesCommand
 
 open System.IO
 open Frank.Resources.Model
@@ -6,7 +6,7 @@ open Frank.Statecharts.Analysis.ProjectionValidator
 open Frank.Cli.Core.Unified
 open Frank.Cli.Core.Statechart.StatechartError
 
-type UnifiedValidateResult =
+type ValidateResult =
     { ProjectionResults: ProjectionCheckResult list
       TotalIssues: int
       TotalErrors: int
@@ -21,7 +21,7 @@ let private buildResult
     (resources: UnifiedResource list)
     (checkProjection: bool)
     (checkProgress: bool)
-    : UnifiedValidateResult =
+    : ValidateResult =
     let withRoles =
         resources
         |> List.choose (fun r ->
@@ -70,7 +70,7 @@ let execute
     (force: bool)
     (checkProjection: bool)
     (checkProgress: bool)
-    : Async<Result<UnifiedValidateResult, StatechartError>> =
+    : Async<Result<ValidateResult, StatechartError>> =
     async {
         if not (File.Exists projectPath) then
             return Error(FileNotFound projectPath)

--- a/src/Frank.Cli.Core/Commands/ValidateResourcesCommand.fs
+++ b/src/Frank.Cli.Core/Commands/ValidateResourcesCommand.fs
@@ -72,15 +72,7 @@ let execute
     (checkProgress: bool)
     : Async<Result<ValidateResult, StatechartError>> =
     async {
-        if not (File.Exists projectPath) then
-            return Error(FileNotFound projectPath)
-        else
-            let projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath))
-
-            match UnifiedCache.tryLoadFresh projectDir force with
-            | Ok state -> return Ok(buildResult true state.Resources checkProjection checkProgress)
-            | Error _ ->
-                match! UnifiedExtractor.extract projectPath with
-                | Error e -> return Error e
-                | Ok resources -> return Ok(buildResult false resources checkProjection checkProgress)
+        match! UnifiedExtractor.loadOrExtract projectPath force with
+        | Error e -> return Error e
+        | Ok(resources, fromCache) -> return Ok(buildResult fromCache resources checkProjection checkProgress)
     }

--- a/src/Frank.Cli.Core/Frank.Cli.Core.fsproj
+++ b/src/Frank.Cli.Core/Frank.Cli.Core.fsproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Frank.Cli.Core.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="Rdf/FSharpRdf.fs" />
     <Compile Include="Rdf/Vocabularies.fs" />
     <!-- Shared utilities -->

--- a/src/Frank.Cli.Core/Frank.Cli.Core.fsproj
+++ b/src/Frank.Cli.Core/Frank.Cli.Core.fsproj
@@ -58,10 +58,11 @@
     <Compile Include="Commands/StatechartValidateCommand.fs" />
     <Compile Include="Commands/OpenApiValidateCommand.fs" />
     <Compile Include="Commands/StatechartParseCommand.fs" />
-    <!-- Unified commands -->
-    <Compile Include="Commands/UnifiedExtractCommand.fs" />
-    <Compile Include="Commands/UnifiedGenerateCommand.fs" />
-    <Compile Include="Commands/UnifiedValidateCommand.fs" />
+    <!-- Top-level commands -->
+    <Compile Include="Commands/ExtractResourcesCommand.fs" />
+    <Compile Include="Commands/GenerateArtifactsCommand.fs" />
+    <Compile Include="Commands/ProjectCommand.fs" />
+    <Compile Include="Commands/ValidateResourcesCommand.fs" />
     <Compile Include="Output/JsonOutput.fs" />
     <Compile Include="Output/TextOutput.fs" />
   </ItemGroup>

--- a/src/Frank.Cli.Core/Output/JsonOutput.fs
+++ b/src/Frank.Cli.Core/Output/JsonOutput.fs
@@ -455,7 +455,7 @@ module JsonOutput =
         writer.Flush()
         Encoding.UTF8.GetString(stream.ToArray())
 
-    let formatUnifiedValidateResult (result: UnifiedValidateCommand.UnifiedValidateResult) : string =
+    let formatResourceValidateResult (result: ValidateResourcesCommand.ValidateResult) : string =
         use stream = new MemoryStream()
         use writer = new Utf8JsonWriter(stream, JsonWriterOptions(Indented = true))
         writer.WriteStartObject()
@@ -564,7 +564,7 @@ module JsonOutput =
 
         Encoding.UTF8.GetString(stream.ToArray())
 
-    let formatUnifiedExtractResult (result: UnifiedExtractCommand.UnifiedExtractResult) : string =
+    let formatResourceExtractResult (result: ExtractResourcesCommand.ExtractResult) : string =
         use stream = new MemoryStream()
         use writer = new Utf8JsonWriter(stream, JsonWriterOptions(Indented = true))
         writer.WriteStartObject()
@@ -613,6 +613,46 @@ module JsonOutput =
                     writer.WriteEndObject()
 
                 writer.WriteEndObject()
+
+                writer.WriteStartArray("roles")
+
+                for role in sc.Roles do
+                    writer.WriteStartObject()
+                    writeString writer "name" role.Name
+
+                    match role.Description with
+                    | Some d -> writeString writer "description" d
+                    | None -> ()
+
+                    writer.WriteEndObject()
+
+                writer.WriteEndArray()
+
+                writer.WriteStartArray("transitions")
+
+                for t in sc.Transitions do
+                    writer.WriteStartObject()
+                    writeString writer "event" t.Event
+                    writeString writer "source" t.Source
+                    writeString writer "target" t.Target
+
+                    match t.Guard with
+                    | Some g -> writeString writer "guard" g
+                    | None -> ()
+
+                    match t.Constraint with
+                    | Frank.Resources.Model.Unrestricted -> writeString writer "constraint" "unrestricted"
+                    | Frank.Resources.Model.RestrictedTo roles ->
+                        writer.WriteStartArray("restrictedTo")
+
+                        for role in roles do
+                            writer.WriteStringValue(role)
+
+                        writer.WriteEndArray()
+
+                    writer.WriteEndObject()
+
+                writer.WriteEndArray()
                 writer.WriteEndObject()
 
             writer.WriteStartArray("httpCapabilities")

--- a/src/Frank.Cli.Core/Output/TextOutput.fs
+++ b/src/Frank.Cli.Core/Output/TextOutput.fs
@@ -369,7 +369,7 @@ module TextOutput =
 
         sb.ToString()
 
-    let formatUnifiedValidateResult (result: UnifiedValidateCommand.UnifiedValidateResult) : string =
+    let formatResourceValidateResult (result: ValidateResourcesCommand.ValidateResult) : string =
         let sb = System.Text.StringBuilder()
         let appendLine (s: string) = sb.AppendLine(s) |> ignore
 
@@ -410,7 +410,7 @@ module TextOutput =
 
         sb.ToString()
 
-    let formatUnifiedExtractResult (result: UnifiedExtractCommand.UnifiedExtractResult) : string =
+    let formatResourceExtractResult (result: ExtractResourcesCommand.ExtractResult) : string =
         let sb = System.Text.StringBuilder()
         let appendLine (s: string) = sb.AppendLine(s) |> ignore
 

--- a/src/Frank.Cli.Core/Unified/ProjectionPipeline.fs
+++ b/src/Frank.Cli.Core/Unified/ProjectionPipeline.fs
@@ -17,6 +17,26 @@ let filterCapabilitiesByStates (stateNames: string list) (capabilities: HttpCapa
         | None -> true
         | Some sk -> Set.contains sk stateSet)
 
+/// Filter capabilities by projected transitions: only keep unsafe capabilities
+/// (POST, PUT, PATCH, DELETE) in states where the role has an unsafe transition.
+/// Safe capabilities (GET, HEAD, OPTIONS) always survive — all roles can observe.
+let filterCapabilitiesByTransitions (transitions: TransitionSpec list) (capabilities: HttpCapability list) : HttpCapability list =
+    // States where this role has an unsafe (non-self-loop) transition
+    let unsafeTransitionSources =
+        transitions
+        |> List.filter (fun t -> t.Source <> t.Target) // exclude self-loops (getGame)
+        |> List.map _.Source
+        |> Set.ofList
+
+    capabilities
+    |> List.filter (fun cap ->
+        if cap.IsSafe then
+            true // Safe methods always available (observation)
+        else
+            match cap.StateKey with
+            | None -> true // No state scope — keep it
+            | Some sk -> Set.contains sk unsafeTransitionSources)
+
 /// Result of running the projection pipeline for a single resource.
 type ProjectionResult =
     { RoleProfiles: Map<string, string>
@@ -50,7 +70,9 @@ let projectResource (resource: UnifiedResource) (baseUri: string) : ProjectionRe
                             ResourceSlug = slug
                             Statechart = Some projectedChart
                             HttpCapabilities =
-                                filterCapabilitiesByStates projectedChart.StateNames resource.HttpCapabilities }
+                                resource.HttpCapabilities
+                                |> filterCapabilitiesByStates projectedChart.StateNames
+                                |> filterCapabilitiesByTransitions projectedChart.Transitions }
 
                     let ctx: UnifiedAlpsGenerator.ProjectionContext =
                         { ProjectedRole = Some roleName

--- a/src/Frank.Cli.Core/Unified/UnifiedExtractor.fs
+++ b/src/Frank.Cli.Core/Unified/UnifiedExtractor.fs
@@ -768,7 +768,7 @@ let private enrichWithDerivedFields (allTypes: AnalyzedType list) (resources: Un
 
 let internal specExtensions = [ ".wsd"; ".smcat"; ".alps.json"; ".alps.xml"; ".scxml" ]
 
-let internal tryParseSpecFile (filePath: string) : Frank.Statecharts.Ast.StatechartDocument option =
+let internal tryParseSpecFile (filePath: string) : Result<Frank.Statecharts.Ast.StatechartDocument, string> =
     try
         let text = File.ReadAllText(filePath)
         let ext = Path.GetExtension(filePath).ToLowerInvariant()
@@ -787,10 +787,11 @@ let internal tryParseSpecFile (filePath: string) : Frank.Statecharts.Ast.Statech
             else
                 None
 
-        parseResult |> Option.map _.Document
+        match parseResult with
+        | Some r -> Ok r.Document
+        | None -> Error $"Unsupported spec file format: '{filePath}'"
     with ex ->
-        eprintfn "Warning: failed to parse spec file '%s': %s" filePath ex.Message
-        None
+        Error $"Failed to parse spec file '{filePath}': {ex.Message}"
 
 /// Find all spec files in {projectDir}/specs/ directory.
 let internal findSpecFiles (projectDir: string) : string list =
@@ -805,19 +806,20 @@ let internal findSpecFiles (projectDir: string) : string list =
         []
 
 /// Extract state names from a StatechartDocument for matching against resources.
+/// Collects both source and target states from transitions, plus explicit state declarations.
 let internal documentStateNames (doc: Frank.Statecharts.Ast.StatechartDocument) : Set<string> =
     doc.Elements
-    |> List.choose (fun elem ->
+    |> List.collect (fun elem ->
         match elem with
-        | Frank.Statecharts.Ast.StateDecl node -> node.Identifier
-        | Frank.Statecharts.Ast.TransitionElement edge -> Some edge.Source
-        | _ -> None)
+        | Frank.Statecharts.Ast.StateDecl node -> node.Identifier |> Option.toList
+        | Frank.Statecharts.Ast.TransitionElement edge -> edge.Source :: (edge.Target |> Option.toList)
+        | _ -> [])
     |> Set.ofList
 
 /// Check if a spec document's states overlap sufficiently with a resource's states.
 let internal statesOverlap (docStates: Set<string>) (resourceStates: Set<string>) : bool =
     let overlap = Set.intersect resourceStates docStates
-    overlap.Count > 0 && overlap.Count >= resourceStates.Count / 2
+    overlap.Count > 0 && overlap.Count * 2 >= resourceStates.Count
 
 /// Match a parsed spec document to a resource by state name overlap.
 let internal matchDocToResource (doc: Frank.Statecharts.Ast.StatechartDocument) (resources: UnifiedResource list) : UnifiedResource option =
@@ -830,16 +832,28 @@ let internal matchDocToResource (doc: Frank.Statecharts.Ast.StatechartDocument) 
         | None -> false)
 
 /// Co-extract transitions from spec files and merge into resources.
-let internal enrichWithSpecTransitions (projectDir: string) (resources: UnifiedResource list) : UnifiedResource list =
+/// Returns enriched resources and any parse warnings.
+let internal enrichWithSpecTransitions (projectDir: string) (resources: UnifiedResource list) : UnifiedResource list * string list =
     let specFiles = findSpecFiles projectDir
 
     if specFiles.IsEmpty then
-        resources
+        resources, []
     else
+        let parseResults = specFiles |> List.map (fun f -> f, tryParseSpecFile f)
+
+        let parseWarnings =
+            parseResults
+            |> List.choose (fun (_, r) ->
+                match r with
+                | Error msg -> Some msg
+                | Ok _ -> None)
+
         let parsedDocs =
-            specFiles
-            |> List.choose (fun f ->
-                tryParseSpecFile f |> Option.map (fun doc -> f, doc, documentStateNames doc))
+            parseResults
+            |> List.choose (fun (f, r) ->
+                match r with
+                | Ok doc -> Some(f, doc, documentStateNames doc)
+                | Error _ -> None)
 
         resources
         |> List.map (fun r ->
@@ -859,8 +873,8 @@ let internal enrichWithSpecTransitions (projectDir: string) (resources: UnifiedR
                     let specRoles = TransitionExtractor.extractRoles doc
 
                     let mergedRoles =
-                        if sc.Roles.IsEmpty && not specRoles.IsEmpty then specRoles
-                        elif not sc.Roles.IsEmpty then sc.Roles
+                        if not sc.Roles.IsEmpty then sc.Roles
+                        elif not specRoles.IsEmpty then specRoles
                         else []
 
                     { r with
@@ -870,7 +884,8 @@ let internal enrichWithSpecTransitions (projectDir: string) (resources: UnifiedR
                                     Transitions = transitions
                                     Roles = mergedRoles } }
                 | None -> r
-            | _ -> r)
+            | _ -> r),
+        parseWarnings
 
 // ══════════════════════════════════════════════════════════════════════════════
 // Public API
@@ -897,7 +912,7 @@ let extract (projectPath: string) : Async<Result<UnifiedResource list, Statechar
 
                 // Phase 3.5: Co-extract transitions from spec files
                 let projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath))
-                let withTransitions = enrichWithSpecTransitions projectDir resources
+                let withTransitions, _specWarnings = enrichWithSpecTransitions projectDir resources
 
                 // Phase 4: Associate types with resources
                 let withTypes = associateTypes withTransitions typedResult.AnalyzedTypes

--- a/src/Frank.Cli.Core/Unified/UnifiedExtractor.fs
+++ b/src/Frank.Cli.Core/Unified/UnifiedExtractor.fs
@@ -168,11 +168,13 @@ let rec private tryExtractForState (expr: SynExpr) : ForStateInfo option =
 
 type private StatefulCeAccum =
     { StateHandlers: ForStateInfo list
-      MachineName: string option }
+      MachineName: string option
+      RoleNames: string list }
 
 let private emptyStatefulCeAccum =
     { StateHandlers = []
-      MachineName = None }
+      MachineName = None
+      RoleNames = [] }
 
 let rec private walkStatefulCeBody (acc: StatefulCeAccum) (expr: SynExpr) : StatefulCeAccum =
     match expr with
@@ -195,6 +197,14 @@ let rec private walkStatefulCeBody (acc: StatefulCeAccum) (expr: SynExpr) : Stat
 
         { acc with MachineName = machineName }
 
+    // role "PlayerX" (fun user -> ...)
+    | SynExpr.App(
+        funcExpr = SynExpr.App(funcExpr = SynExpr.Ident ident; argExpr = SynExpr.Const(SynConst.String(roleName, _, _), _))) when
+        ident.idText = "role"
+        ->
+        { acc with
+            RoleNames = roleName :: acc.RoleNames }
+
     | SynExpr.LetOrUse(body = body) -> walkStatefulCeBody acc body
     | SynExpr.Paren(expr = inner) -> walkStatefulCeBody acc inner
     | _ -> acc
@@ -202,7 +212,8 @@ let rec private walkStatefulCeBody (acc: StatefulCeAccum) (expr: SynExpr) : Stat
 type private SyntaxStatefulResource =
     { RouteTemplate: string
       MachineName: string option
-      StateHandlers: ForStateInfo list }
+      StateHandlers: ForStateInfo list
+      RoleNames: string list }
 
 let private tryExtractStatefulResource (expr: SynExpr) : SyntaxStatefulResource option =
     match expr with
@@ -216,7 +227,8 @@ let private tryExtractStatefulResource (expr: SynExpr) : SyntaxStatefulResource 
         Some
             { RouteTemplate = routeTemplate
               MachineName = acc.MachineName
-              StateHandlers = List.rev acc.StateHandlers }
+              StateHandlers = List.rev acc.StateHandlers
+              RoleNames = List.rev acc.RoleNames }
     | _ -> None
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -225,7 +237,11 @@ let private tryExtractStatefulResource (expr: SynExpr) : SyntaxStatefulResource 
 
 type SyntaxFinding =
     | FoundPlainResource of resource: AnalyzedResource
-    | FoundStatefulResource of route: string * machineName: string option * stateHandlers: (string * string list) list
+    | FoundStatefulResource of
+        route: string *
+        machineName: string option *
+        stateHandlers: (string * string list) list *
+        roleNames: string list
 
 /// Single-pass expression walker that dispatches to both resource and statefulResource extraction.
 let rec private walkExpr (file: string) (results: ResizeArray<SyntaxFinding>) (expr: SynExpr) =
@@ -233,7 +249,7 @@ let rec private walkExpr (file: string) (results: ResizeArray<SyntaxFinding>) (e
     match tryExtractStatefulResource expr with
     | Some sr ->
         let handlers = sr.StateHandlers |> List.map (fun fs -> fs.CaseName, fs.Methods)
-        results.Add(FoundStatefulResource(sr.RouteTemplate, sr.MachineName, handlers))
+        results.Add(FoundStatefulResource(sr.RouteTemplate, sr.MachineName, handlers, sr.RoleNames))
     | None ->
         // Try plain resource
         match tryExtractResource expr file with
@@ -575,7 +591,7 @@ let private buildUnifiedResources
               HttpCapabilities = capabilities
               DerivedFields = ResourceModel.emptyDerivedFields }
 
-        | FoundStatefulResource(route, machineName, stateHandlers) ->
+        | FoundStatefulResource(route, machineName, stateHandlers, roleNames) ->
             let slug = ResourceModel.resourceSlug route
 
             let machineInfo =
@@ -613,8 +629,12 @@ let private buildUnifiedResources
                       Description = None })
                 |> Map.ofList
 
+            let roles =
+                roleNames
+                |> List.map (fun name -> { Name = name; Description = None }: RoleInfo)
+
             let statechart =
-                StatechartExtractor.toExtractedStatechart route stateNames initialStateKey guardNames stateMetadata []
+                StatechartExtractor.toExtractedStatechart route stateNames initialStateKey guardNames stateMetadata roles
 
             let capabilities =
                 stateHandlers
@@ -743,6 +763,119 @@ let private enrichWithDerivedFields (allTypes: AnalyzedType list) (resources: Un
             DerivedFields = computeDerivedFields r allTypes })
 
 // ══════════════════════════════════════════════════════════════════════════════
+// Spec file co-extraction: bridge transitions from spec files into extracted statecharts
+// ══════════════════════════════════════════════════════════════════════════════
+
+let private specExtensions = [ ".wsd"; ".smcat"; ".alps.json"; ".alps.xml"; ".scxml" ]
+
+let private tryParseSpecFile (filePath: string) : Frank.Statecharts.Ast.StatechartDocument option =
+    try
+        let text = File.ReadAllText(filePath)
+        let ext = Path.GetExtension(filePath).ToLowerInvariant()
+
+        let parseResult =
+            if ext = ".wsd" then
+                Some(Frank.Statecharts.Wsd.Parser.parseWsd text)
+            elif filePath.EndsWith(".alps.json", System.StringComparison.OrdinalIgnoreCase) then
+                Some(Frank.Statecharts.Alps.JsonParser.parseAlpsJson text)
+            elif filePath.EndsWith(".alps.xml", System.StringComparison.OrdinalIgnoreCase) then
+                Some(Frank.Statecharts.Alps.XmlParser.parseAlpsXml text)
+            elif ext = ".smcat" then
+                Some(Frank.Statecharts.Smcat.Parser.parseSmcat text)
+            elif ext = ".scxml" then
+                Some(Frank.Statecharts.Scxml.Parser.parseString text)
+            else
+                None
+
+        parseResult |> Option.map _.Document
+    with _ ->
+        None
+
+/// Find all spec files in {projectDir}/specs/ directory.
+let private findSpecFiles (projectDir: string) : string list =
+    let specsDir = Path.Combine(projectDir, "specs")
+
+    if Directory.Exists(specsDir) then
+        Directory.GetFiles(specsDir)
+        |> Array.filter (fun f ->
+            specExtensions |> List.exists (fun ext -> f.EndsWith(ext, System.StringComparison.OrdinalIgnoreCase)))
+        |> Array.toList
+    else
+        []
+
+/// Extract state names from a StatechartDocument for matching against resources.
+let private documentStateNames (doc: Frank.Statecharts.Ast.StatechartDocument) : Set<string> =
+    doc.Elements
+    |> List.choose (fun elem ->
+        match elem with
+        | Frank.Statecharts.Ast.StateDecl node -> node.Identifier
+        | Frank.Statecharts.Ast.TransitionElement edge -> Some edge.Source
+        | _ -> None)
+    |> Set.ofList
+
+/// Match a parsed spec document to a resource by state name overlap.
+let private matchDocToResource (doc: Frank.Statecharts.Ast.StatechartDocument) (resources: UnifiedResource list) : UnifiedResource option =
+    resources
+    |> List.tryFind (fun r ->
+        match r.Statechart with
+        | Some sc ->
+            let resourceStates = Set.ofList sc.StateNames
+            let docStates = documentStateNames doc
+            // Match if the majority of resource states appear in the document
+            let overlap = Set.intersect resourceStates docStates
+            overlap.Count > 0 && overlap.Count >= resourceStates.Count / 2
+        | None -> false)
+
+/// Co-extract transitions from spec files and merge into resources.
+let private enrichWithSpecTransitions (projectDir: string) (resources: UnifiedResource list) : UnifiedResource list =
+    let specFiles = findSpecFiles projectDir
+
+    if specFiles.IsEmpty then
+        resources
+    else
+        let parsedDocs =
+            specFiles
+            |> List.choose (fun f ->
+                tryParseSpecFile f |> Option.map (fun doc -> f, doc))
+
+        // For each resource with a statechart, try to find a matching spec document
+        resources
+        |> List.map (fun r ->
+            match r.Statechart with
+            | Some sc when sc.Transitions.IsEmpty ->
+                let matchingDoc =
+                    parsedDocs
+                    |> List.tryPick (fun (_path, doc) ->
+                        let docStates = documentStateNames doc
+                        let resourceStates = Set.ofList sc.StateNames
+                        let overlap = Set.intersect resourceStates docStates
+
+                        if overlap.Count > 0 && overlap.Count >= resourceStates.Count / 2 then
+                            Some doc
+                        else
+                            None)
+
+                match matchingDoc with
+                | Some doc ->
+                    let transitions = TransitionExtractor.extract doc
+
+                    let specRoles = TransitionExtractor.extractRoles doc
+
+                    let mergedRoles =
+                        if sc.Roles.IsEmpty && not specRoles.IsEmpty then specRoles
+                        elif not sc.Roles.IsEmpty then sc.Roles
+                        else []
+
+                    { r with
+                        Statechart =
+                            Some
+                                { sc with
+                                    Transitions = transitions
+                                    Roles = mergedRoles } }
+                | None -> r
+            | _ -> r)
+
+// ══════════════════════════════════════════════════════════════════════════════
 // Public API
 // ══════════════════════════════════════════════════════════════════════════════
 
@@ -765,8 +898,12 @@ let extract (projectPath: string) : Async<Result<UnifiedResource list, Statechar
                 // Phase 3: Cross-reference and build UnifiedResource records
                 let resources = buildUnifiedResources syntaxFindings typedResult
 
+                // Phase 3.5: Co-extract transitions from spec files
+                let projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath))
+                let withTransitions = enrichWithSpecTransitions projectDir resources
+
                 // Phase 4: Associate types with resources
-                let withTypes = associateTypes resources typedResult.AnalyzedTypes
+                let withTypes = associateTypes withTransitions typedResult.AnalyzedTypes
 
                 // Phase 5: Compute derived fields
                 let enriched = enrichWithDerivedFields typedResult.AnalyzedTypes withTypes

--- a/src/Frank.Cli.Core/Unified/UnifiedExtractor.fs
+++ b/src/Frank.Cli.Core/Unified/UnifiedExtractor.fs
@@ -788,7 +788,8 @@ let internal tryParseSpecFile (filePath: string) : Frank.Statecharts.Ast.Statech
                 None
 
         parseResult |> Option.map _.Document
-    with _ ->
+    with ex ->
+        eprintfn "Warning: failed to parse spec file '%s': %s" filePath ex.Message
         None
 
 /// Find all spec files in {projectDir}/specs/ directory.
@@ -813,17 +814,19 @@ let internal documentStateNames (doc: Frank.Statecharts.Ast.StatechartDocument) 
         | _ -> None)
     |> Set.ofList
 
+/// Check if a spec document's states overlap sufficiently with a resource's states.
+let internal statesOverlap (docStates: Set<string>) (resourceStates: Set<string>) : bool =
+    let overlap = Set.intersect resourceStates docStates
+    overlap.Count > 0 && overlap.Count >= resourceStates.Count / 2
+
 /// Match a parsed spec document to a resource by state name overlap.
 let internal matchDocToResource (doc: Frank.Statecharts.Ast.StatechartDocument) (resources: UnifiedResource list) : UnifiedResource option =
+    let docStates = documentStateNames doc
+
     resources
     |> List.tryFind (fun r ->
         match r.Statechart with
-        | Some sc ->
-            let resourceStates = Set.ofList sc.StateNames
-            let docStates = documentStateNames doc
-            // Match if the majority of resource states appear in the document
-            let overlap = Set.intersect resourceStates docStates
-            overlap.Count > 0 && overlap.Count >= resourceStates.Count / 2
+        | Some sc -> statesOverlap docStates (Set.ofList sc.StateNames)
         | None -> false)
 
 /// Co-extract transitions from spec files and merge into resources.
@@ -836,24 +839,18 @@ let internal enrichWithSpecTransitions (projectDir: string) (resources: UnifiedR
         let parsedDocs =
             specFiles
             |> List.choose (fun f ->
-                tryParseSpecFile f |> Option.map (fun doc -> f, doc))
+                tryParseSpecFile f |> Option.map (fun doc -> f, doc, documentStateNames doc))
 
-        // For each resource with a statechart, try to find a matching spec document
         resources
         |> List.map (fun r ->
             match r.Statechart with
             | Some sc when sc.Transitions.IsEmpty ->
+                let resourceStates = Set.ofList sc.StateNames
+
                 let matchingDoc =
                     parsedDocs
-                    |> List.tryPick (fun (_path, doc) ->
-                        let docStates = documentStateNames doc
-                        let resourceStates = Set.ofList sc.StateNames
-                        let overlap = Set.intersect resourceStates docStates
-
-                        if overlap.Count > 0 && overlap.Count >= resourceStates.Count / 2 then
-                            Some doc
-                        else
-                            None)
+                    |> List.tryPick (fun (_path, doc, docStates) ->
+                        if statesOverlap docStates resourceStates then Some doc else None)
 
                 match matchingDoc with
                 | Some doc ->
@@ -909,4 +906,24 @@ let extract (projectPath: string) : Async<Result<UnifiedResource list, Statechar
                 let enriched = enrichWithDerivedFields typedResult.AnalyzedTypes withTypes
 
                 return Ok enriched
+    }
+
+/// Load resources from cache if fresh, otherwise extract from source.
+/// Shared by all commands that need resources (extract, generate, validate, project).
+let loadOrExtract
+    (projectPath: string)
+    (force: bool)
+    : Async<Result<UnifiedResource list * bool, StatechartError>> =
+    async {
+        if not (File.Exists projectPath) then
+            return Error(FileNotFound projectPath)
+        else
+            let projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath))
+
+            match UnifiedCache.tryLoadFresh projectDir force with
+            | Ok state -> return Ok(state.Resources, true)
+            | Error _ ->
+                match! extract projectPath with
+                | Ok resources -> return Ok(resources, false)
+                | Error e -> return Error e
     }

--- a/src/Frank.Cli.Core/Unified/UnifiedExtractor.fs
+++ b/src/Frank.Cli.Core/Unified/UnifiedExtractor.fs
@@ -766,9 +766,9 @@ let private enrichWithDerivedFields (allTypes: AnalyzedType list) (resources: Un
 // Spec file co-extraction: bridge transitions from spec files into extracted statecharts
 // ══════════════════════════════════════════════════════════════════════════════
 
-let private specExtensions = [ ".wsd"; ".smcat"; ".alps.json"; ".alps.xml"; ".scxml" ]
+let internal specExtensions = [ ".wsd"; ".smcat"; ".alps.json"; ".alps.xml"; ".scxml" ]
 
-let private tryParseSpecFile (filePath: string) : Frank.Statecharts.Ast.StatechartDocument option =
+let internal tryParseSpecFile (filePath: string) : Frank.Statecharts.Ast.StatechartDocument option =
     try
         let text = File.ReadAllText(filePath)
         let ext = Path.GetExtension(filePath).ToLowerInvariant()
@@ -792,7 +792,7 @@ let private tryParseSpecFile (filePath: string) : Frank.Statecharts.Ast.Statecha
         None
 
 /// Find all spec files in {projectDir}/specs/ directory.
-let private findSpecFiles (projectDir: string) : string list =
+let internal findSpecFiles (projectDir: string) : string list =
     let specsDir = Path.Combine(projectDir, "specs")
 
     if Directory.Exists(specsDir) then
@@ -804,7 +804,7 @@ let private findSpecFiles (projectDir: string) : string list =
         []
 
 /// Extract state names from a StatechartDocument for matching against resources.
-let private documentStateNames (doc: Frank.Statecharts.Ast.StatechartDocument) : Set<string> =
+let internal documentStateNames (doc: Frank.Statecharts.Ast.StatechartDocument) : Set<string> =
     doc.Elements
     |> List.choose (fun elem ->
         match elem with
@@ -814,7 +814,7 @@ let private documentStateNames (doc: Frank.Statecharts.Ast.StatechartDocument) :
     |> Set.ofList
 
 /// Match a parsed spec document to a resource by state name overlap.
-let private matchDocToResource (doc: Frank.Statecharts.Ast.StatechartDocument) (resources: UnifiedResource list) : UnifiedResource option =
+let internal matchDocToResource (doc: Frank.Statecharts.Ast.StatechartDocument) (resources: UnifiedResource list) : UnifiedResource option =
     resources
     |> List.tryFind (fun r ->
         match r.Statechart with
@@ -827,7 +827,7 @@ let private matchDocToResource (doc: Frank.Statecharts.Ast.StatechartDocument) (
         | None -> false)
 
 /// Co-extract transitions from spec files and merge into resources.
-let private enrichWithSpecTransitions (projectDir: string) (resources: UnifiedResource list) : UnifiedResource list =
+let internal enrichWithSpecTransitions (projectDir: string) (resources: UnifiedResource list) : UnifiedResource list =
     let specFiles = findSpecFiles projectDir
 
     if specFiles.IsEmpty then

--- a/src/Frank.Cli/Program.fs
+++ b/src/Frank.Cli/Program.fs
@@ -599,16 +599,16 @@ let main args =
         let format = parseResult.GetValue(uniExtractFormatOpt)
 
         let result =
-            UnifiedExtractCommand.execute project baseUri vocabs force
+            ExtractResourcesCommand.execute project baseUri vocabs force
             |> Async.RunSynchronously
 
         match result with
         | Ok extractResult ->
             let output =
                 if format = "json" then
-                    JsonOutput.formatUnifiedExtractResult extractResult
+                    JsonOutput.formatResourceExtractResult extractResult
                 else
-                    TextOutput.formatUnifiedExtractResult extractResult
+                    TextOutput.formatResourceExtractResult extractResult
 
             Console.WriteLine(output)
         | Error e ->
@@ -657,7 +657,7 @@ let main args =
         let force = parseResult.GetValue(uniGenForceOpt)
 
         let result =
-            UnifiedGenerateCommand.execute project format outputDir resource force
+            GenerateArtifactsCommand.execute project format outputDir resource force
             |> Async.RunSynchronously
 
         match result with
@@ -716,16 +716,16 @@ let main args =
             Environment.ExitCode <- 1
         else
             let result =
-                UnifiedValidateCommand.execute project force checkProjection checkProgress
+                ValidateResourcesCommand.execute project force checkProjection checkProgress
                 |> Async.RunSynchronously
 
             match result with
             | Ok valResult ->
                 let output =
                     if format = "json" then
-                        JsonOutput.formatUnifiedValidateResult valResult
+                        JsonOutput.formatResourceValidateResult valResult
                     else
-                        TextOutput.formatUnifiedValidateResult valResult
+                        TextOutput.formatResourceValidateResult valResult
 
                 Console.WriteLine(output)
 
@@ -736,6 +736,65 @@ let main args =
                 Console.Error.WriteLine(StatechartError.formatError e))
 
     root.Subcommands.Add(uniValCmd)
+
+    // ── project (top-level, unified) ──
+    let uniProjCmd = Command("project")
+
+    uniProjCmd.Description <-
+        "Generate per-role ALPS profiles from stateful resources using the projection operator"
+
+    let uniProjProjectOpt = Option<string>("--project")
+    uniProjProjectOpt.Description <- "Path to .fsproj file"
+    uniProjProjectOpt.Required <- true
+    let uniProjOutputOpt = Option<string>("--output")
+    uniProjOutputOpt.Description <- "Output directory for projected ALPS profiles"
+    let uniProjResourceOpt = Option<string>("--resource")
+    uniProjResourceOpt.Description <- "Project for a specific resource only"
+    let uniProjForceOpt = Option<bool>("--force")
+    uniProjForceOpt.Description <- "Force re-extraction, bypassing cache"
+    uniProjForceOpt.DefaultValueFactory <- (fun _ -> false)
+    uniProjCmd.Options.Add(uniProjProjectOpt)
+    uniProjCmd.Options.Add(uniProjOutputOpt)
+    uniProjCmd.Options.Add(uniProjResourceOpt)
+    uniProjCmd.Options.Add(uniProjForceOpt)
+
+    uniProjCmd.SetAction(fun parseResult ->
+        let project = parseResult.GetValue(uniProjProjectOpt)
+
+        let outputDir =
+            let v = parseResult.GetValue(uniProjOutputOpt)
+            if String.IsNullOrEmpty v then None else Some v
+
+        let resource =
+            let v = parseResult.GetValue(uniProjResourceOpt)
+            if String.IsNullOrEmpty v then None else Some v
+
+        let force = parseResult.GetValue(uniProjForceOpt)
+
+        let result =
+            ProjectCommand.execute project outputDir resource force
+            |> Async.RunSynchronously
+
+        match result with
+        | Ok projResult ->
+            for warn in projResult.OrphanWarnings do
+                Console.Error.WriteLine(warn)
+
+            for err in projResult.Errors do
+                Console.Error.WriteLine(err)
+
+            for artifact in projResult.Artifacts do
+                match artifact.FilePath with
+                | Some fp ->
+                    let kind = if artifact.IsGlobalOverride then "global" else "role"
+                    Console.WriteLine($"Projected ({kind}): {fp}")
+                | None ->
+                    Console.WriteLine(artifact.Content)
+        | Error e ->
+            Environment.ExitCode <- 1
+            Console.Error.WriteLine(StatechartError.formatError e))
+
+    root.Subcommands.Add(uniProjCmd)
 
     // ── status (top-level) ──
     let statusCmd = Command("status")

--- a/test/Frank.Cli.Core.Tests/Frank.Cli.Core.Tests.fsproj
+++ b/test/Frank.Cli.Core.Tests/Frank.Cli.Core.Tests.fsproj
@@ -37,6 +37,8 @@
     <Compile Include="Unified/UnifiedAlpsGeneratorTests.fs" />
     <Compile Include="Unified/AffordanceMapGeneratorTests.fs" />
     <Compile Include="Unified/ExtractionStateProjectorTests.fs" />
+    <Compile Include="Unified/ProjectionPipelineTests.fs" />
+    <Compile Include="Unified/SpecCoExtractionTests.fs" />
     <Compile Include="Unified/ProjectionIntegrationTests.fs" />
     <Compile Include="Unified/RoleAwareShapeTests.fs" />
     <Compile Include="Program.fs" />

--- a/test/Frank.Cli.Core.Tests/Unified/ProjectionIntegrationTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/ProjectionIntegrationTests.fs
@@ -1,11 +1,13 @@
 module Frank.Cli.Core.Tests.Unified.ProjectionIntegrationTests
 
+open System.Text.Json
 open Expecto
 open Frank.Statecharts.Ast
 open Frank.Statecharts.Alps.JsonParser
 open Frank.Statecharts.TransitionExtractor
 open Frank.Resources.Model
 open Frank.Resources.Model.Projection
+open Frank.Cli.Core.Unified.ProjectionPipeline
 
 // ══════════════════════════════════════════════════════════════════════════════
 // Shared ALPS JSON fixture (TicTacToe with role-based projection)
@@ -362,4 +364,278 @@ let projectionIntegrationTests =
                 <| fun _ ->
                     let doc = parseDocument ()
                     let roles = extractRoles doc
-                    Expect.equal roles.Length 3 "Should extract exactly 3 roles" ] ]
+                    Expect.equal roles.Length 3 "Should extract exactly 3 roles" ]
+
+          testList
+              "End-to-end extract -> project -> per-role ALPS"
+              [ testCase "projectResource produces role profiles for all 3 roles"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let sc = buildStatechart doc
+
+                    let resource: UnifiedResource =
+                        { RouteTemplate = "/games/{gameId}"
+                          ResourceSlug = "games"
+                          TypeInfo = []
+                          Statechart = Some sc
+                          HttpCapabilities =
+                            [ { Method = "GET"
+                                StateKey = Some "XTurn"
+                                LinkRelation = "self"
+                                IsSafe = true }
+                              { Method = "POST"
+                                StateKey = Some "XTurn"
+                                LinkRelation = "makeMove"
+                                IsSafe = false }
+                              { Method = "GET"
+                                StateKey = Some "OTurn"
+                                LinkRelation = "self"
+                                IsSafe = true }
+                              { Method = "POST"
+                                StateKey = Some "OTurn"
+                                LinkRelation = "makeMove"
+                                IsSafe = false }
+                              { Method = "GET"
+                                StateKey = Some "XWins"
+                                LinkRelation = "self"
+                                IsSafe = true }
+                              { Method = "GET"
+                                StateKey = Some "OWins"
+                                LinkRelation = "self"
+                                IsSafe = true }
+                              { Method = "GET"
+                                StateKey = Some "Draw"
+                                LinkRelation = "self"
+                                IsSafe = true } ]
+                          DerivedFields = ResourceModel.emptyDerivedFields }
+
+                    let result = projectResource resource ""
+
+                    Expect.equal result.RoleProfiles.Count 3 "Should produce 3 role profiles"
+
+                    Expect.isTrue
+                        (result.RoleProfiles.ContainsKey "games-playerx")
+                        "Should have PlayerX profile"
+
+                    Expect.isTrue
+                        (result.RoleProfiles.ContainsKey "games-playero")
+                        "Should have PlayerO profile"
+
+                    Expect.isTrue
+                        (result.RoleProfiles.ContainsKey "games-spectator")
+                        "Should have Spectator profile"
+
+                testCase "PlayerX profile is valid ALPS JSON with descriptors"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let sc = buildStatechart doc
+
+                    let resource: UnifiedResource =
+                        { RouteTemplate = "/games/{gameId}"
+                          ResourceSlug = "games"
+                          TypeInfo = []
+                          Statechart = Some sc
+                          HttpCapabilities =
+                            [ { Method = "GET"
+                                StateKey = Some "XTurn"
+                                LinkRelation = "self"
+                                IsSafe = true }
+                              { Method = "POST"
+                                StateKey = Some "XTurn"
+                                LinkRelation = "makeMove"
+                                IsSafe = false }
+                              { Method = "GET"
+                                StateKey = Some "OTurn"
+                                LinkRelation = "self"
+                                IsSafe = true }
+                              { Method = "POST"
+                                StateKey = Some "OTurn"
+                                LinkRelation = "makeMove"
+                                IsSafe = false } ]
+                          DerivedFields = ResourceModel.emptyDerivedFields }
+
+                    let result = projectResource resource ""
+                    let json = result.RoleProfiles.["games-playerx"]
+                    use jsonDoc = JsonDocument.Parse(json)
+                    let alps = jsonDoc.RootElement.GetProperty("alps")
+
+                    match alps.TryGetProperty("descriptor") with
+                    | true, descriptors ->
+                        Expect.isGreaterThan (descriptors.GetArrayLength()) 0 "Should have descriptors"
+                    | _ -> failtest "Should have descriptors"
+
+                testCase "capability filtering removes Spectator POST with restricted-only transitions"
+                <| fun _ ->
+                    // Use a fixture with only role-restricted transitions (no unrestricted getGame)
+                    let sc: ExtractedStatechart =
+                        { RouteTemplate = "/games/{gameId}"
+                          StateNames = [ "XTurn"; "OTurn"; "Won"; "Draw" ]
+                          InitialStateKey = "XTurn"
+                          GuardNames = []
+                          StateMetadata = Map.empty
+                          Roles =
+                            [ { Name = "PlayerX"; Description = None }
+                              { Name = "PlayerO"; Description = None }
+                              { Name = "Spectator"; Description = None } ]
+                          Transitions =
+                            [ { Event = "MakeMove"
+                                Source = "XTurn"
+                                Target = "OTurn"
+                                Guard = None
+                                Constraint = RestrictedTo [ "PlayerX" ] }
+                              { Event = "MakeMove"
+                                Source = "OTurn"
+                                Target = "XTurn"
+                                Guard = None
+                                Constraint = RestrictedTo [ "PlayerO" ] } ] }
+
+                    let caps =
+                        [ { Method = "GET"
+                            StateKey = Some "XTurn"
+                            LinkRelation = "self"
+                            IsSafe = true }
+                          { Method = "POST"
+                            StateKey = Some "XTurn"
+                            LinkRelation = "makeMove"
+                            IsSafe = false }
+                          { Method = "GET"
+                            StateKey = Some "OTurn"
+                            LinkRelation = "self"
+                            IsSafe = true }
+                          { Method = "POST"
+                            StateKey = Some "OTurn"
+                            LinkRelation = "makeMove"
+                            IsSafe = false } ]
+
+                    let resource: UnifiedResource =
+                        { RouteTemplate = "/games/{gameId}"
+                          ResourceSlug = "games"
+                          TypeInfo = []
+                          Statechart = Some sc
+                          HttpCapabilities = caps
+                          DerivedFields = ResourceModel.emptyDerivedFields }
+
+                    let result = projectResource resource ""
+
+                    // Spectator has no transitions, so no unsafe capabilities survive
+                    let spectatorJson = result.RoleProfiles.["games-spectator"]
+                    use spectatorDoc = JsonDocument.Parse(spectatorJson)
+                    let alps = spectatorDoc.RootElement.GetProperty("alps")
+
+                    match alps.TryGetProperty("descriptor") with
+                    | true, descriptors ->
+                        let rec findUnsafe (elem: JsonElement) =
+                            [ match elem.TryGetProperty("type") with
+                              | true, t when t.GetString() = "unsafe" ->
+                                  match elem.TryGetProperty("id") with
+                                  | true, id -> yield id.GetString()
+                                  | _ -> ()
+                              | _ -> ()
+                              match elem.TryGetProperty("descriptor") with
+                              | true, children when children.ValueKind = JsonValueKind.Array ->
+                                  for child in children.EnumerateArray() do
+                                      yield! findUnsafe child
+                              | _ -> () ]
+
+                        let unsafeIds =
+                            [ for d in descriptors.EnumerateArray() do
+                                  yield! findUnsafe d ]
+
+                        Expect.isEmpty unsafeIds "Spectator should have no unsafe descriptors"
+                    | _ -> ()
+
+                testCase "no orphaned transitions in TicTacToe projection"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let sc = buildStatechart doc
+
+                    let resource: UnifiedResource =
+                        { RouteTemplate = "/games/{gameId}"
+                          ResourceSlug = "games"
+                          TypeInfo = []
+                          Statechart = Some sc
+                          HttpCapabilities = []
+                          DerivedFields = ResourceModel.emptyDerivedFields }
+
+                    let result = projectResource resource ""
+                    Expect.isEmpty result.Orphans "Should have no orphaned transitions"
+                    Expect.isEmpty result.Errors "Should have no errors"
+
+                testCase "global profile is regenerated with cross-links"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let sc = buildStatechart doc
+
+                    let resource: UnifiedResource =
+                        { RouteTemplate = "/games/{gameId}"
+                          ResourceSlug = "games"
+                          TypeInfo = []
+                          Statechart = Some sc
+                          HttpCapabilities =
+                            [ { Method = "GET"
+                                StateKey = Some "XTurn"
+                                LinkRelation = "self"
+                                IsSafe = true } ]
+                          DerivedFields = ResourceModel.emptyDerivedFields }
+
+                    let result = projectResource resource ""
+                    Expect.isSome result.UpdatedGlobalProfile "Should regenerate global profile"
+
+                testCase "resource without roles produces empty projection result"
+                <| fun _ ->
+                    let noRolesSc =
+                        { RouteTemplate = "/items"
+                          StateNames = [ "Active" ]
+                          InitialStateKey = "Active"
+                          GuardNames = []
+                          StateMetadata = Map.empty
+                          Roles = []
+                          Transitions = [] }
+
+                    let resource: UnifiedResource =
+                        { RouteTemplate = "/items"
+                          ResourceSlug = "items"
+                          TypeInfo = []
+                          Statechart = Some noRolesSc
+                          HttpCapabilities = []
+                          DerivedFields = ResourceModel.emptyDerivedFields }
+
+                    let result = projectResource resource ""
+                    Expect.isEmpty result.RoleProfiles "Should have no role profiles"
+                    Expect.isNone result.UpdatedGlobalProfile "Should not regenerate global"
+
+                testCase "projectAllResources merges multiple resources"
+                <| fun _ ->
+                    let doc = parseDocument ()
+                    let sc = buildStatechart doc
+
+                    let resource1: UnifiedResource =
+                        { RouteTemplate = "/games/{gameId}"
+                          ResourceSlug = "games"
+                          TypeInfo = []
+                          Statechart = Some sc
+                          HttpCapabilities =
+                            [ { Method = "GET"
+                                StateKey = Some "XTurn"
+                                LinkRelation = "self"
+                                IsSafe = true } ]
+                          DerivedFields = ResourceModel.emptyDerivedFields }
+
+                    let plainResource: UnifiedResource =
+                        { RouteTemplate = "/health"
+                          ResourceSlug = "health"
+                          TypeInfo = []
+                          Statechart = None
+                          HttpCapabilities =
+                            [ { Method = "GET"
+                                StateKey = None
+                                LinkRelation = "self"
+                                IsSafe = true } ]
+                          DerivedFields = ResourceModel.emptyDerivedFields }
+
+                    let batchResult, results = projectAllResources [ resource1; plainResource ] ""
+
+                    Expect.equal batchResult.RoleAlpsProfiles.Count 3 "Should have 3 role profiles from games"
+                    Expect.isTrue (batchResult.ProjectedSlugs.Contains "games") "games should be projected"
+                    Expect.isFalse (batchResult.ProjectedSlugs.Contains "health") "health should not be projected"
+                    Expect.equal results.Length 2 "Should have results for both resources" ] ]

--- a/test/Frank.Cli.Core.Tests/Unified/ProjectionPipelineTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/ProjectionPipelineTests.fs
@@ -1,0 +1,202 @@
+module Frank.Cli.Core.Tests.Unified.ProjectionPipelineTests
+
+open Expecto
+open Frank.Resources.Model
+open Frank.Cli.Core.Unified.ProjectionPipeline
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Shared fixtures
+// ══════════════════════════════════════════════════════════════════════════════
+
+let private ticTacToeTransitions =
+    [ // PlayerX moves from XTurn
+      { Event = "MakeMove"
+        Source = "XTurn"
+        Target = "OTurn"
+        Guard = Some "TurnGuard"
+        Constraint = RestrictedTo [ "PlayerX" ] }
+      { Event = "MakeMove"
+        Source = "XTurn"
+        Target = "Won"
+        Guard = Some "TurnGuard"
+        Constraint = RestrictedTo [ "PlayerX" ] }
+      // PlayerO moves from OTurn
+      { Event = "MakeMove"
+        Source = "OTurn"
+        Target = "XTurn"
+        Guard = Some "TurnGuard"
+        Constraint = RestrictedTo [ "PlayerO" ] }
+      { Event = "MakeMove"
+        Source = "OTurn"
+        Target = "Won"
+        Guard = Some "TurnGuard"
+        Constraint = RestrictedTo [ "PlayerO" ] } ]
+
+let private capabilities: HttpCapability list =
+    [ { Method = "GET"
+        StateKey = Some "XTurn"
+        LinkRelation = "self"
+        IsSafe = true }
+      { Method = "POST"
+        StateKey = Some "XTurn"
+        LinkRelation = "makeMove"
+        IsSafe = false }
+      { Method = "GET"
+        StateKey = Some "OTurn"
+        LinkRelation = "self"
+        IsSafe = true }
+      { Method = "POST"
+        StateKey = Some "OTurn"
+        LinkRelation = "makeMove"
+        IsSafe = false }
+      { Method = "GET"
+        StateKey = Some "Won"
+        LinkRelation = "self"
+        IsSafe = true } ]
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Tests
+// ══════════════════════════════════════════════════════════════════════════════
+
+[<Tests>]
+let projectionPipelineTests =
+    testList
+        "ProjectionPipeline"
+        [ testList
+              "filterCapabilitiesByTransitions"
+              [ testCase "PlayerX: keeps POST in XTurn, removes POST in OTurn"
+                <| fun _ ->
+                    let playerXTransitions =
+                        ticTacToeTransitions
+                        |> List.filter (fun t ->
+                            match t.Constraint with
+                            | RestrictedTo roles -> List.contains "PlayerX" roles
+                            | Unrestricted -> true)
+
+                    let filtered = filterCapabilitiesByTransitions playerXTransitions capabilities
+
+                    let xTurnPost =
+                        filtered
+                        |> List.tryFind (fun c -> c.Method = "POST" && c.StateKey = Some "XTurn")
+
+                    Expect.isSome xTurnPost "PlayerX should keep POST in XTurn"
+
+                    let oTurnPost =
+                        filtered
+                        |> List.tryFind (fun c -> c.Method = "POST" && c.StateKey = Some "OTurn")
+
+                    Expect.isNone oTurnPost "PlayerX should lose POST in OTurn"
+
+                testCase "PlayerO: keeps POST in OTurn, removes POST in XTurn"
+                <| fun _ ->
+                    let playerOTransitions =
+                        ticTacToeTransitions
+                        |> List.filter (fun t ->
+                            match t.Constraint with
+                            | RestrictedTo roles -> List.contains "PlayerO" roles
+                            | Unrestricted -> true)
+
+                    let filtered = filterCapabilitiesByTransitions playerOTransitions capabilities
+
+                    let oTurnPost =
+                        filtered
+                        |> List.tryFind (fun c -> c.Method = "POST" && c.StateKey = Some "OTurn")
+
+                    Expect.isSome oTurnPost "PlayerO should keep POST in OTurn"
+
+                    let xTurnPost =
+                        filtered
+                        |> List.tryFind (fun c -> c.Method = "POST" && c.StateKey = Some "XTurn")
+
+                    Expect.isNone xTurnPost "PlayerO should lose POST in XTurn"
+
+                testCase "Spectator: no unsafe transitions removes all POST"
+                <| fun _ ->
+                    let spectatorTransitions: TransitionSpec list = []
+
+                    let filtered = filterCapabilitiesByTransitions spectatorTransitions capabilities
+
+                    let postCaps = filtered |> List.filter (fun c -> c.Method = "POST")
+                    Expect.isEmpty postCaps "Spectator should have no POST capabilities"
+
+                testCase "Spectator: all GET capabilities survive"
+                <| fun _ ->
+                    let spectatorTransitions: TransitionSpec list = []
+
+                    let filtered = filterCapabilitiesByTransitions spectatorTransitions capabilities
+
+                    let getCaps = filtered |> List.filter (fun c -> c.Method = "GET")
+                    Expect.equal getCaps.Length 3 "Spectator should keep all 3 GET capabilities"
+
+                testCase "capabilities without StateKey always kept"
+                <| fun _ ->
+                    let capsWithGlobal =
+                        capabilities
+                        @ [ { Method = "POST"
+                              StateKey = None
+                              LinkRelation = "create"
+                              IsSafe = false } ]
+
+                    let filtered = filterCapabilitiesByTransitions [] capsWithGlobal
+
+                    let globalPost =
+                        filtered
+                        |> List.tryFind (fun c -> c.Method = "POST" && c.StateKey = None)
+
+                    Expect.isSome globalPost "Unscoped POST should survive even with no transitions"
+
+                testCase "self-loop transitions do not grant unsafe access"
+                <| fun _ ->
+                    let selfLoopTransitions =
+                        [ { Event = "Refresh"
+                            Source = "XTurn"
+                            Target = "XTurn"
+                            Guard = None
+                            Constraint = Unrestricted } ]
+
+                    let filtered = filterCapabilitiesByTransitions selfLoopTransitions capabilities
+
+                    let xTurnPost =
+                        filtered
+                        |> List.tryFind (fun c -> c.Method = "POST" && c.StateKey = Some "XTurn")
+
+                    Expect.isNone xTurnPost "Self-loop should not grant POST access" ]
+
+          testList
+              "filterCapabilitiesByStates"
+              [ testCase "removes capabilities for pruned states"
+                <| fun _ ->
+                    let filtered = filterCapabilitiesByStates [ "XTurn"; "Won" ] capabilities
+
+                    let oTurnCaps =
+                        filtered |> List.filter (fun c -> c.StateKey = Some "OTurn")
+
+                    Expect.isEmpty oTurnCaps "OTurn capabilities should be removed"
+
+                    let xTurnCaps =
+                        filtered |> List.filter (fun c -> c.StateKey = Some "XTurn")
+
+                    Expect.equal xTurnCaps.Length 2 "XTurn capabilities should survive"
+
+                testCase "capabilities without StateKey survive pruning"
+                <| fun _ ->
+                    let capsWithGlobal =
+                        [ { Method = "OPTIONS"
+                            StateKey = None
+                            LinkRelation = "self"
+                            IsSafe = true } ]
+
+                    let filtered = filterCapabilitiesByStates [ "XTurn" ] capsWithGlobal
+                    Expect.equal filtered.Length 1 "Global capability should survive" ]
+
+          testList
+              "roleSlug"
+              [ testCase "produces lowercase slug"
+                <| fun _ ->
+                    let slug = roleSlug "games" "PlayerX"
+                    Expect.equal slug "games-playerx" "Should be lowercase"
+
+                testCase "handles single-word role"
+                <| fun _ ->
+                    let slug = roleSlug "games" "Spectator"
+                    Expect.equal slug "games-spectator" "Should be lowercase" ] ]

--- a/test/Frank.Cli.Core.Tests/Unified/SpecCoExtractionTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/SpecCoExtractionTests.fs
@@ -1,0 +1,268 @@
+module Frank.Cli.Core.Tests.Unified.SpecCoExtractionTests
+
+open System
+open System.IO
+open Expecto
+open Frank.Resources.Model
+open Frank.Cli.Core.Unified.UnifiedExtractor
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Helpers
+// ══════════════════════════════════════════════════════════════════════════════
+
+let private setupTempDir () =
+    let dir = Path.Combine(Path.GetTempPath(), $"frank-spec-test-{Guid.NewGuid():N}")
+    Directory.CreateDirectory(dir) |> ignore
+    dir
+
+let private cleanup (dir: string) =
+    try
+        Directory.Delete(dir, true)
+    with _ ->
+        ()
+
+/// A minimal smcat file with XTurn/OTurn states.
+let private tictactoeSmcat =
+    """
+XTurn => OTurn: makeMove;
+OTurn => XTurn: makeMove;
+"""
+
+/// A resource with a statechart whose state names overlap with the smcat file.
+let private makeResourceWithStates (stateNames: string list) (transitions: TransitionSpec list) : UnifiedResource =
+    { RouteTemplate = "/games/{gameId}"
+      ResourceSlug = "games"
+      TypeInfo = []
+      Statechart =
+        Some
+            { RouteTemplate = "/games/{gameId}"
+              StateNames = stateNames
+              InitialStateKey = stateNames |> List.tryHead |> Option.defaultValue "Unknown"
+              GuardNames = []
+              StateMetadata = Map.empty
+              Roles = []
+              Transitions = transitions }
+      HttpCapabilities = []
+      DerivedFields = ResourceModel.emptyDerivedFields }
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Tests
+// ══════════════════════════════════════════════════════════════════════════════
+
+[<Tests>]
+let specCoExtractionTests =
+    testList
+        "Spec co-extraction"
+        [ testList
+              "findSpecFiles"
+              [ testCase "finds spec files in specs/ directory"
+                <| fun _ ->
+                    let dir = setupTempDir ()
+
+                    try
+                        let specsDir = Path.Combine(dir, "specs")
+                        Directory.CreateDirectory(specsDir) |> ignore
+                        File.WriteAllText(Path.Combine(specsDir, "test.smcat"), tictactoeSmcat)
+                        File.WriteAllText(Path.Combine(specsDir, "test.wsd"), "@startuml\n@enduml")
+                        File.WriteAllText(Path.Combine(specsDir, "readme.txt"), "not a spec")
+
+                        let files = findSpecFiles dir
+                        Expect.equal files.Length 2 "Should find 2 spec files (not txt)"
+
+                        let extensions = files |> List.map Path.GetExtension
+                        Expect.contains extensions ".smcat" "Should include .smcat"
+                        Expect.contains extensions ".wsd" "Should include .wsd"
+                    finally
+                        cleanup dir
+
+                testCase "returns empty when no specs/ directory"
+                <| fun _ ->
+                    let dir = setupTempDir ()
+
+                    try
+                        let files = findSpecFiles dir
+                        Expect.isEmpty files "Should return empty list"
+                    finally
+                        cleanup dir
+
+                testCase "returns empty when specs/ is empty"
+                <| fun _ ->
+                    let dir = setupTempDir ()
+
+                    try
+                        Directory.CreateDirectory(Path.Combine(dir, "specs")) |> ignore
+                        let files = findSpecFiles dir
+                        Expect.isEmpty files "Should return empty list for empty specs dir"
+                    finally
+                        cleanup dir
+
+                testCase "finds alps.json files"
+                <| fun _ ->
+                    let dir = setupTempDir ()
+
+                    try
+                        let specsDir = Path.Combine(dir, "specs")
+                        Directory.CreateDirectory(specsDir) |> ignore
+
+                        File.WriteAllText(
+                            Path.Combine(specsDir, "game.alps.json"),
+                            """{"alps":{"version":"1.0","descriptor":[]}}""")
+
+                        let files = findSpecFiles dir
+                        Expect.equal files.Length 1 "Should find alps.json file"
+                    finally
+                        cleanup dir ]
+
+          testList
+              "tryParseSpecFile"
+              [ testCase "parses valid smcat file"
+                <| fun _ ->
+                    let dir = setupTempDir ()
+
+                    try
+                        let filePath = Path.Combine(dir, "test.smcat")
+                        File.WriteAllText(filePath, tictactoeSmcat)
+                        let result = tryParseSpecFile filePath
+                        Expect.isSome result "Should parse smcat file"
+                    finally
+                        cleanup dir
+
+                testCase "returns None for unknown extension"
+                <| fun _ ->
+                    let dir = setupTempDir ()
+
+                    try
+                        let filePath = Path.Combine(dir, "test.txt")
+                        File.WriteAllText(filePath, "not a spec")
+                        let result = tryParseSpecFile filePath
+                        Expect.isNone result "Should return None for .txt"
+                    finally
+                        cleanup dir
+
+                testCase "returns None for nonexistent file"
+                <| fun _ ->
+                    let result = tryParseSpecFile "/nonexistent/path/file.smcat"
+                    Expect.isNone result "Should return None for nonexistent file" ]
+
+          testList
+              "documentStateNames"
+              [ testCase "extracts state names from parsed smcat document"
+                <| fun _ ->
+                    let dir = setupTempDir ()
+
+                    try
+                        let filePath = Path.Combine(dir, "test.smcat")
+                        File.WriteAllText(filePath, tictactoeSmcat)
+
+                        match tryParseSpecFile filePath with
+                        | Some doc ->
+                            let names = documentStateNames doc
+                            Expect.isTrue (names.Contains "XTurn") "Should contain XTurn"
+                            Expect.isTrue (names.Contains "OTurn") "Should contain OTurn"
+                        | None -> failtest "Should parse the smcat file"
+                    finally
+                        cleanup dir ]
+
+          testList
+              "enrichWithSpecTransitions"
+              [ testCase "populates transitions from matching spec file"
+                <| fun _ ->
+                    let dir = setupTempDir ()
+
+                    try
+                        let specsDir = Path.Combine(dir, "specs")
+                        Directory.CreateDirectory(specsDir) |> ignore
+                        File.WriteAllText(Path.Combine(specsDir, "game.smcat"), tictactoeSmcat)
+
+                        let resource = makeResourceWithStates [ "XTurn"; "OTurn" ] []
+                        let enriched = enrichWithSpecTransitions dir [ resource ]
+
+                        match enriched.[0].Statechart with
+                        | Some sc ->
+                            Expect.isGreaterThan sc.Transitions.Length 0 "Should have transitions after enrichment"
+
+                            let sources = sc.Transitions |> List.map _.Source |> Set.ofList
+                            Expect.isTrue (sources.Contains "XTurn") "Should have transition from XTurn"
+                            Expect.isTrue (sources.Contains "OTurn") "Should have transition from OTurn"
+                        | None -> failtest "Should have statechart"
+                    finally
+                        cleanup dir
+
+                testCase "no crash when project has no specs directory"
+                <| fun _ ->
+                    let dir = setupTempDir ()
+
+                    try
+                        let resource = makeResourceWithStates [ "XTurn"; "OTurn" ] []
+                        let enriched = enrichWithSpecTransitions dir [ resource ]
+
+                        match enriched.[0].Statechart with
+                        | Some sc -> Expect.isEmpty sc.Transitions "Transitions should remain empty"
+                        | None -> failtest "Should have statechart"
+                    finally
+                        cleanup dir
+
+                testCase "no match when spec state names don't overlap"
+                <| fun _ ->
+                    let dir = setupTempDir ()
+
+                    try
+                        let specsDir = Path.Combine(dir, "specs")
+                        Directory.CreateDirectory(specsDir) |> ignore
+                        File.WriteAllText(Path.Combine(specsDir, "game.smcat"), tictactoeSmcat)
+
+                        let resource = makeResourceWithStates [ "Active"; "Completed" ] []
+                        let enriched = enrichWithSpecTransitions dir [ resource ]
+
+                        match enriched.[0].Statechart with
+                        | Some sc -> Expect.isEmpty sc.Transitions "Transitions should remain empty when no overlap"
+                        | None -> failtest "Should have statechart"
+                    finally
+                        cleanup dir
+
+                testCase "does not overwrite existing transitions"
+                <| fun _ ->
+                    let dir = setupTempDir ()
+
+                    try
+                        let specsDir = Path.Combine(dir, "specs")
+                        Directory.CreateDirectory(specsDir) |> ignore
+                        File.WriteAllText(Path.Combine(specsDir, "game.smcat"), tictactoeSmcat)
+
+                        let existingTransition =
+                            { Event = "Existing"
+                              Source = "XTurn"
+                              Target = "OTurn"
+                              Guard = None
+                              Constraint = Unrestricted }
+
+                        let resource = makeResourceWithStates [ "XTurn"; "OTurn" ] [ existingTransition ]
+                        let enriched = enrichWithSpecTransitions dir [ resource ]
+
+                        match enriched.[0].Statechart with
+                        | Some sc ->
+                            Expect.equal sc.Transitions.Length 1 "Should keep existing transition"
+                            Expect.equal sc.Transitions.[0].Event "Existing" "Should keep existing event name"
+                        | None -> failtest "Should have statechart"
+                    finally
+                        cleanup dir
+
+                testCase "matchDocToResource matches by state name overlap"
+                <| fun _ ->
+                    let dir = setupTempDir ()
+
+                    try
+                        let filePath = Path.Combine(dir, "test.smcat")
+                        File.WriteAllText(filePath, tictactoeSmcat)
+
+                        match tryParseSpecFile filePath with
+                        | Some doc ->
+                            let matching = makeResourceWithStates [ "XTurn"; "OTurn" ] []
+                            let nonMatching = makeResourceWithStates [ "Active"; "Done" ] []
+
+                            let result = matchDocToResource doc [ nonMatching; matching ]
+                            Expect.isSome result "Should find matching resource"
+                            Expect.equal result.Value.ResourceSlug "games" "Should match the games resource"
+                        | None -> failtest "Should parse smcat"
+                    finally
+                        cleanup dir ] ]

--- a/test/Frank.Cli.Core.Tests/Unified/SpecCoExtractionTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/SpecCoExtractionTests.fs
@@ -123,11 +123,11 @@ let specCoExtractionTests =
                         let filePath = Path.Combine(dir, "test.smcat")
                         File.WriteAllText(filePath, tictactoeSmcat)
                         let result = tryParseSpecFile filePath
-                        Expect.isSome result "Should parse smcat file"
+                        Expect.isOk result "Should parse smcat file"
                     finally
                         cleanup dir
 
-                testCase "returns None for unknown extension"
+                testCase "returns Error for unknown extension"
                 <| fun _ ->
                     let dir = setupTempDir ()
 
@@ -135,14 +135,14 @@ let specCoExtractionTests =
                         let filePath = Path.Combine(dir, "test.txt")
                         File.WriteAllText(filePath, "not a spec")
                         let result = tryParseSpecFile filePath
-                        Expect.isNone result "Should return None for .txt"
+                        Expect.isError result "Should return Error for .txt"
                     finally
                         cleanup dir
 
-                testCase "returns None for nonexistent file"
+                testCase "returns Error for nonexistent file"
                 <| fun _ ->
                     let result = tryParseSpecFile "/nonexistent/path/file.smcat"
-                    Expect.isNone result "Should return None for nonexistent file" ]
+                    Expect.isError result "Should return Error for nonexistent file" ]
 
           testList
               "documentStateNames"
@@ -155,11 +155,11 @@ let specCoExtractionTests =
                         File.WriteAllText(filePath, tictactoeSmcat)
 
                         match tryParseSpecFile filePath with
-                        | Some doc ->
+                        | Ok doc ->
                             let names = documentStateNames doc
                             Expect.isTrue (names.Contains "XTurn") "Should contain XTurn"
                             Expect.isTrue (names.Contains "OTurn") "Should contain OTurn"
-                        | None -> failtest "Should parse the smcat file"
+                        | Error msg -> failtest $"Should parse the smcat file: {msg}"
                     finally
                         cleanup dir ]
 
@@ -175,7 +175,7 @@ let specCoExtractionTests =
                         File.WriteAllText(Path.Combine(specsDir, "game.smcat"), tictactoeSmcat)
 
                         let resource = makeResourceWithStates [ "XTurn"; "OTurn" ] []
-                        let enriched = enrichWithSpecTransitions dir [ resource ]
+                        let enriched, _warnings = enrichWithSpecTransitions dir [ resource ]
 
                         match enriched.[0].Statechart with
                         | Some sc ->
@@ -194,7 +194,7 @@ let specCoExtractionTests =
 
                     try
                         let resource = makeResourceWithStates [ "XTurn"; "OTurn" ] []
-                        let enriched = enrichWithSpecTransitions dir [ resource ]
+                        let enriched, _warnings = enrichWithSpecTransitions dir [ resource ]
 
                         match enriched.[0].Statechart with
                         | Some sc -> Expect.isEmpty sc.Transitions "Transitions should remain empty"
@@ -212,7 +212,7 @@ let specCoExtractionTests =
                         File.WriteAllText(Path.Combine(specsDir, "game.smcat"), tictactoeSmcat)
 
                         let resource = makeResourceWithStates [ "Active"; "Completed" ] []
-                        let enriched = enrichWithSpecTransitions dir [ resource ]
+                        let enriched, _warnings = enrichWithSpecTransitions dir [ resource ]
 
                         match enriched.[0].Statechart with
                         | Some sc -> Expect.isEmpty sc.Transitions "Transitions should remain empty when no overlap"
@@ -237,7 +237,7 @@ let specCoExtractionTests =
                               Constraint = Unrestricted }
 
                         let resource = makeResourceWithStates [ "XTurn"; "OTurn" ] [ existingTransition ]
-                        let enriched = enrichWithSpecTransitions dir [ resource ]
+                        let enriched, _warnings = enrichWithSpecTransitions dir [ resource ]
 
                         match enriched.[0].Statechart with
                         | Some sc ->
@@ -256,13 +256,13 @@ let specCoExtractionTests =
                         File.WriteAllText(filePath, tictactoeSmcat)
 
                         match tryParseSpecFile filePath with
-                        | Some doc ->
+                        | Ok doc ->
                             let matching = makeResourceWithStates [ "XTurn"; "OTurn" ] []
                             let nonMatching = makeResourceWithStates [ "Active"; "Done" ] []
 
                             let result = matchDocToResource doc [ nonMatching; matching ]
                             Expect.isSome result "Should find matching resource"
                             Expect.equal result.Value.ResourceSlug "games" "Should match the games resource"
-                        | None -> failtest "Should parse smcat"
+                        | Error msg -> failtest $"Should parse smcat: {msg}"
                     finally
                         cleanup dir ] ]

--- a/test/Frank.Cli.Core.Tests/Unified/UnifiedCacheTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/UnifiedCacheTests.fs
@@ -352,4 +352,92 @@ let unifiedCacheTests =
                             Expect.equal state.Resources.[0].RouteTemplate "/games/{gameId}" "Route preserved"
                         | Error msg -> failtest $"Expected Ok, got Error: {msg}"
                     finally
+                        cleanup dir
+
+                testCase "roundtrips transitions and roles through cache"
+                <| fun _ ->
+                    let dir = setupTempProject ()
+
+                    try
+                        let transitions =
+                            [ { Event = "MakeMove"
+                                Source = "XTurn"
+                                Target = "OTurn"
+                                Guard = Some "TurnGuard"
+                                Constraint = RestrictedTo [ "PlayerX" ] }
+                              { Event = "MakeMove"
+                                Source = "OTurn"
+                                Target = "XTurn"
+                                Guard = Some "TurnGuard"
+                                Constraint = RestrictedTo [ "PlayerO" ] } ]
+
+                        let roles: RoleInfo list =
+                            [ { Name = "PlayerX"; Description = None }
+                              { Name = "PlayerO"; Description = None }
+                              { Name = "Spectator"
+                                Description = Some "Observes only" } ]
+
+                        let resources: UnifiedResource list =
+                            [ { RouteTemplate = "/games/{gameId}"
+                                ResourceSlug = "games"
+                                TypeInfo = []
+                                Statechart =
+                                    Some
+                                        { RouteTemplate = "/games/{gameId}"
+                                          StateNames = [ "XTurn"; "OTurn"; "Won"; "Draw" ]
+                                          InitialStateKey = "XTurn"
+                                          GuardNames = [ "TurnGuard" ]
+                                          StateMetadata = Map.empty
+                                          Roles = roles
+                                          Transitions = transitions }
+                                HttpCapabilities =
+                                    [ { Method = "GET"
+                                        StateKey = Some "XTurn"
+                                        LinkRelation = "self"
+                                        IsSafe = true }
+                                      { Method = "POST"
+                                        StateKey = Some "XTurn"
+                                        LinkRelation = "makeMove"
+                                        IsSafe = false } ]
+                                DerivedFields = ResourceModel.emptyDerivedFields } ]
+
+                        let state =
+                            { createSampleState "transitions-test" with
+                                Resources = resources }
+
+                        let path = UnifiedCache.cachePath dir
+                        let saveResult = UnifiedCache.save path state
+                        Expect.isOk saveResult "save should succeed"
+
+                        let loadResult = UnifiedCache.load path
+                        Expect.isOk loadResult "load should succeed"
+
+                        match loadResult with
+                        | Ok(Some loaded) ->
+                            let sc = loaded.Resources.[0].Statechart
+                            Expect.isSome sc "Should have statechart after reload"
+
+                            let chart = sc.Value
+                            Expect.equal chart.Transitions.Length 2 "Should preserve 2 transitions"
+                            Expect.equal chart.Roles.Length 3 "Should preserve 3 roles"
+
+                            let t0 = chart.Transitions.[0]
+                            Expect.equal t0.Event "MakeMove" "Event preserved"
+                            Expect.equal t0.Source "XTurn" "Source preserved"
+                            Expect.equal t0.Target "OTurn" "Target preserved"
+                            Expect.equal t0.Guard (Some "TurnGuard") "Guard preserved"
+                            Expect.equal t0.Constraint (RestrictedTo [ "PlayerX" ]) "Constraint preserved"
+
+                            let spectator = chart.Roles |> List.find (fun r -> r.Name = "Spectator")
+                            Expect.equal spectator.Description (Some "Observes only") "Role description preserved"
+
+                            let caps = loaded.Resources.[0].HttpCapabilities
+                            Expect.equal caps.Length 2 "Should preserve capabilities"
+
+                            let postCap = caps |> List.find (fun c -> c.Method = "POST")
+                            Expect.equal postCap.StateKey (Some "XTurn") "StateKey preserved"
+                            Expect.equal postCap.IsSafe false "IsSafe preserved"
+                        | Ok None -> failtest "Expected Some state, got None"
+                        | Error msg -> failtest $"Expected Ok, got Error: {msg}"
+                    finally
                         cleanup dir ] ]

--- a/test/Frank.Cli.Core.Tests/Unified/UnifiedExtractorTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/UnifiedExtractorTests.fs
@@ -63,7 +63,7 @@ let game = statefulResource "/games/{gameId}" {
                     Expect.equal findings.Length 1 "Should find 1 resource"
 
                     match findings.[0] with
-                    | FoundStatefulResource(route, machineName, stateHandlers) ->
+                    | FoundStatefulResource(route, machineName, stateHandlers, _roleNames) ->
                         Expect.equal route "/games/{gameId}" "Route should match"
                         Expect.equal machineName (Some "gameMachine") "Machine name should be gameMachine"
                         Expect.equal stateHandlers.Length 2 "Should have 2 state handlers"
@@ -103,7 +103,7 @@ let game = statefulResource "/games/{gameId}" {
                         findings
                         |> List.exists (fun f ->
                             match f with
-                            | FoundStatefulResource(route, _, _) -> route = "/games/{gameId}"
+                            | FoundStatefulResource(route, _, _, _) -> route = "/games/{gameId}"
                             | _ -> false)
 
                     Expect.isTrue hasPlain "Should find plain resource"
@@ -170,7 +170,7 @@ let game = statefulResource "/games/{gameId}" {
                     let findings = findResourcesInParsedInput ast
 
                     match findings.[0] with
-                    | FoundStatefulResource(_, machineName, stateHandlers) ->
+                    | FoundStatefulResource(_, machineName, stateHandlers, _) ->
                         Expect.isNone machineName "Machine name should be None"
                         Expect.equal stateHandlers.Length 2 "Should have 2 state handlers"
                     | _ -> failtest "Expected FoundStatefulResource"

--- a/test/Frank.Cli.Core.Tests/Unified/UnifiedExtractorTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/UnifiedExtractorTests.fs
@@ -357,6 +357,80 @@ let game = statefulResource "/games/{gameId}" {
                     Expect.equal result.TypeCoverage 1.0 "Coverage should be 1.0" ]
 
           testList
+              "role extraction"
+              [ testCaseAsync "extracts role names from statefulResource CE"
+                <| async {
+                    let source =
+                        """
+module Test
+let game = statefulResource "/games/{gameId}" {
+    machine gameMachine
+    role "PlayerX" (fun user -> user.HasClaim("player", "X"))
+    role "PlayerO" (fun user -> user.HasClaim("player", "O"))
+    role "Spectator" (fun _user -> true)
+    inState (forState XTurn [ get handler; post handler ])
+    inState (forState OTurn [ get handler; post handler ])
+}
+"""
+
+                    let! ast = parseSource source
+                    let findings = findResourcesInParsedInput ast
+
+                    Expect.equal findings.Length 1 "Should find 1 resource"
+
+                    match findings.[0] with
+                    | FoundStatefulResource(_route, _machineName, _stateHandlers, roleNames) ->
+                        Expect.equal roleNames.Length 3 "Should have 3 roles"
+                        Expect.contains roleNames "PlayerX" "Should contain PlayerX"
+                        Expect.contains roleNames "PlayerO" "Should contain PlayerO"
+                        Expect.contains roleNames "Spectator" "Should contain Spectator"
+                    | _ -> failtest "Expected FoundStatefulResource"
+                }
+
+                testCaseAsync "statefulResource without roles returns empty role list"
+                <| async {
+                    let source =
+                        """
+module Test
+let game = statefulResource "/games/{gameId}" {
+    machine gameMachine
+    inState (forState Playing [ get handler; post handler ])
+    inState (forState Finished [ get handler ])
+}
+"""
+
+                    let! ast = parseSource source
+                    let findings = findResourcesInParsedInput ast
+
+                    match findings.[0] with
+                    | FoundStatefulResource(_route, _machineName, _stateHandlers, roleNames) ->
+                        Expect.isEmpty roleNames "Should have no roles"
+                    | _ -> failtest "Expected FoundStatefulResource"
+                }
+
+                testCaseAsync "role extraction preserves order"
+                <| async {
+                    let source =
+                        """
+module Test
+let game = statefulResource "/games/{gameId}" {
+    machine gameMachine
+    role "Admin" (fun user -> user.IsInRole("admin"))
+    role "User" (fun _user -> true)
+    inState (forState Active [ get handler ])
+}
+"""
+
+                    let! ast = parseSource source
+                    let findings = findResourcesInParsedInput ast
+
+                    match findings.[0] with
+                    | FoundStatefulResource(_, _, _, roleNames) ->
+                        Expect.equal roleNames [ "Admin"; "User" ] "Roles should be in declaration order"
+                    | _ -> failtest "Expected FoundStatefulResource"
+                } ]
+
+          testList
               "comparison with old extractors"
               [ testCaseAsync "unified walker finds same plain resources as AstAnalyzer"
                 <| async {


### PR DESCRIPTION
## Summary

- Adds `frank project` CLI command that generates per-role ALPS profiles from statechart + role definitions
- Implements spec file co-extraction: discovers `specs/{slug}.*` files (WSD, SMCAT, ALPS JSON), parses transitions via `TransitionExtractor`, and merges into `ExtractedStatechart`
- Adds `filterCapabilitiesByTransitions` to remove unsafe HTTP capabilities from states where a role has no non-self-loop transition
- Renames command files: drops `Unified` prefix → `ExtractResourcesCommand`, `GenerateArtifactsCommand`, `ValidateResourcesCommand`
- Adds roles (PlayerX, PlayerO, Spectator) to TicTacToe sample
- Aligns spec file state names (XWins/OWins → Won) to match F# DU
- Adds roles and transitions arrays to JSON extraction output
- 34 new tests: role CE extraction, spec file discovery, `filterCapabilitiesByTransitions`, end-to-end extract→project integration, cache round-trip

### Verified end-to-end output

- **PlayerX**: `create` (POST) only in XTurn state
- **PlayerO**: `create` (POST) only in OTurn state
- **Spectator**: `get` (GET) only — observe-only role

## Test plan

- [x] `dotnet build Frank.sln` — 0 errors
- [x] `dotnet test Frank.sln --filter "FullyQualifiedName!~Sample"` — 2,176 tests pass
- [x] `frank project --project sample/Frank.TicTacToe.Sample` produces differentiated role profiles
- [ ] Review role CE extraction handles edge cases
- [ ] Review spec file discovery fallback ordering

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)