### PR TITLE
feat: entry-point designation for JSON Home document

### DIFF
--- a/src/Frank.Discovery/JsonHomeDocument.fs
+++ b/src/Frank.Discovery/JsonHomeDocument.fs
@@ -30,6 +30,16 @@ type JsonHomeInput =
       DescribedByUrl: string option
       Resources: JsonHomeResource list }
 
+/// Result of projecting endpoints into a JSON Home document.
+/// Carries the input data plus a flag indicating whether fallback behavior was used.
+type JsonHomeProjectionResult =
+    {
+        /// The projected JSON Home input data.
+        Input: JsonHomeInput
+        /// True when no endpoints had EntryPointMetadata and the fallback (include all) was used.
+        UsedFallback: bool
+    }
+
 module JsonHomeDocument =
 
     let private writeOptionalArray (w: Utf8JsonWriter) (name: string) (types: string list option) =

--- a/src/Frank.Discovery/JsonHomeMiddleware.fs
+++ b/src/Frank.Discovery/JsonHomeMiddleware.fs
@@ -13,28 +13,47 @@ open Frank.Builder
 /// Receives EndpointDataSource via DI constructor injection. Lazily computes the
 /// JSON Home document on first request (after all endpoints are finalized) and
 /// caches the result forever.
-type JsonHomeMiddleware(next: RequestDelegate, dataSource: EndpointDataSource, serviceProvider: System.IServiceProvider, logger: ILogger<JsonHomeMiddleware>) =
+type JsonHomeMiddleware
+    (
+        next: RequestDelegate,
+        dataSource: EndpointDataSource,
+        serviceProvider: System.IServiceProvider,
+        logger: ILogger<JsonHomeMiddleware>
+    ) =
 
     static let jsonHomeMediaType = "application/json-home"
 
     // Lazy computation: thread-safe via Lazy<T> (ExecutionAndPublication mode).
     // Built on first request after all endpoints are finalized, cached forever.
-    let computed = lazy(
-        let metadata =
-            match serviceProvider.GetService(typeof<JsonHomeMetadata>) with
-            | :? JsonHomeMetadata as m -> Some m
-            | _ -> None
-        let assemblyName =
-            let asm = System.Reflection.Assembly.GetEntryAssembly()
-            if isNull asm then "Frank" else asm.GetName().Name
-        let input = JsonHomeProjection.project dataSource metadata assemblyName
-        let linkHeader =
-            input.DescribedByUrl
-            |> Option.map (fun url -> $"<{url}>; rel=\"describedby\"")
-        linkHeader, JsonHomeDocument.build input)
+    let computed =
+        lazy
+            (let metadata =
+                match serviceProvider.GetService(typeof<JsonHomeMetadata>) with
+                | :? JsonHomeMetadata as m -> Some m
+                | _ -> None
+
+             let assemblyName =
+                 let asm = System.Reflection.Assembly.GetEntryAssembly()
+                 if isNull asm then "Frank" else asm.GetName().Name
+
+             let result = JsonHomeProjection.project dataSource metadata assemblyName
+
+             if result.UsedFallback then
+                 logger.LogWarning(
+                     "No resources are designated as entry points via 'entryPoint'. "
+                     + "All non-internal resources will appear in the JSON Home document. "
+                     + "Use the 'entryPoint' CE operation on resources that should be discoverable."
+                 )
+
+             let linkHeader =
+                 result.Input.DescribedByUrl
+                 |> Option.map (fun url -> $"<{url}>; rel=\"describedby\"")
+
+             linkHeader, JsonHomeDocument.build result.Input)
 
     let isJsonHomeAccept (ctx: HttpContext) =
         let acceptHeaders = ctx.Request.GetTypedHeaders().Accept
+
         if isNull acceptHeaders || acceptHeaders.Count = 0 then
             false
         else
@@ -47,6 +66,7 @@ type JsonHomeMiddleware(next: RequestDelegate, dataSource: EndpointDataSource, s
     member _.Invoke(ctx: HttpContext) : Task =
         let isGet = HttpMethods.IsGet(ctx.Request.Method)
         let isHead = HttpMethods.IsHead(ctx.Request.Method)
+
         if not isGet && not isHead then
             next.Invoke(ctx)
         elif ctx.Request.Path.Value <> "/" then

--- a/src/Frank.Discovery/JsonHomeProjection.fs
+++ b/src/Frank.Discovery/JsonHomeProjection.fs
@@ -74,12 +74,21 @@ module JsonHomeProjection =
                 sprintf "%s#%s" cleanBase fragment
         | _ -> sprintf "urn:frank:%s%s" assemblyName routeTemplate
 
-    /// Project an EndpointDataSource into a JsonHomeInput.
+    /// Check whether any endpoint in a group carries EntryPointMetadata.
+    let private hasEntryPointMetadata (endpoints: RouteEndpoint list) =
+        endpoints
+        |> List.exists (fun ep ->
+            let marker = ep.Metadata.GetMetadata<EntryPointMetadata>()
+            not (isNull (box marker)) && marker.IsEntryPoint)
+
+    /// Project an EndpointDataSource into a JsonHomeProjectionResult.
+    /// When any endpoints carry EntryPointMetadata, only those routes appear.
+    /// Otherwise all non-internal endpoints appear (backward compat fallback).
     let project
         (dataSource: EndpointDataSource)
         (metadata: JsonHomeMetadata option)
         (assemblyName: string)
-        : JsonHomeInput =
+        : JsonHomeProjectionResult =
 
         let title =
             metadata |> Option.bind (fun m -> m.Title) |> Option.defaultValue assemblyName
@@ -103,7 +112,7 @@ module JsonHomeProjection =
                 | _ -> false)
             |> fun found -> if found then Some "/.well-known/frank-profiles" else None
 
-        let resources =
+        let groupedEndpoints =
             dataSource.Endpoints
             |> Seq.choose (fun ep ->
                 match ep with
@@ -118,6 +127,22 @@ module JsonHomeProjection =
             |> Seq.groupBy fst
             |> Seq.map (fun (routeTemplate, endpoints) ->
                 let allEndpoints = endpoints |> Seq.map snd |> Seq.toList
+                (routeTemplate, allEndpoints))
+            |> Seq.toList
+
+        // Determine entry-point filtering: if any group has EntryPointMetadata, filter.
+        let anyEntryPoints =
+            groupedEndpoints |> List.exists (fun (_, eps) -> hasEntryPointMetadata eps)
+
+        let filteredGroups =
+            if anyEntryPoints then
+                groupedEndpoints |> List.filter (fun (_, eps) -> hasEntryPointMetadata eps)
+            else
+                groupedEndpoints
+
+        let resources =
+            filteredGroups
+            |> List.map (fun (routeTemplate, allEndpoints) ->
                 let slug = routeTemplate.TrimStart('/').Split('/') |> Array.head
 
                 let routeVars =
@@ -165,8 +190,11 @@ module JsonHomeProjection =
                       AcceptPut = collectAcceptTypes "PUT"
                       AcceptPatch = collectAcceptTypes "PATCH"
                       DocsUrl = docsUrl } })
-            |> Seq.toList
 
-        { Title = title
-          DescribedByUrl = describedByUrl
-          Resources = resources }
+        let usedFallback = not anyEntryPoints && not (List.isEmpty groupedEndpoints)
+
+        { Input =
+            { Title = title
+              DescribedByUrl = describedByUrl
+              Resources = resources }
+          UsedFallback = usedFallback }

--- a/src/Frank/Builder.fs
+++ b/src/Frank/Builder.fs
@@ -98,6 +98,12 @@ module Builder =
               AlpsBaseUri = None
               AlpsDescriptors = None }
 
+    /// Marker metadata indicating a resource is an entry point for the JSON Home document.
+    /// When any endpoints carry this metadata, only those endpoints appear in the home document.
+    /// When no endpoints carry it, all non-internal endpoints appear (backward compat fallback).
+    /// Not a struct because EndpointMetadataCollection.GetMetadata<T> requires reference semantics.
+    type EntryPointMetadata = { IsEntryPoint: bool }
+
     type ResourceSpec =
         { Name: string option
           Handlers: (string * RequestDelegate) list
@@ -149,6 +155,12 @@ module Builder =
 
         [<CustomOperation("name")>]
         member __.Name(spec, name) = { spec with Name = Some name }
+
+        /// Marks this resource as a JSON Home entry point.
+        /// Only entry-point resources appear in the home document when any are designated.
+        [<CustomOperation("entryPoint")>]
+        member __.EntryPoint(spec) =
+            ResourceBuilder.AddMetadata(spec, fun b -> b.Metadata.Add({ IsEntryPoint = true }: EntryPointMetadata))
 
         static member AddMetadata(spec: ResourceSpec, convention: EndpointBuilder -> unit) : ResourceSpec =
             { spec with

--- a/test/Frank.Discovery.Tests/JsonHomeMiddlewareTests.fs
+++ b/test/Frank.Discovery.Tests/JsonHomeMiddlewareTests.fs
@@ -12,6 +12,7 @@ open Microsoft.AspNetCore.Routing.Patterns
 open Microsoft.AspNetCore.TestHost
 open Microsoft.Extensions.DependencyInjection
 open Microsoft.Extensions.Hosting
+open Microsoft.Extensions.Logging
 open Expecto
 open Frank.Builder
 open Frank.Discovery
@@ -47,6 +48,62 @@ let private withServer (f: HttpClient -> Task) =
 
             try
                 do! f client
+            finally
+                client.Dispose()
+        finally
+            (host :> System.IDisposable).Dispose()
+    }
+    :> Task
+
+/// Captures log messages for assertion in tests.
+type TestLoggerProvider() =
+    let messages = System.Collections.Generic.List<string>()
+
+    member _.Messages = messages |> Seq.toList
+
+    interface ILoggerProvider with
+        member _.CreateLogger(_categoryName: string) =
+            { new ILogger with
+                member _.Log<'TState>(logLevel, _eventId, state: 'TState, _ex, formatter) =
+                    if logLevel >= LogLevel.Warning then
+                        let msg = formatter.Invoke(state, _ex)
+                        messages.Add(msg)
+
+                member _.IsEnabled(_logLevel) = true
+                member _.BeginScope<'TState>(_state: 'TState) = null }
+
+        member _.Dispose() = ()
+
+let private withServerAndLogs (endpoints: Endpoint[]) (f: HttpClient -> TestLoggerProvider -> Task) =
+    task {
+        let dataSource = TestEndpointDataSource(endpoints)
+        let logProvider = new TestLoggerProvider()
+
+        let host =
+            Host.CreateDefaultBuilder([||])
+                .ConfigureWebHost(fun webBuilder ->
+                    webBuilder
+                        .UseTestServer()
+                        .ConfigureServices(fun services ->
+                            services.AddRouting() |> ignore
+                            services.AddSingleton<EndpointDataSource>(dataSource) |> ignore
+                            services.AddLogging(fun logging ->
+                                logging.AddProvider(logProvider) |> ignore) |> ignore)
+                        .Configure(fun app ->
+                            app.UseMiddleware<JsonHomeMiddleware>() |> ignore
+                            app.UseRouting() |> ignore
+                            app.UseEndpoints(fun endpoints ->
+                                endpoints.DataSources.Add(dataSource)) |> ignore)
+                    |> ignore)
+                .Build()
+
+        host.Start()
+
+        try
+            let client = host.GetTestClient()
+
+            try
+                do! f client logProvider
             finally
                 client.Dispose()
         finally
@@ -339,5 +396,68 @@ let metadataTests =
                     client.Dispose()
             finally
                 (host :> System.IDisposable).Dispose()
+        }
+    ]
+
+[<Tests>]
+let entryPointMiddlewareTests =
+    testList "JsonHomeMiddleware entry-point logging" [
+        testTask "logs warning when fallback-all behavior is used (no entry points marked)" {
+            let res = resource "/items" { get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("items"))) }
+
+            do! withServerAndLogs res.Endpoints (fun client logProvider -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp.StatusCode HttpStatusCode.OK "should serve home document"
+                let! (body: string) = resp.Content.ReadAsStringAsync()
+                Expect.isTrue (body.Contains("/items")) "should contain items resource in fallback"
+                let hasWarning =
+                    logProvider.Messages
+                    |> Seq.exists (fun msg -> msg.Contains("entry point") || msg.Contains("entryPoint"))
+                Expect.isTrue hasWarning "should log warning about missing entry-point designations"
+            })
+        }
+
+        testTask "does not log warning when entry points are explicitly marked" {
+            let entryRes =
+                resource "/games" {
+                    entryPoint
+                    get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("games")))
+                }
+
+            do! withServerAndLogs entryRes.Endpoints (fun client logProvider -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp.StatusCode HttpStatusCode.OK "should serve home document"
+                let hasWarning =
+                    logProvider.Messages
+                    |> Seq.exists (fun msg -> msg.Contains("entry point") || msg.Contains("entryPoint"))
+                Expect.isFalse hasWarning "should not log warning when entry points are designated"
+            })
+        }
+
+        testTask "entry-point resources appear in JSON Home via middleware; non-entry-point resources do not" {
+            let entryRes =
+                resource "/games" {
+                    entryPoint
+                    get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("games")))
+                }
+            let hiddenRes =
+                resource "/internal/metrics" {
+                    get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("metrics")))
+                }
+            let allEndpoints = Array.append entryRes.Endpoints hiddenRes.Endpoints
+
+            do! withServerAndLogs allEndpoints (fun client _logProvider -> task {
+                let req = new HttpRequestMessage(HttpMethod.Get, "/")
+                req.Headers.Accept.Add(MediaTypeWithQualityHeaderValue("application/json-home"))
+                let! (resp: HttpResponseMessage) = client.SendAsync(req)
+                Expect.equal resp.StatusCode HttpStatusCode.OK "should serve home document"
+                let! (body: string) = resp.Content.ReadAsStringAsync()
+                Expect.isTrue (body.Contains("/games")) "should contain entry-point resource"
+                Expect.isFalse (body.Contains("/internal/metrics")) "should not contain non-entry-point resource"
+            })
         }
     ]

--- a/test/Frank.Discovery.Tests/JsonHomeProjectionTests.fs
+++ b/test/Frank.Discovery.Tests/JsonHomeProjectionTests.fs
@@ -16,9 +16,9 @@ let tests =
             let res = resource "/health" { get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("ok"))) }
             let dataSource = TestEndpointDataSource(res.Endpoints)
             let result = JsonHomeProjection.project dataSource None "TestApp"
-            Expect.equal result.Title "TestApp" "should use assembly name"
-            Expect.equal result.Resources.Length 1 "should have one resource"
-            let r = result.Resources.[0]
+            Expect.equal result.Input.Title "TestApp" "should use assembly name"
+            Expect.equal result.Input.Resources.Length 1 "should have one resource"
+            let r = result.Input.Resources.[0]
             Expect.equal r.RouteTemplate "/health" "route template"
             Expect.isTrue (Map.isEmpty r.RouteVariables) "no route variables"
             Expect.equal r.RelationType "urn:frank:TestApp/health" "URN fallback relation"
@@ -27,7 +27,7 @@ let tests =
             let res = resource "/games/{gameId}" { get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("ok"))) }
             let dataSource = TestEndpointDataSource(res.Endpoints)
             let result = JsonHomeProjection.project dataSource None "TestApp"
-            let r = result.Resources.[0]
+            let r = result.Input.Resources.[0]
             Expect.equal r.RouteVariables.Count 1 "should have one variable"
             Expect.isTrue (r.RouteVariables.ContainsKey("gameId")) "should have gameId"
             Expect.equal r.RouteVariables.["gameId"] "urn:frank:TestApp/param/gameId" "URN fallback var"
@@ -41,10 +41,10 @@ let tests =
                   AlpsBaseUri = Some "http://example.com/alps/games"
                   AlpsDescriptors = Some (Map.ofList [ "games", Map.ofList [ "gameId", "http://example.com/alps/games#gameId" ] ]) }
             let result = JsonHomeProjection.project dataSource (Some metadata) "TestApp"
-            let r = result.Resources.[0]
+            let r = result.Input.Resources.[0]
             Expect.equal r.RelationType "http://example.com/alps/games#games~gameId" "ALPS-derived relation"
             Expect.equal r.RouteVariables.["gameId"] "http://example.com/alps/games#gameId" "ALPS-enriched hrefVar"
-            Expect.equal result.Title "My Game API" "should use metadata title"
+            Expect.equal result.Input.Title "My Game API" "should use metadata title"
 
         testCase "collects HTTP methods into hints.allow" <| fun _ ->
             let res = resource "/items" {
@@ -53,7 +53,7 @@ let tests =
             }
             let dataSource = TestEndpointDataSource(res.Endpoints)
             let result = JsonHomeProjection.project dataSource None "TestApp"
-            let r = result.Resources.[0]
+            let r = result.Input.Resources.[0]
             Expect.contains r.Hints.Allow "GET" "should have GET"
             Expect.contains r.Hints.Allow "POST" "should have POST"
 
@@ -68,13 +68,13 @@ let tests =
             let allEndpoints = Array.append userRes.Endpoints [| internalEndpoint |]
             let dataSource = TestEndpointDataSource(allEndpoints)
             let result = JsonHomeProjection.project dataSource None "TestApp"
-            Expect.equal result.Resources.Length 1 "should only have user resource"
-            Expect.equal result.Resources.[0].RouteTemplate "/items" "should be items"
+            Expect.equal result.Input.Resources.Length 1 "should only have user resource"
+            Expect.equal result.Input.Resources.[0].RouteTemplate "/items" "should be items"
 
         testCase "empty data source produces empty resources" <| fun _ ->
             let dataSource = TestEndpointDataSource([||])
             let result = JsonHomeProjection.project dataSource None "TestApp"
-            Expect.isEmpty result.Resources "should have no resources"
+            Expect.isEmpty result.Input.Resources "should have no resources"
 
         testCase "docsUrl from metadata flows to hints" <| fun _ ->
             let res = resource "/items" { get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("ok"))) }
@@ -82,7 +82,7 @@ let tests =
             let metadata: JsonHomeMetadata =
                 { JsonHomeMetadata.Empty with DocsUrl = Some "/scalar/v1" }
             let result = JsonHomeProjection.project dataSource (Some metadata) "TestApp"
-            Expect.equal result.Resources.[0].Hints.DocsUrl (Some "/scalar/v1") "should have docs URL"
+            Expect.equal result.Input.Resources.[0].Hints.DocsUrl (Some "/scalar/v1") "should have docs URL"
 
         testCase "describedByUrl detected from well-known endpoint" <| fun _ ->
             let userRes = resource "/items" { get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("ok"))) }
@@ -95,14 +95,14 @@ let tests =
             let allEndpoints = Array.append userRes.Endpoints [| profilesEndpoint |]
             let dataSource = TestEndpointDataSource(allEndpoints)
             let result = JsonHomeProjection.project dataSource None "TestApp"
-            Expect.equal result.DescribedByUrl (Some "/.well-known/frank-profiles") "should detect profiles endpoint"
+            Expect.equal result.Input.DescribedByUrl (Some "/.well-known/frank-profiles") "should detect profiles endpoint"
 
         // M-1: route constraints stripped from hrefTemplate
         testCase "route constraints stripped from template" <| fun _ ->
             let res = resource "/items/{id:int}" { get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("ok"))) }
             let dataSource = TestEndpointDataSource(res.Endpoints)
             let result = JsonHomeProjection.project dataSource None "TestApp"
-            let r = result.Resources.[0]
+            let r = result.Input.Resources.[0]
             Expect.equal r.RouteTemplate "/items/{id}" "route constraint should be stripped"
             Expect.isFalse (r.RouteTemplate.Contains(":")) "should not contain constraint colon"
 
@@ -118,7 +118,7 @@ let tests =
                   AlpsBaseUri = Some "http://example.com/alps/games"
                   AlpsDescriptors = Some (Map.ofList [ "games", Map.ofList [ "gameId", "http://example.com/alps/games#gameId" ] ]) }
             let result = JsonHomeProjection.project dataSource (Some metadata) "TestApp"
-            let rels = result.Resources |> List.map _.RelationType
+            let rels = result.Input.Resources |> List.map _.RelationType
             Expect.equal rels.Length 2 "should have two resources"
             Expect.notEqual rels.[0] rels.[1] "relation types must be distinct (no slug collision)"
             Expect.isTrue (rels |> List.exists (fun r -> r.Contains("#games~gameId"))) "item route should have games~gameId fragment"
@@ -138,7 +138,7 @@ let tests =
                   AlpsBaseUri = Some "http://example.com/alps/games"
                   AlpsDescriptors = Some (Map.ofList [ "games", Map.ofList [ "gameId", "http://example.com/alps/games#gameId" ] ]) }
             let result = JsonHomeProjection.project dataSource (Some metadata) "TestApp"
-            let rels = result.Resources |> List.map _.RelationType
+            let rels = result.Input.Resources |> List.map _.RelationType
             Expect.equal rels.Length 4 "should have four resources"
             // All relation types must be distinct
             Expect.equal (rels |> List.distinct |> List.length) 4 "all relation types must be distinct"
@@ -157,7 +157,7 @@ let tests =
                   AlpsBaseUri = Some "http://example.com/alps/items"
                   AlpsDescriptors = Some (Map.ofList [ "items", Map.empty ]) }
             let result = JsonHomeProjection.project dataSource (Some metadata) "TestApp"
-            let r = result.Resources.[0]
+            let r = result.Input.Resources.[0]
             Expect.equal r.RelationType "http://example.com/alps/items#items" "single route should produce simple fragment"
 
         // M-2: AlpsBaseUri alone is sufficient for ALPS relation (no descriptor required)
@@ -170,7 +170,7 @@ let tests =
                   AlpsBaseUri = Some "http://example.com/alps/widgets"
                   AlpsDescriptors = None }
             let result = JsonHomeProjection.project dataSource (Some metadata) "TestApp"
-            let r = result.Resources.[0]
+            let r = result.Input.Resources.[0]
             Expect.isTrue (r.RelationType.StartsWith("http://example.com/alps/widgets#")) "AlpsBaseUri alone should produce ALPS relation, not URN"
 
         // M-6: AlpsBaseUri with existing fragment strips fragment before appending
@@ -183,7 +183,7 @@ let tests =
                   AlpsBaseUri = Some "http://example.com/alps#existing"
                   AlpsDescriptors = Some (Map.ofList [ "items", Map.empty ]) }
             let result = JsonHomeProjection.project dataSource (Some metadata) "TestApp"
-            let r = result.Resources.[0]
+            let r = result.Input.Resources.[0]
             Expect.isFalse (r.RelationType.Contains("#existing#")) "should not produce double-fragment URI"
             Expect.equal r.RelationType "http://example.com/alps#items" "should strip existing fragment and append new one"
 
@@ -199,7 +199,7 @@ let tests =
                   AlpsBaseUri = Some "http://example.com/alps/test"
                   AlpsDescriptors = Some (Map.ofList [ "a-b", Map.empty; "a", Map.empty ]) }
             let result = JsonHomeProjection.project dataSource (Some metadata) "TestApp"
-            let rels = result.Resources |> List.map _.RelationType
+            let rels = result.Input.Resources |> List.map _.RelationType
             Expect.equal rels.Length 2 "should have two resources"
             Expect.notEqual rels.[0] rels.[1] "relation types must be distinct (no collision)"
 
@@ -213,7 +213,7 @@ let tests =
                   AlpsBaseUri = Some "/alps/tictactoe"
                   AlpsDescriptors = Some (Map.ofList [ "games", Map.empty ]) }
             let result = JsonHomeProjection.project dataSource (Some metadata) "TestApp"
-            let r = result.Resources.[0]
+            let r = result.Input.Resources.[0]
             Expect.isTrue (r.RelationType.StartsWith("urn:frank:")) "relative AlpsBaseUri should fall back to URN"
 
         // #201: empty string AlpsBaseUri falls back to URN
@@ -226,7 +226,7 @@ let tests =
                   AlpsBaseUri = Some ""
                   AlpsDescriptors = Some (Map.ofList [ "games", Map.empty ]) }
             let result = JsonHomeProjection.project dataSource (Some metadata) "TestApp"
-            let r = result.Resources.[0]
+            let r = result.Input.Resources.[0]
             Expect.isTrue (r.RelationType.StartsWith("urn:frank:")) "empty AlpsBaseUri should fall back to URN"
 
         // #201: absolute http:// URI works correctly
@@ -239,7 +239,7 @@ let tests =
                   AlpsBaseUri = Some "http://api.example.com/alps"
                   AlpsDescriptors = Some (Map.ofList [ "items", Map.empty ]) }
             let result = JsonHomeProjection.project dataSource (Some metadata) "TestApp"
-            let r = result.Resources.[0]
+            let r = result.Input.Resources.[0]
             Expect.equal r.RelationType "http://api.example.com/alps#items" "http:// URI should produce valid ALPS relation"
 
         // #201: absolute https:// URI works correctly
@@ -252,6 +252,70 @@ let tests =
                   AlpsBaseUri = Some "https://secure.example.com/alps"
                   AlpsDescriptors = Some (Map.ofList [ "items", Map.empty ]) }
             let result = JsonHomeProjection.project dataSource (Some metadata) "TestApp"
-            let r = result.Resources.[0]
+            let r = result.Input.Resources.[0]
             Expect.equal r.RelationType "https://secure.example.com/alps#items" "https:// URI should produce valid ALPS relation"
+    ]
+
+[<Tests>]
+let entryPointTests =
+    testList "JsonHomeProjection entry-point filtering" [
+        testCase "resource with entryPoint appears in JSON Home; resource without it does not" <| fun _ ->
+            let entryRes =
+                resource "/games" {
+                    entryPoint
+                    get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("games")))
+                }
+            let hiddenRes =
+                resource "/internal/metrics" {
+                    get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("metrics")))
+                }
+            let allEndpoints = Array.append entryRes.Endpoints hiddenRes.Endpoints
+            let dataSource = TestEndpointDataSource(allEndpoints)
+            let result = JsonHomeProjection.project dataSource None "TestApp"
+            Expect.equal result.Input.Resources.Length 1 "should have only entry-point resource"
+            Expect.equal result.Input.Resources.[0].RouteTemplate "/games" "should be the entry-point resource"
+            Expect.isFalse result.UsedFallback "should not use fallback when entry points exist"
+
+        testCase "when no resources are marked, all appear (fallback)" <| fun _ ->
+            let res1 = resource "/items" { get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("items"))) }
+            let res2 = resource "/orders" { get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("orders"))) }
+            let allEndpoints = Array.append res1.Endpoints res2.Endpoints
+            let dataSource = TestEndpointDataSource(allEndpoints)
+            let result = JsonHomeProjection.project dataSource None "TestApp"
+            Expect.equal result.Input.Resources.Length 2 "should have both resources in fallback"
+            Expect.isTrue result.UsedFallback "should indicate fallback was used"
+
+        testCase "multiple entry points all appear" <| fun _ ->
+            let res1 =
+                resource "/games" {
+                    entryPoint
+                    get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("games")))
+                }
+            let res2 =
+                resource "/players" {
+                    entryPoint
+                    get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("players")))
+                }
+            let res3 =
+                resource "/admin/stats" {
+                    get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("stats")))
+                }
+            let allEndpoints = Array.concat [| res1.Endpoints; res2.Endpoints; res3.Endpoints |]
+            let dataSource = TestEndpointDataSource(allEndpoints)
+            let result = JsonHomeProjection.project dataSource None "TestApp"
+            Expect.equal result.Input.Resources.Length 2 "should have two entry-point resources"
+            let templates = result.Input.Resources |> List.map _.RouteTemplate |> List.sort
+            Expect.equal templates [ "/games"; "/players" ] "should contain both entry-point resources"
+            Expect.isFalse result.UsedFallback "should not use fallback"
+
+        testCase "entryPoint metadata survives endpoint build and is visible on Endpoint.Metadata" <| fun _ ->
+            let res =
+                resource "/test" {
+                    entryPoint
+                    get (RequestDelegate(fun ctx -> ctx.Response.WriteAsync("test")))
+                }
+            let ep = res.Endpoints.[0]
+            let marker = ep.Metadata.GetMetadata<EntryPointMetadata>()
+            Expect.isNotNull (box marker) "should have EntryPointMetadata on endpoint"
+            Expect.isTrue marker.IsEntryPoint "should be marked as entry point"
     ]


### PR DESCRIPTION
Closes #206

## Summary

- **EntryPointMetadata marker type** added to `src/Frank/Builder.fs` -- not a struct because `EndpointMetadataCollection.GetMetadata<T>` requires reference semantics
- **`entryPoint` CE operation** on `ResourceBuilder` adds `EntryPointMetadata` to endpoint metadata
- **JsonHomeProjection filtering**: when any endpoints carry `EntryPointMetadata`, only those routes appear in the home document; otherwise all non-internal routes appear (backward compat fallback)
- **JsonHomeProjectionResult** return type wraps `JsonHomeInput` + `UsedFallback` flag, keeping the projection pure
- **Warning log** in `JsonHomeMiddleware` when fallback-all behavior is used (no entry points designated)

## Requirement Accounting

| Requirement | Status |
|---|---|
| Define marker type `EntryPointMetadata` | Implemented in `src/Frank/Builder.fs` |
| Add `entryPoint` CE operation on resource builder | Implemented in `src/Frank/Builder.fs` |
| Filter in projection (only entry-point resources when any are marked) | Implemented in `src/Frank.Discovery/JsonHomeProjection.fs` |
| Backward compat fallback (all resources when none marked) | Implemented with `UsedFallback` flag |
| Log warning when fallback used | Implemented in `src/Frank.Discovery/JsonHomeMiddleware.fs` |
| Test: resource with entryPoint appears; without does not | Implemented |
| Test: when no resources marked, all appear (fallback) | Implemented |
| Test: warning logged when fallback used | Implemented |
| Test: multiple entry points all appear | Implemented |

## Verified Results

- `dotnet build Frank.sln` -- 0 errors
- `dotnet test Frank.sln --filter "FullyQualifiedName!~Sample"` -- 2,297 tests passed, 0 failed
- `dotnet test test/Frank.Tests/` -- 89 tests passed (separate sln)
- `dotnet test test/Frank.Discovery.Tests/` -- 49 tests passed (7 new entry-point tests)
- `dotnet fantomas --check` on all changed src files -- passes

## Test plan

- [x] Resource with `entryPoint` appears in JSON Home; resource without it does not
- [x] When no resources are marked, all appear (fallback)
- [x] Warning is logged when fallback is used
- [x] Multiple entry points all appear
- [x] `entryPoint` metadata survives endpoint build and is visible on `Endpoint.Metadata`
- [x] Entry-point filtering works end-to-end through middleware
- [x] No warning logged when entry points are explicitly marked
- [x] All existing tests pass unchanged (with updated `result.Input.` accessor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)