### PR TITLE
refactor: extract tryFcs helper to replace bare with _ -> catches

### DIFF
--- a/src/Frank.Cli.Core/Analysis/ProjectLoader.fs
+++ b/src/Frank.Cli.Core/Analysis/ProjectLoader.fs
@@ -8,12 +8,12 @@ open System.Text.Json
 open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Syntax
 open FSharp.Compiler.Text
+open Frank.Cli.Core.Shared
 
-type LoadedProject = {
-    ProjectPath: string
-    ParsedFiles: (string * ParsedInput) list
-    CheckResults: FSharpCheckProjectResults
-}
+type LoadedProject =
+    { ProjectPath: string
+      ParsedFiles: (string * ParsedInput) list
+      CheckResults: FSharpCheckProjectResults }
 
 module ProjectLoader =
 
@@ -25,10 +25,17 @@ module ProjectLoader =
     let private parseSourceFile (checker: FSharpChecker) (sourceFile: string) =
         async {
             let sourceText = SourceText.ofString (File.ReadAllText sourceFile)
-            let parsingOptions = { FSharpParsingOptions.Default with SourceFiles = [| sourceFile |] }
+
+            let parsingOptions =
+                { FSharpParsingOptions.Default with
+                    SourceFiles = [| sourceFile |] }
+
             let! parseResult = checker.ParseFile(sourceFile, sourceText, parsingOptions)
-            if parseResult.ParseHadErrors then return None
-            else return Some (sourceFile, parseResult.ParseTree)
+
+            if parseResult.ParseHadErrors then
+                return None
+            else
+                return Some(sourceFile, parseResult.ParseTree)
         }
 
     /// Detect the first target framework for multi-targeted projects.
@@ -45,43 +52,51 @@ module ProjectLoader =
         proc.StandardError.ReadToEnd() |> ignore
         proc.WaitForExit()
 
-        if proc.ExitCode <> 0 then None
+        if proc.ExitCode <> 0 then
+            None
         else
-        try
-            let doc = JsonDocument.Parse(stdout)
-            let props = doc.RootElement.GetProperty("Properties")
+            tryFcs None (fun () ->
+                let doc = JsonDocument.Parse(stdout)
+                let props = doc.RootElement.GetProperty("Properties")
 
-            match props.TryGetProperty("TargetFrameworks") with
-            | true, v ->
-                let tfms = v.GetString()
-                if not (String.IsNullOrWhiteSpace tfms) then
-                    let parts = tfms.Split(';', StringSplitOptions.RemoveEmptyEntries)
-                    if parts.Length > 0 then Some parts.[parts.Length - 1]
-                    else None
-                else
-                    match props.TryGetProperty("TargetFramework") with
-                    | true, v2 ->
-                        let tfm = v2.GetString()
-                        if String.IsNullOrWhiteSpace tfm then None else Some tfm
-                    | _ -> None
-            | _ ->
-                match props.TryGetProperty("TargetFramework") with
+                match props.TryGetProperty("TargetFrameworks") with
                 | true, v ->
-                    let tfm = v.GetString()
-                    if String.IsNullOrWhiteSpace tfm then None else Some tfm
-                | _ -> None
-        with _ -> None
+                    let tfms = v.GetString()
+
+                    if not (String.IsNullOrWhiteSpace tfms) then
+                        let parts = tfms.Split(';', StringSplitOptions.RemoveEmptyEntries)
+
+                        if parts.Length > 0 then
+                            Some parts.[parts.Length - 1]
+                        else
+                            None
+                    else
+                        match props.TryGetProperty("TargetFramework") with
+                        | true, v2 ->
+                            let tfm = v2.GetString()
+                            if String.IsNullOrWhiteSpace tfm then None else Some tfm
+                        | _ -> None
+                | _ ->
+                    match props.TryGetProperty("TargetFramework") with
+                    | true, v ->
+                        let tfm = v.GetString()
+                        if String.IsNullOrWhiteSpace tfm then None else Some tfm
+                    | _ -> None)
 
     /// Run dotnet msbuild with structured JSON output to resolve project options.
-    let private resolveProjectOptions (fsprojPath: string) : Result<string list * string list * string list * string list, string> =
+    let private resolveProjectOptions
+        (fsprojPath: string)
+        : Result<string list * string list * string list * string list, string> =
         let tfmArg =
             match detectTargetFramework fsprojPath with
             | Some tfm -> $" /p:TargetFramework={tfm}"
             | None -> ""
 
         let psi = ProcessStartInfo("dotnet")
+
         psi.Arguments <-
             $"msbuild \"{fsprojPath}\" /t:ResolveAssemblyReferences /p:DesignTimeBuild=true{tfmArg} -getItem:Compile -getItem:ReferencePath -getProperty:DefineConstants -getProperty:OtherFlags"
+
         psi.RedirectStandardOutput <- true
         psi.RedirectStandardError <- true
         psi.UseShellExecute <- false
@@ -90,60 +105,68 @@ module ProjectLoader =
         use proc = Process.Start(psi)
 
         let stderrBuf = StringBuilder()
+
         proc.ErrorDataReceived.Add(fun args ->
-            if not (isNull args.Data) then stderrBuf.AppendLine(args.Data) |> ignore)
+            if not (isNull args.Data) then
+                stderrBuf.AppendLine(args.Data) |> ignore)
+
         proc.BeginErrorReadLine()
 
         let stdout = proc.StandardOutput.ReadToEnd()
         let exited = proc.WaitForExit(120_000)
+
         if not exited then
             proc.Kill()
             Error "dotnet msbuild timed out after 120 seconds. Ensure the project restores successfully: dotnet restore"
         else
 
-        let stderr = stderrBuf.ToString()
+            let stderr = stderrBuf.ToString()
 
-        if proc.ExitCode <> 0 then
-            Error $"dotnet msbuild failed (exit code {proc.ExitCode}):\n{stderr}"
-        else
-
-        try
-            use doc = JsonDocument.Parse(stdout)
-            let root = doc.RootElement
-
-            let props = root.GetProperty("Properties")
-            let items = root.GetProperty("Items")
-
-            let defines =
-                match props.TryGetProperty("DefineConstants") with
-                | true, v ->
-                    v.GetString().Split([| ';' |], StringSplitOptions.RemoveEmptyEntries)
-                    |> Array.toList
-                | _ -> []
-
-            let otherFlags =
-                match props.TryGetProperty("OtherFlags") with
-                | true, v ->
-                    let s = v.GetString()
-                    if String.IsNullOrWhiteSpace s then []
-                    else s.Split([| ' '; '\t' |], StringSplitOptions.RemoveEmptyEntries) |> Array.toList
-                | _ -> []
-
-            let sourceFiles =
-                [ for item in items.GetProperty("Compile").EnumerateArray() ->
-                      item.GetProperty("FullPath").GetString() ]
-
-            let references =
-                [ for item in items.GetProperty("ReferencePath").EnumerateArray() ->
-                      item.GetProperty("Identity").GetString() ]
-
-            if references.IsEmpty then
-                Error $"No assembly references resolved for: {fsprojPath}\nThis usually means the project needs restoring. Run: dotnet restore \"{fsprojPath}\""
+            if proc.ExitCode <> 0 then
+                Error $"dotnet msbuild failed (exit code {proc.ExitCode}):\n{stderr}"
             else
-                Ok (sourceFiles, references, defines, otherFlags)
-        with ex ->
-            let preview = if stdout.Length > 500 then stdout.[..499] else stdout
-            Error $"Failed to parse MSBuild output: {ex.Message}\nOutput: {preview}"
+
+                try
+                    use doc = JsonDocument.Parse(stdout)
+                    let root = doc.RootElement
+
+                    let props = root.GetProperty("Properties")
+                    let items = root.GetProperty("Items")
+
+                    let defines =
+                        match props.TryGetProperty("DefineConstants") with
+                        | true, v ->
+                            v.GetString().Split([| ';' |], StringSplitOptions.RemoveEmptyEntries)
+                            |> Array.toList
+                        | _ -> []
+
+                    let otherFlags =
+                        match props.TryGetProperty("OtherFlags") with
+                        | true, v ->
+                            let s = v.GetString()
+
+                            if String.IsNullOrWhiteSpace s then
+                                []
+                            else
+                                s.Split([| ' '; '\t' |], StringSplitOptions.RemoveEmptyEntries) |> Array.toList
+                        | _ -> []
+
+                    let sourceFiles =
+                        [ for item in items.GetProperty("Compile").EnumerateArray() ->
+                              item.GetProperty("FullPath").GetString() ]
+
+                    let references =
+                        [ for item in items.GetProperty("ReferencePath").EnumerateArray() ->
+                              item.GetProperty("Identity").GetString() ]
+
+                    if references.IsEmpty then
+                        Error
+                            $"No assembly references resolved for: {fsprojPath}\nThis usually means the project needs restoring. Run: dotnet restore \"{fsprojPath}\""
+                    else
+                        Ok(sourceFiles, references, defines, otherFlags)
+                with ex ->
+                    let preview = if stdout.Length > 500 then stdout.[..499] else stdout
+                    Error $"Failed to parse MSBuild output: {ex.Message}\nOutput: {preview}"
 
     /// Build FSharpProjectOptions from resolved source files, references, and defines.
     let private buildFcsOptions
@@ -180,36 +203,41 @@ module ProjectLoader =
 
                     match resolveProjectOptions fullPath with
                     | Error e -> return Error e
-                    | Ok (sourceFiles, references, defines, otherFlags) ->
+                    | Ok(sourceFiles, references, defines, otherFlags) ->
 
-                    if sourceFiles.IsEmpty then
-                        return Error $"No source files found in project: {fullPath}"
-                    else
+                        if sourceFiles.IsEmpty then
+                            return Error $"No source files found in project: {fullPath}"
+                        else
 
-                    let options = buildFcsOptions checker fullPath sourceFiles references defines otherFlags
+                            let options =
+                                buildFcsOptions checker fullPath sourceFiles references defines otherFlags
 
-                    let! projectResults = checker.ParseAndCheckProject(options)
+                            let! projectResults = checker.ParseAndCheckProject(options)
 
-                    if projectResults.HasCriticalErrors then
-                        let errors =
-                            projectResults.Diagnostics
-                            |> Array.filter (fun d -> d.Severity = FSharp.Compiler.Diagnostics.FSharpDiagnosticSeverity.Error)
-                            |> Array.map (fun d -> $"  {d.FileName}({d.StartLine},{d.StartColumn}): {d.Message}")
-                            |> String.concat "\n"
-                        return Error $"Type-check errors:\n{errors}"
-                    else
-                        let! parsedFiles =
-                            sourceFiles
-                            |> List.toArray
-                            |> Array.map (parseSourceFile checker)
-                            |> Async.Sequential
-                        let parsedFiles = parsedFiles |> Array.choose id |> Array.toList
+                            if projectResults.HasCriticalErrors then
+                                let errors =
+                                    projectResults.Diagnostics
+                                    |> Array.filter (fun d ->
+                                        d.Severity = FSharp.Compiler.Diagnostics.FSharpDiagnosticSeverity.Error)
+                                    |> Array.map (fun d ->
+                                        $"  {d.FileName}({d.StartLine},{d.StartColumn}): {d.Message}")
+                                    |> String.concat "\n"
 
-                        return Ok {
-                            ProjectPath = fullPath
-                            ParsedFiles = parsedFiles
-                            CheckResults = projectResults
-                        }
+                                return Error $"Type-check errors:\n{errors}"
+                            else
+                                let! parsedFiles =
+                                    sourceFiles
+                                    |> List.toArray
+                                    |> Array.map (parseSourceFile checker)
+                                    |> Async.Sequential
+
+                                let parsedFiles = parsedFiles |> Array.choose id |> Array.toList
+
+                                return
+                                    Ok
+                                        { ProjectPath = fullPath
+                                          ParsedFiles = parsedFiles
+                                          CheckResults = projectResults }
             with ex ->
                 return Error $"Failed to load project: {ex.Message}"
         }

--- a/src/Frank.Cli.Core/Analysis/TypeAnalyzer.fs
+++ b/src/Frank.Cli.Core/Analysis/TypeAnalyzer.fs
@@ -4,14 +4,12 @@ open FSharp.Compiler.CodeAnalysis
 open FSharp.Compiler.Symbols
 open FSharp.Compiler.Text
 open Frank.Resources.Model
+open Frank.Cli.Core.Shared
 
 module TypeAnalyzer =
 
     let private tryGetFullName (td: FSharpEntity) =
-        try
-            Some td.FullName
-        with _ ->
-            None
+        tryFcs None (fun () -> Some td.FullName)
 
     let rec mapFieldType (fsharpType: FSharpType) : FieldKind =
         if fsharpType.HasTypeDefinition then
@@ -60,11 +58,7 @@ module TypeAnalyzer =
                             if elem.HasTypeDefinition then
                                 let dn = elem.TypeDefinition.DisplayName
 
-                                let fn =
-                                    try
-                                        elem.TypeDefinition.FullName
-                                    with _ ->
-                                        ""
+                                let fn = tryFcs "" (fun () -> elem.TypeDefinition.FullName)
 
                                 fn = "System.Byte" || dn = "Byte" || dn = "byte"
                             else
@@ -84,11 +78,7 @@ module TypeAnalyzer =
                             if elem.HasTypeDefinition then
                                 let dn = elem.TypeDefinition.DisplayName
 
-                                let fn =
-                                    try
-                                        elem.TypeDefinition.FullName
-                                    with _ ->
-                                        ""
+                                let fn = tryFcs "" (fun () -> elem.TypeDefinition.FullName)
 
                                 fn = "System.Byte" || dn = "Byte" || dn = "byte"
                             else
@@ -108,14 +98,10 @@ module TypeAnalyzer =
             Reference(fsharpType.Format(FSharpDisplayContext.Empty))
 
     let private extractConstraintAttributes (field: FSharpField) : ConstraintAttribute list =
-        try
+        tryFcs [] (fun () ->
             Seq.append field.FieldAttributes field.PropertyAttributes
             |> Seq.choose (fun attr ->
-                let attrName =
-                    try
-                        attr.AttributeType.DisplayName
-                    with _ ->
-                        ""
+                let attrName = tryFcs "" (fun () -> attr.AttributeType.DisplayName)
 
                 match attrName with
                 | "PatternAttribute"
@@ -144,9 +130,7 @@ module TypeAnalyzer =
                     | Some(_, (:? int as n)) -> Some(MaxLengthAttr n)
                     | _ -> None
                 | _ -> None)
-            |> Seq.toList
-        with _ ->
-            []
+            |> Seq.toList)
 
     let private makeField (name: string) (fsharpType: FSharpType) : AnalyzedField =
         let kind = mapFieldType fsharpType
@@ -175,22 +159,17 @@ module TypeAnalyzer =
             Constraints = constraints }
 
     let private entityToSourceLocation (entity: FSharpEntity) : SourceLocation option =
-        try
+        tryFcs None (fun () ->
             let r = entity.DeclarationLocation
 
             Some
                 { File = r.FileName
                   Line = r.StartLine
-                  Column = r.StartColumn }
-        with _ ->
-            None
+                  Column = r.StartColumn })
 
     let rec collectEntities (entity: FSharpEntity) : AnalyzedType list =
         let nested =
-            try
-                entity.NestedEntities |> Seq.collect collectEntities |> Seq.toList
-            with _ ->
-                []
+            tryFcs [] (fun () -> entity.NestedEntities |> Seq.collect collectEntities |> Seq.toList)
 
         let entityFullName = tryGetFullName entity |> Option.defaultValue entity.DisplayName
 

--- a/src/Frank.Cli.Core/Commands/StatechartParseCommand.fs
+++ b/src/Frank.Cli.Core/Commands/StatechartParseCommand.fs
@@ -3,6 +3,7 @@ module Frank.Cli.Core.Commands.StatechartParseCommand
 open System.IO
 open Frank.Statecharts.Ast
 open Frank.Statecharts.Validation
+open Frank.Cli.Core.Shared
 open Frank.Cli.Core.Statechart.StatechartError
 
 type ParseCommandResult =
@@ -14,30 +15,25 @@ let private parseFormatString (s: string) : Result<FormatTag, StatechartError> =
     match s.ToLowerInvariant() with
     | "wsd" -> Ok Wsd
     | "alps" -> Ok Alps
-    | "alps-xml" | "alpsxml" -> Ok AlpsXml
+    | "alps-xml"
+    | "alpsxml" -> Ok AlpsXml
     | "scxml" -> Ok Scxml
     | "smcat" -> Ok Smcat
     | "xstate" -> Ok XState
-    | other -> Error (UnknownFormat other)
+    | other -> Error(UnknownFormat other)
 
 let private parseContent (format: FormatTag) (content: string) : ParseResult =
     match format with
-    | Wsd ->
-        Frank.Statecharts.Wsd.Parser.parseWsd content
-    | Alps ->
-        Frank.Statecharts.Alps.JsonParser.parseAlpsJson content
-    | AlpsXml ->
-        Frank.Statecharts.Alps.XmlParser.parseAlpsXml content
-    | Scxml ->
-        Frank.Statecharts.Scxml.Parser.parseString content
-    | Smcat ->
-        Frank.Statecharts.Smcat.Parser.parseSmcat content
-    | XState ->
-        Frank.Statecharts.XState.Deserializer.deserialize content
+    | Wsd -> Frank.Statecharts.Wsd.Parser.parseWsd content
+    | Alps -> Frank.Statecharts.Alps.JsonParser.parseAlpsJson content
+    | AlpsXml -> Frank.Statecharts.Alps.XmlParser.parseAlpsXml content
+    | Scxml -> Frank.Statecharts.Scxml.Parser.parseString content
+    | Smcat -> Frank.Statecharts.Smcat.Parser.parseSmcat content
+    | XState -> Frank.Statecharts.XState.Deserializer.deserialize content
 
 let execute (specFile: string) (explicitFormat: string option) : Result<ParseCommandResult, StatechartError> =
     if not (File.Exists specFile) then
-        Error (FileNotFound specFile)
+        Error(FileNotFound specFile)
     else
         let content = File.ReadAllText(specFile)
 
@@ -48,25 +44,34 @@ let execute (specFile: string) (explicitFormat: string option) : Result<ParseCom
                 match Frank.Cli.Core.Statechart.FormatDetector.detect specFile with
                 | Frank.Cli.Core.Statechart.FormatDetector.Detected format -> Ok format
                 | Frank.Cli.Core.Statechart.FormatDetector.Ambiguous candidates ->
-                    // Ambiguous extension: try each candidate, pick whichever parses without errors
+                    // Ambiguous extension: try each candidate, pick whichever parses without errors.
+                    // Failures are expected here — non-matching formats throw, and tryFcs
+                    // filters them out so only successfully-parsed formats survive.
                     let tryParse fmt =
-                        try
+                        tryFcs None (fun () ->
                             let r = parseContent fmt content
-                            if r.Errors.IsEmpty then Some fmt else None
-                        with _ -> None
+                            if r.Errors.IsEmpty then Some fmt else None)
+
                     let successes = candidates |> List.choose tryParse
+
                     match successes with
                     | [ single ] -> Ok single
                     | [] ->
-                        let names = candidates |> List.map (fun t -> Frank.Cli.Core.Statechart.FormatDetector.FormatTag.toString t)
-                        Error (AmbiguousParseFailed(specFile, names))
-                    | _ ->
-                        Error (AmbiguousFileExtension(specFile, candidates))
+                        let names =
+                            candidates
+                            |> List.map (fun t -> Frank.Cli.Core.Statechart.FormatDetector.FormatTag.toString t)
+
+                        Error(AmbiguousParseFailed(specFile, names))
+                    | _ -> Error(AmbiguousFileExtension(specFile, candidates))
                 | Frank.Cli.Core.Statechart.FormatDetector.Unsupported ext ->
-                    Error (UnsupportedFileExtension(ext, specFile))
+                    Error(UnsupportedFileExtension(ext, specFile))
 
         match resolveFormat () with
         | Error e -> Error e
         | Ok format ->
             let result = parseContent format content
-            Ok { ParseResult = result; Format = format; HasErrors = not result.Errors.IsEmpty }
+
+            Ok
+                { ParseResult = result
+                  Format = format
+                  HasErrors = not result.Errors.IsEmpty }

--- a/src/Frank.Cli.Core/Frank.Cli.Core.fsproj
+++ b/src/Frank.Cli.Core/Frank.Cli.Core.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="Rdf/FSharpRdf.fs" />
     <Compile Include="Rdf/Vocabularies.fs" />
     <!-- Shared utilities -->
+    <Compile Include="Shared/FcsHelpers.fs" />
     <Compile Include="Shared/SchemaAlignment.fs" />
     <Compile Include="Analysis/AstAnalyzer.fs" />
     <Compile Include="Analysis/TypeAnalyzer.fs" />

--- a/src/Frank.Cli.Core/Shared/FcsHelpers.fs
+++ b/src/Frank.Cli.Core/Shared/FcsHelpers.fs
@@ -1,0 +1,16 @@
+namespace Frank.Cli.Core.Shared
+
+open System.Diagnostics
+
+[<AutoOpen>]
+module FcsHelpers =
+
+    /// Safely invoke an FCS reflection operation, returning fallback on failure.
+    /// FCS APIs can throw when inspecting symbols from broken or incomplete assemblies;
+    /// failures are logged at Debug level for diagnostic visibility.
+    let tryFcs (fallback: 'T) (f: unit -> 'T) : 'T =
+        try
+            f ()
+        with ex ->
+            Debug.WriteLine($"FCS: {ex.Message}")
+            fallback

--- a/src/Frank.Cli.Core/State/DiffEngine.fs
+++ b/src/Frank.Cli.Core/State/DiffEngine.fs
@@ -1,6 +1,7 @@
 namespace Frank.Cli.Core.State
 
 open System
+open System.Diagnostics
 open System.Text
 open VDS.RDF
 
@@ -97,7 +98,8 @@ module DiffEngine =
             let subjectUri =
                 try
                     Uri(s)
-                with _ ->
+                with ex ->
+                    Debug.WriteLine($"Uri parse: {ex.Message}")
                     Uri("urn:blank:" + s)
 
             if hasAdded && hasRemoved then

--- a/src/Frank.Cli.Core/Unified/UnifiedExtractor.fs
+++ b/src/Frank.Cli.Core/Unified/UnifiedExtractor.fs
@@ -7,6 +7,7 @@ open FSharp.Compiler.Symbols
 open FSharp.Compiler.CodeAnalysis
 open Frank.Statecharts
 open Frank.Resources.Model
+open Frank.Cli.Core.Shared
 open Frank.Cli.Core.Analysis
 open Frank.Cli.Core.Statechart
 open Frank.Cli.Core.Statechart.StatechartError
@@ -371,21 +372,16 @@ let private emptyTypedResult =
 // Type analysis helpers (duplicated from TypeAnalyzer since they are private)
 
 let private tryGetFullName (td: FSharpEntity) =
-    try
-        Some td.FullName
-    with _ ->
-        None
+    tryFcs None (fun () -> Some td.FullName)
 
 let private entityToSourceLocation (entity: FSharpEntity) : Frank.Resources.Model.SourceLocation option =
-    try
+    tryFcs None (fun () ->
         let r = entity.DeclarationLocation
 
         Some
             { File = r.FileName
               Line = r.StartLine
-              Column = r.StartColumn }
-    with _ ->
-        None
+              Column = r.StartColumn })
 
 let private makeField (name: string) (fsharpType: FSharpType) : AnalyzedField =
     let kind = TypeAnalyzer.mapFieldType fsharpType
@@ -407,14 +403,10 @@ let private makeField (name: string) (fsharpType: FSharpType) : AnalyzedField =
       Constraints = [] }
 
 let private extractConstraintAttributes (field: FSharpField) : ConstraintAttribute list =
-    try
+    tryFcs [] (fun () ->
         Seq.append field.FieldAttributes field.PropertyAttributes
         |> Seq.choose (fun attr ->
-            let attrName =
-                try
-                    attr.AttributeType.DisplayName
-                with _ ->
-                    ""
+            let attrName = tryFcs "" (fun () -> attr.AttributeType.DisplayName)
 
             match attrName with
             | "PatternAttribute"
@@ -443,9 +435,7 @@ let private extractConstraintAttributes (field: FSharpField) : ConstraintAttribu
                 | Some(_, (:? int as n)) -> Some(MaxLengthAttr n)
                 | _ -> None
             | _ -> None)
-        |> Seq.toList
-    with _ ->
-        []
+        |> Seq.toList)
 
 let private makeFieldFromFSharpField (field: FSharpField) : AnalyzedField =
     let baseField = makeField field.Name field.FieldType


### PR DESCRIPTION
## Summary

- Add shared `FcsHelpers.tryFcs` in `Shared/FcsHelpers.fs` that wraps try/with, logs at Debug level via `Debug.WriteLine`, and returns a fallback value
- Replace 13 bare `with _ ->` catches across TypeAnalyzer.fs (7), UnifiedExtractor.fs (4), ProjectLoader.fs (1), StatechartParseCommand.fs (1)
- DiffEngine.fs kept as inline try/with to avoid eager fallback allocation (Uri construction on every iteration)
- Add documenting comment in StatechartParseCommand.fs explaining the try-all-parsers pattern

## Notes

Found 14 bare `with _ ->` catches (not 16 as estimated). ProjectLoader.fs has 1 bare catch, not 2 — the other two use `with ex ->` and already report structured errors. DiffEngine.fs was initially converted to `tryFcs` but reverted during `/simplify` review because the fallback `Uri("urn:blank:" + s)` was being eagerly allocated on every iteration.

No behavioral change. All 2176 tests pass.

## Test plan

- [x] `dotnet build Frank.sln` — Build succeeded
- [x] `dotnet test Frank.sln --filter "FullyQualifiedName!~Sample"` — 2176 passed, 0 failed
- [x] `dotnet fantomas --check` on changed files — all clean
- [x] `grep "with _ ->"` across Frank.Cli.Core — 0 matches remaining
- [x] `/simplify` — 3 parallel review agents, fixed DiffEngine eager fallback
- [x] `/expert-review` — @7sharp9 + Seemann, no critical findings

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)