### PR TITLE
feat: add --base-uri option to project and generate commands

### DIFF
--- a/src/Frank.Cli.Core/Commands/GenerateArtifactsCommand.fs
+++ b/src/Frank.Cli.Core/Commands/GenerateArtifactsCommand.fs
@@ -64,7 +64,7 @@ let private generateAffordanceMapJson (resources: UnifiedResource list) (baseUri
                 writer.WriteEndArray()
                 writer.WriteStartArray("linkRelations")
                 writer.WriteEndArray()
-                writer.WriteString("profileUrl", $"{baseUri}{resource.ResourceSlug}")
+                writer.WriteString("profileUrl", $"{baseUri}/{resource.ResourceSlug}")
                 writer.WriteEndObject()
         | None ->
             writer.WriteStartObject()
@@ -89,6 +89,7 @@ let private generateAffordanceMapJson (resources: UnifiedResource list) (baseUri
 let execute
     (projectPath: string)
     (format: string)
+    (baseUri: string)
     (outputDir: string option)
     (resourceFilter: string option)
     (force: bool)
@@ -98,7 +99,7 @@ let execute
             match! UnifiedExtractor.loadOrExtract projectPath force with
             | Error e -> return Error e
             | Ok(resources, fromCache) ->
-                let mapContent = generateAffordanceMapJson resources ""
+                let mapContent = generateAffordanceMapJson resources baseUri
 
                 return
                     Ok
@@ -172,7 +173,7 @@ let execute
                                     resources |> List.filter (fun r -> Set.contains r.RouteTemplate filteredRoutes)
 
                                 let batchResult, projectionResults =
-                                    ProjectionPipeline.projectAllResources matchingResources ""
+                                    ProjectionPipeline.projectAllResources matchingResources baseUri
 
                                 // Print warnings from projection
                                 for result in projectionResults do

--- a/src/Frank.Cli.Core/Commands/ProjectCommand.fs
+++ b/src/Frank.Cli.Core/Commands/ProjectCommand.fs
@@ -20,6 +20,7 @@ type ProjectResult =
 
 let execute
     (projectPath: string)
+    (baseUri: string)
     (outputDir: string option)
     (resourceFilter: string option)
     (force: bool)
@@ -35,15 +36,14 @@ let execute
                 | None -> resources
                 | Some name ->
                     resources
-                    |> List.filter (fun r ->
-                        r.ResourceSlug = name || r.RouteTemplate.Contains(name))
+                    |> List.filter (fun r -> r.ResourceSlug = name || r.RouteTemplate.Contains(name))
 
             match resourceFilter, filtered with
             | Some name, [] ->
                 let available = resources |> List.map _.ResourceSlug
                 return Error(ResourceNotFound(name, available))
             | _ ->
-                let batchResult, projectionResults = projectAllResources filtered ""
+                let batchResult, projectionResults = projectAllResources filtered baseUri
 
                 let orphanWarnings =
                     [ for result in projectionResults do

--- a/src/Frank.Cli/Program.fs
+++ b/src/Frank.Cli/Program.fs
@@ -574,8 +574,11 @@ let main args =
     uniExtractProjectOpt.Description <- "Path to .fsproj file"
     uniExtractProjectOpt.Required <- true
     let uniExtractBaseUriOpt = Option<string>("--base-uri")
-    uniExtractBaseUriOpt.Description <- "Base URI for ALPS profiles"
-    uniExtractBaseUriOpt.DefaultValueFactory <- (fun _ -> "http://example.org/")
+
+    uniExtractBaseUriOpt.Description <-
+        "Base URI for ALPS profile namespace (used in descriptor hrefs and cross-profile links)"
+
+    uniExtractBaseUriOpt.DefaultValueFactory <- (fun _ -> "http://example.org")
     let uniExtractVocabOpt = Option<string array>("--vocabularies")
     uniExtractVocabOpt.Description <- "Vocabulary namespaces to align"
     uniExtractVocabOpt.DefaultValueFactory <- (fun _ -> [| "schema.org" |])
@@ -629,6 +632,12 @@ let main args =
     let uniGenFormatOpt = Option<string>("--format")
     uniGenFormatOpt.Description <- "Target format (wsd|alps|alps-xml|scxml|smcat|xstate|affordance-map|all)"
     uniGenFormatOpt.Required <- true
+    let uniGenBaseUriOpt = Option<string>("--base-uri")
+
+    uniGenBaseUriOpt.Description <-
+        "Base URI for ALPS profile namespace (used in descriptor hrefs and cross-profile links)"
+
+    uniGenBaseUriOpt.DefaultValueFactory <- (fun _ -> "http://example.org")
     let uniGenOutputOpt = Option<string>("--output")
     uniGenOutputOpt.Description <- "Output directory for generated artifacts"
     let uniGenResourceOpt = Option<string>("--resource")
@@ -638,6 +647,7 @@ let main args =
     uniGenForceOpt.DefaultValueFactory <- (fun _ -> false)
     uniGenCmd.Options.Add(uniGenProjectOpt)
     uniGenCmd.Options.Add(uniGenFormatOpt)
+    uniGenCmd.Options.Add(uniGenBaseUriOpt)
     uniGenCmd.Options.Add(uniGenOutputOpt)
     uniGenCmd.Options.Add(uniGenResourceOpt)
     uniGenCmd.Options.Add(uniGenForceOpt)
@@ -645,6 +655,7 @@ let main args =
     uniGenCmd.SetAction(fun parseResult ->
         let project = parseResult.GetValue(uniGenProjectOpt)
         let format = parseResult.GetValue(uniGenFormatOpt)
+        let baseUri = parseResult.GetValue(uniGenBaseUriOpt)
 
         let outputDir =
             let v = parseResult.GetValue(uniGenOutputOpt)
@@ -657,7 +668,7 @@ let main args =
         let force = parseResult.GetValue(uniGenForceOpt)
 
         let result =
-            GenerateArtifactsCommand.execute project format outputDir resource force
+            GenerateArtifactsCommand.execute project format baseUri outputDir resource force
             |> Async.RunSynchronously
 
         match result with
@@ -740,12 +751,17 @@ let main args =
     // ── project (top-level, unified) ──
     let uniProjCmd = Command("project")
 
-    uniProjCmd.Description <-
-        "Generate per-role ALPS profiles from stateful resources using the projection operator"
+    uniProjCmd.Description <- "Generate per-role ALPS profiles from stateful resources using the projection operator"
 
     let uniProjProjectOpt = Option<string>("--project")
     uniProjProjectOpt.Description <- "Path to .fsproj file"
     uniProjProjectOpt.Required <- true
+    let uniProjBaseUriOpt = Option<string>("--base-uri")
+
+    uniProjBaseUriOpt.Description <-
+        "Base URI for ALPS profile namespace (used in descriptor hrefs and cross-profile links)"
+
+    uniProjBaseUriOpt.DefaultValueFactory <- (fun _ -> "http://example.org")
     let uniProjOutputOpt = Option<string>("--output")
     uniProjOutputOpt.Description <- "Output directory for projected ALPS profiles"
     let uniProjResourceOpt = Option<string>("--resource")
@@ -754,12 +770,14 @@ let main args =
     uniProjForceOpt.Description <- "Force re-extraction, bypassing cache"
     uniProjForceOpt.DefaultValueFactory <- (fun _ -> false)
     uniProjCmd.Options.Add(uniProjProjectOpt)
+    uniProjCmd.Options.Add(uniProjBaseUriOpt)
     uniProjCmd.Options.Add(uniProjOutputOpt)
     uniProjCmd.Options.Add(uniProjResourceOpt)
     uniProjCmd.Options.Add(uniProjForceOpt)
 
     uniProjCmd.SetAction(fun parseResult ->
         let project = parseResult.GetValue(uniProjProjectOpt)
+        let baseUri = parseResult.GetValue(uniProjBaseUriOpt)
 
         let outputDir =
             let v = parseResult.GetValue(uniProjOutputOpt)
@@ -772,7 +790,7 @@ let main args =
         let force = parseResult.GetValue(uniProjForceOpt)
 
         let result =
-            ProjectCommand.execute project outputDir resource force
+            ProjectCommand.execute project baseUri outputDir resource force
             |> Async.RunSynchronously
 
         match result with
@@ -788,8 +806,7 @@ let main args =
                 | Some fp ->
                     let kind = if artifact.IsGlobalOverride then "global" else "role"
                     Console.WriteLine($"Projected ({kind}): {fp}")
-                | None ->
-                    Console.WriteLine(artifact.Content)
+                | None -> Console.WriteLine(artifact.Content)
         | Error e ->
             Environment.ExitCode <- 1
             Console.Error.WriteLine(StatechartError.formatError e))

--- a/test/Frank.Cli.Core.Tests/Unified/ProjectionIntegrationTests.fs
+++ b/test/Frank.Cli.Core.Tests/Unified/ProjectionIntegrationTests.fs
@@ -240,7 +240,10 @@ let projectionIntegrationTests =
                     Expect.isGreaterThan xTurnMoves.Length 0 "Should have makeMove transitions from XTurn"
 
                     for t in xTurnMoves do
-                        Expect.equal t.Constraint (RestrictedTo [ "PlayerX" ]) $"XTurn transition %s{t.Event} should be restricted to PlayerX"
+                        Expect.equal
+                            t.Constraint
+                            (RestrictedTo [ "PlayerX" ])
+                            $"XTurn transition %s{t.Event} should be restricted to PlayerX"
 
                 testCase "OTurn makeMove transitions are restricted to PlayerO"
                 <| fun _ ->
@@ -254,7 +257,10 @@ let projectionIntegrationTests =
                     Expect.isGreaterThan oTurnMoves.Length 0 "Should have makeMove transitions from OTurn"
 
                     for t in oTurnMoves do
-                        Expect.equal t.Constraint (RestrictedTo [ "PlayerO" ]) $"OTurn transition %s{t.Event} should be restricted to PlayerO"
+                        Expect.equal
+                            t.Constraint
+                            (RestrictedTo [ "PlayerO" ])
+                            $"OTurn transition %s{t.Event} should be restricted to PlayerO"
 
                 testCase "getGame transitions from states are unrestricted"
                 <| fun _ ->
@@ -262,8 +268,7 @@ let projectionIntegrationTests =
                     let transitions = extract doc
 
                     let getGameTransitions =
-                        transitions
-                        |> List.filter (fun t -> t.Event.StartsWith("getGame"))
+                        transitions |> List.filter (fun t -> t.Event.StartsWith("getGame"))
 
                     Expect.isGreaterThan getGameTransitions.Length 0 "Should have getGame transitions"
 
@@ -279,13 +284,15 @@ let projectionIntegrationTests =
                     let projected = projectForRole "PlayerX" statechart
 
                     let makeMoves =
-                        projected.Transitions
-                        |> List.filter (fun t -> t.Event.StartsWith("makeMove"))
+                        projected.Transitions |> List.filter (fun t -> t.Event.StartsWith("makeMove"))
 
                     Expect.isGreaterThan makeMoves.Length 0 "PlayerX should have makeMove transitions"
 
                     for t in makeMoves do
-                        Expect.equal t.Source "XTurn" $"PlayerX makeMove transition should be from XTurn, got %s{t.Source}"
+                        Expect.equal
+                            t.Source
+                            "XTurn"
+                            $"PlayerX makeMove transition should be from XTurn, got %s{t.Source}"
 
                 testCase "PlayerO projection includes only OTurn makeMove transitions"
                 <| fun _ ->
@@ -294,13 +301,15 @@ let projectionIntegrationTests =
                     let projected = projectForRole "PlayerO" statechart
 
                     let makeMoves =
-                        projected.Transitions
-                        |> List.filter (fun t -> t.Event.StartsWith("makeMove"))
+                        projected.Transitions |> List.filter (fun t -> t.Event.StartsWith("makeMove"))
 
                     Expect.isGreaterThan makeMoves.Length 0 "PlayerO should have makeMove transitions"
 
                     for t in makeMoves do
-                        Expect.equal t.Source "OTurn" $"PlayerO makeMove transition should be from OTurn, got %s{t.Source}"
+                        Expect.equal
+                            t.Source
+                            "OTurn"
+                            $"PlayerO makeMove transition should be from OTurn, got %s{t.Source}"
 
                 testCase "Spectator projection has no makeMove transitions"
                 <| fun _ ->
@@ -309,8 +318,7 @@ let projectionIntegrationTests =
                     let projected = projectForRole "Spectator" statechart
 
                     let makeMoves =
-                        projected.Transitions
-                        |> List.filter (fun t -> t.Event.StartsWith("makeMove"))
+                        projected.Transitions |> List.filter (fun t -> t.Event.StartsWith("makeMove"))
 
                     Expect.isEmpty makeMoves "Spectator should have no makeMove transitions"
 
@@ -323,8 +331,7 @@ let projectionIntegrationTests =
                         let projected = projectForRole role statechart
 
                         let getGames =
-                            projected.Transitions
-                            |> List.filter (fun t -> t.Event.StartsWith("getGame"))
+                            projected.Transitions |> List.filter (fun t -> t.Event.StartsWith("getGame"))
 
                         Expect.isGreaterThan getGames.Length 0 $"%s{role} should retain getGame transitions" ]
 
@@ -409,21 +416,15 @@ let projectionIntegrationTests =
                                 IsSafe = true } ]
                           DerivedFields = ResourceModel.emptyDerivedFields }
 
-                    let result = projectResource resource ""
+                    let result = projectResource resource "http://example.org"
 
                     Expect.equal result.RoleProfiles.Count 3 "Should produce 3 role profiles"
 
-                    Expect.isTrue
-                        (result.RoleProfiles.ContainsKey "games-playerx")
-                        "Should have PlayerX profile"
+                    Expect.isTrue (result.RoleProfiles.ContainsKey "games-playerx") "Should have PlayerX profile"
 
-                    Expect.isTrue
-                        (result.RoleProfiles.ContainsKey "games-playero")
-                        "Should have PlayerO profile"
+                    Expect.isTrue (result.RoleProfiles.ContainsKey "games-playero") "Should have PlayerO profile"
 
-                    Expect.isTrue
-                        (result.RoleProfiles.ContainsKey "games-spectator")
-                        "Should have Spectator profile"
+                    Expect.isTrue (result.RoleProfiles.ContainsKey "games-spectator") "Should have Spectator profile"
 
                 testCase "PlayerX profile is valid ALPS JSON with descriptors"
                 <| fun _ ->
@@ -454,7 +455,7 @@ let projectionIntegrationTests =
                                 IsSafe = false } ]
                           DerivedFields = ResourceModel.emptyDerivedFields }
 
-                    let result = projectResource resource ""
+                    let result = projectResource resource "http://example.org"
                     let json = result.RoleProfiles.["games-playerx"]
                     use jsonDoc = JsonDocument.Parse(json)
                     let alps = jsonDoc.RootElement.GetProperty("alps")
@@ -476,7 +477,8 @@ let projectionIntegrationTests =
                           Roles =
                             [ { Name = "PlayerX"; Description = None }
                               { Name = "PlayerO"; Description = None }
-                              { Name = "Spectator"; Description = None } ]
+                              { Name = "Spectator"
+                                Description = None } ]
                           Transitions =
                             [ { Event = "MakeMove"
                                 Source = "XTurn"
@@ -515,7 +517,7 @@ let projectionIntegrationTests =
                           HttpCapabilities = caps
                           DerivedFields = ResourceModel.emptyDerivedFields }
 
-                    let result = projectResource resource ""
+                    let result = projectResource resource "http://example.org"
 
                     // Spectator has no transitions, so no unsafe capabilities survive
                     let spectatorJson = result.RoleProfiles.["games-spectator"]
@@ -557,7 +559,7 @@ let projectionIntegrationTests =
                           HttpCapabilities = []
                           DerivedFields = ResourceModel.emptyDerivedFields }
 
-                    let result = projectResource resource ""
+                    let result = projectResource resource "http://example.org"
                     Expect.isEmpty result.Orphans "Should have no orphaned transitions"
                     Expect.isEmpty result.Errors "Should have no errors"
 
@@ -578,7 +580,7 @@ let projectionIntegrationTests =
                                 IsSafe = true } ]
                           DerivedFields = ResourceModel.emptyDerivedFields }
 
-                    let result = projectResource resource ""
+                    let result = projectResource resource "http://example.org"
                     Expect.isSome result.UpdatedGlobalProfile "Should regenerate global profile"
 
                 testCase "resource without roles produces empty projection result"
@@ -600,7 +602,7 @@ let projectionIntegrationTests =
                           HttpCapabilities = []
                           DerivedFields = ResourceModel.emptyDerivedFields }
 
-                    let result = projectResource resource ""
+                    let result = projectResource resource "http://example.org"
                     Expect.isEmpty result.RoleProfiles "Should have no role profiles"
                     Expect.isNone result.UpdatedGlobalProfile "Should not regenerate global"
 
@@ -633,7 +635,8 @@ let projectionIntegrationTests =
                                 IsSafe = true } ]
                           DerivedFields = ResourceModel.emptyDerivedFields }
 
-                    let batchResult, results = projectAllResources [ resource1; plainResource ] ""
+                    let batchResult, results =
+                        projectAllResources [ resource1; plainResource ] "http://example.org"
 
                     Expect.equal batchResult.RoleAlpsProfiles.Count 3 "Should have 3 role profiles from games"
                     Expect.isTrue (batchResult.ProjectedSlugs.Contains "games") "games should be projected"


### PR DESCRIPTION
Closes #185

## Summary

- Add `--base-uri` option to `frank project` command (the original issue)
- Add `--base-uri` option to `frank generate` command (same bug — hardcoded `""`)
- Fix trailing-slash default: `http://example.org` not `http://example.org/` to avoid double-slash in generated ALPS URIs (`http://example.org//games`)
- Fix affordance map `profileUrl` interpolation to include `/` separator
- Update projection integration tests to use `"http://example.org"` instead of `""`
- Improve `--base-uri` description across all three commands

All three unified commands (`extract`, `generate`, `project`) now share a consistent default of `http://example.org`.

## Expert review findings addressed

| Finding | Status |
|---------|--------|
| [MILLER-CRITICAL] Trailing slash → double-slash | Fixed: default is now `http://example.org` (no trailing slash) |
| [MILLER-CRITICAL] Inconsistent defaults across commands | Fixed: all three unified commands use `http://example.org` |
| [MILLER-IMPORTANT] Tests pass `""` as baseUri | Fixed: tests now use `"http://example.org"` |
| [SYME-IMPORTANT] `GenerateArtifactsCommand` hardcodes `""` | Fixed: `--base-uri` plumbed through |
| [7SHARP9-MINOR] Declaration vs registration order | Fixed: aligned in project command |

## Test plan

- [x] `dotnet build Frank.sln` — 0 errors
- [x] `dotnet test Frank.sln --filter "FullyQualifiedName!~Sample"` — all pass
- [x] `dotnet test test/Frank.Tests/` — 89 pass
- [x] `dotnet fantomas --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)