### PR TITLE
fix: replace bare catch-all with TryParseList in LinkedData content negotiation

### DIFF
--- a/src/Frank.LinkedData/WebHostBuilderExtensions.fs
+++ b/src/Frank.LinkedData/WebHostBuilderExtensions.fs
@@ -22,22 +22,22 @@ module WebHostBuilderExtensions =
         [ "application/ld+json"; "text/turtle"; "application/rdf+xml" ]
 
     /// Determines the RDF media type from the Accept header, if any.
-    /// Uses MediaTypeHeaderValue for proper RFC 7231 parsing with quality factors.
+    /// Uses MediaTypeHeaderValue for proper RFC 9110 Section 12.5.1 parsing with quality factors.
     let negotiateRdfType (accept: string) =
         if String.IsNullOrWhiteSpace accept then
             None
         else
-            let mediaTypes =
-                try
-                    MediaTypeHeaderValue.ParseList(Microsoft.Extensions.Primitives.StringValues(accept))
-                with _ ->
-                    System.Collections.Generic.List<MediaTypeHeaderValue>()
+            let (success, mediaTypes) =
+                MediaTypeHeaderValue.TryParseList(Microsoft.Extensions.Primitives.StringValues(accept))
 
-            mediaTypes
-            |> Seq.sortByDescending (fun mt -> mt.Quality |> Option.ofNullable |> Option.defaultValue 1.0)
-            |> Seq.tryPick (fun mt ->
-                supportedMediaTypes
-                |> List.tryFind (fun s -> mt.MediaType.Equals(s, StringComparison.OrdinalIgnoreCase)))
+            if not success || isNull mediaTypes then
+                None
+            else
+                mediaTypes
+                |> Seq.sortByDescending (fun mt -> mt.Quality |> Option.ofNullable |> Option.defaultValue 1.0)
+                |> Seq.tryPick (fun mt ->
+                    supportedMediaTypes
+                    |> List.tryFind (fun s -> mt.MediaType.Equals(s, StringComparison.OrdinalIgnoreCase)))
 
     /// Writes an IGraph to the stream in the specified RDF media type.
     let writeRdf (mediaType: string) (graph: IGraph) (stream: Stream) =

--- a/test/Frank.LinkedData.Tests/ContentNegotiationTests.fs
+++ b/test/Frank.LinkedData.Tests/ContentNegotiationTests.fs
@@ -385,4 +385,24 @@ let tests =
               request.Headers.Add("Accept", "text/turtle")
               let response: HttpResponseMessage = client.SendAsync(request).Result
               let body = response.Content.ReadAsStringAsync().Result
-              Expect.stringContains body "not valid json" "Should pass through original response on projection failure" ]
+              Expect.stringContains body "not valid json" "Should pass through original response on projection failure"
+
+          // Pragmatic choice: malformed Accept passes through to downstream handler (serves JSON)
+          // rather than 400. The middleware cannot know if the downstream handler prefers to 400.
+          // RFC 9110 Section 12.5.1 allows ignoring an unparseable Accept header.
+          testCase "middleware passes through when Accept header is malformed"
+          <| fun _ ->
+              let ontology = makeOntologyWithNameAndAge ()
+              let config = makeConfig ontology
+              use host = createTestHost config true
+              let server = host.GetTestServer()
+              use client = server.CreateClient()
+
+              use request = new HttpRequestMessage(HttpMethod.Get, "/person/1")
+
+              request.Headers.TryAddWithoutValidation("Accept", ";;;not-a-media-type;;;")
+              |> ignore
+
+              let (response: HttpResponseMessage) = client.SendAsync(request).Result
+              let body = response.Content.ReadAsStringAsync().Result
+              Expect.stringContains body "Alice" "Malformed Accept should fall through to original handler" ]


### PR DESCRIPTION
## Summary

- Replace `ParseList` + bare `with _ ->` catch-all with `TryParseList` (no-throw API) for malformed Accept header handling in `negotiateRdfType`
- Eliminates exception-driven control flow on untrusted input — satisfies Constitution VII
- Updated RFC reference from 7231 to 9110 Section 12.5.1
- Added middleware integration test for malformed Accept header passthrough with design decision comment

## Expert review

Fielding, Fowler, @7sharp9 all approve. Key feedback incorporated:
- **Fielding**: Added comment documenting pragmatic passthrough choice (RFC 9110 §12.5.1 allows ignoring unparseable Accept)
- **Fowler**: `isNull` guard is defensive but correct at interop boundary
- **@7sharp9**: `use` on `HttpRequestMessage` is correct per Constitution VI (pre-existing inconsistency noted for follow-up)

## Test plan

- [x] `dotnet build Frank.sln` — 0 errors
- [x] `dotnet test Frank.sln --filter "FullyQualifiedName!~Sample"` — 2,177 tests pass
- [x] `dotnet fantomas --check` — clean
- [x] New test: malformed Accept header passes through to original handler

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)