### PR TITLE
release: v7.3.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,32 @@
+### New in 7.3.1
+
+Patch release: state-aware OPTIONS, role-filtered Link rels, and ALPS profile completeness.
+
+**Discovery and Entry Points**
+
+- **Entry-point designation** for JSON Home — `entryPoint` CE operation on both `ResourceBuilder` and `StatefulResourceBuilder` filters the home document to designated resources only (fallback to all with logged warning)
+- **ALPS extension IDs** use HTTPS dereferenceable URIs (`https://frank-fs.github.io/alps-ext/{name}`) with backward-compatible parsing of bare names
+- **`protocolState` ext element** emitted in generated ALPS profiles alongside `availableInStates`
+
+**Validation and Conformance**
+
+- **Conformance sequence validation** — `checkSequenceConformance` verifies transition ordering from initial state, not just per-transition role checks
+- **Guard consistency check** — new `ProjectionCheckKind.GuardConsistency` compares ALPS guard annotations against SCXML guard definitions
+- **SHACL shape cross-reference** — new `ProjectionCheckKind.ShapeReference` validates ALPS `def` URIs against `ShapeCache` entries
+- **CLI filter fix** — `--check-projection` now includes guard-only statecharts (previously required roles)
+
+**TicTacToe Sample**
+
+- **Auto-load affordances** — replaced `useAffordancesWith` with `useAffordances` (loads from embedded `model.bin`)
+- **Projected profile serving** — added `useProjectedProfiles` for role-specific ALPS profile Link headers
+- **Entry-point designated** — games resource marked with `entryPoint`
+
+**Code Quality**
+
+- Removed 8 dead `StatechartError` DU cases from abandoned assembly extraction feature
+- Added orphaned `Wsd/LexerTests.fs` to fsproj (453 lines of tests that were never compiled)
+- Deleted 5 stale test file copies left from restructure
+
 ### New in 7.3.0
 
 Self-describing, protocol-aware applications — legible to both human developers and machine agents, with formal multi-party session guarantees enforced at the HTTP boundary.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>7.3.0</VersionPrefix>
+    <VersionPrefix>7.3.1</VersionPrefix>
     <Authors>panesofglass</Authors>
     <Description>F# computation expressions for configuring the Microsoft.AspNetCore.Hosting.IWebHostBuilder and defining routes for HTTP resources using Microsoft.AspNetCore.Routing.</Description>
     <Copyright>Copyright © 2011-2026 Ryan Riley. All rights reserved.</Copyright>


### PR DESCRIPTION
## Summary
- Bump `VersionPrefix` from 7.3.0 to 7.3.1
- Add v7.3.1 release notes to RELEASE_NOTES.md

## Release Notes

Patch release: state-aware OPTIONS, role-filtered Link rels, and ALPS profile completeness.

**Discovery and Entry Points** — entry-point designation, HTTPS ext URIs, protocolState emission

**Validation and Conformance** — sequence validation, guard consistency, SHACL cross-ref, CLI filter fix

**TicTacToe Sample** — auto-load affordances, projected profiles, entry-point wiring

**Code Quality** — 8 dead DU cases removed, orphaned tests added, stale files cleaned

🤖 Generated with [Claude Code](https://claude.com/claude-code)