### PR TITLE
feat: typed sub-DUs for AlpsRole and AlpsDuality

### DIFF
--- a/src/Frank.Statecharts.Core/Types.fs
+++ b/src/Frank.Statecharts.Core/Types.fs
@@ -73,6 +73,20 @@ type AlpsTransitionKind =
     | Unsafe
     | Idempotent
 
+/// Sub-DU for AlpsRole id field (#167).
+/// Typed replacement for raw string ids like "projectedRole" / "protocolState".
+type AlpsRoleKind =
+    | ProjectedRole
+    | ProtocolState
+
+/// Sub-DU for AlpsDuality id field (#167).
+/// Typed replacement for raw string ids like "clientObligation" / "advancesProtocol" / etc.
+type AlpsDualityKind =
+    | ClientObligation
+    | AdvancesProtocol
+    | DualOf
+    | CutPoint
+
 /// ALPS-specific annotation metadata.
 type AlpsMeta =
     | AlpsTransitionType of AlpsTransitionKind
@@ -82,12 +96,12 @@ type AlpsMeta =
     | AlpsLink of rel: string * href: string
     | AlpsDataDescriptor of id: string * doc: (string option * string) option
     | AlpsVersion of string
-    | AlpsRole of id: string * value: string
+    | AlpsRole of kind: AlpsRoleKind * value: string
     /// Guard annotation for state/document-level ext elements only.
     /// Invariant: never appears on TransitionEdge.Annotations (guards are
     /// extracted to TransitionEdge.Guard during classification).
     | AlpsGuardExt of value: string
-    | AlpsDuality of id: string * value: string
+    | AlpsDuality of kind: AlpsDualityKind * value: string
     | AlpsAvailableInStates of states: string list
 
 // -- SCXML annotation types --

--- a/src/Frank.Statecharts/Alps/Classification.fs
+++ b/src/Frank.Statecharts/Alps/Classification.fs
@@ -188,23 +188,23 @@ let classifyExtension (ext: ParsedExtension) : Annotation =
     // Guard: new URI and old bare name
     | GuardExtId
     | "guard" -> AlpsAnnotation(AlpsGuardExt value)
-    // Role extensions: new URIs and old bare names, always store canonical URI
-    | ProjectedRoleExtId -> AlpsAnnotation(AlpsRole(ProjectedRoleExtId, value))
-    | "projectedRole" -> AlpsAnnotation(AlpsRole(ProjectedRoleExtId, value))
-    | ProtocolStateExtId -> AlpsAnnotation(AlpsRole(ProtocolStateExtId, value))
-    | "protocolState" -> AlpsAnnotation(AlpsRole(ProtocolStateExtId, value))
+    // Role extensions: new URIs and old bare names, map to typed AlpsRoleKind
+    | ProjectedRoleExtId -> AlpsAnnotation(AlpsRole(ProjectedRole, value))
+    | "projectedRole" -> AlpsAnnotation(AlpsRole(ProjectedRole, value))
+    | ProtocolStateExtId -> AlpsAnnotation(AlpsRole(ProtocolState, value))
+    | "protocolState" -> AlpsAnnotation(AlpsRole(ProtocolState, value))
     // AvailableInStates: new URI and old bare name
     | AvailableInStatesExtId -> AlpsAnnotation(AlpsAvailableInStates(parseStates value))
     | "availableInStates" -> AlpsAnnotation(AlpsAvailableInStates(parseStates value))
-    // Duality extensions: new URIs and old bare names, always store canonical URI
-    | ClientObligationExtId -> AlpsAnnotation(AlpsDuality(ClientObligationExtId, value))
-    | "clientObligation" -> AlpsAnnotation(AlpsDuality(ClientObligationExtId, value))
-    | AdvancesProtocolExtId -> AlpsAnnotation(AlpsDuality(AdvancesProtocolExtId, value))
-    | "advancesProtocol" -> AlpsAnnotation(AlpsDuality(AdvancesProtocolExtId, value))
-    | DualOfExtId -> AlpsAnnotation(AlpsDuality(DualOfExtId, value))
-    | "dualOf" -> AlpsAnnotation(AlpsDuality(DualOfExtId, value))
-    | CutPointExtId -> AlpsAnnotation(AlpsDuality(CutPointExtId, value))
-    | "cutPoint" -> AlpsAnnotation(AlpsDuality(CutPointExtId, value))
+    // Duality extensions: new URIs and old bare names, map to typed AlpsDualityKind
+    | ClientObligationExtId -> AlpsAnnotation(AlpsDuality(ClientObligation, value))
+    | "clientObligation" -> AlpsAnnotation(AlpsDuality(ClientObligation, value))
+    | AdvancesProtocolExtId -> AlpsAnnotation(AlpsDuality(AdvancesProtocol, value))
+    | "advancesProtocol" -> AlpsAnnotation(AlpsDuality(AdvancesProtocol, value))
+    | DualOfExtId -> AlpsAnnotation(AlpsDuality(DualOf, value))
+    | "dualOf" -> AlpsAnnotation(AlpsDuality(DualOf, value))
+    | CutPointExtId -> AlpsAnnotation(AlpsDuality(CutPoint, value))
+    | "cutPoint" -> AlpsAnnotation(AlpsDuality(CutPoint, value))
     | _ -> AlpsAnnotation(AlpsExtension(ext.Id, ext.Href, ext.Value))
 
 // ---------------------------------------------------------------------------

--- a/src/Frank.Statecharts/Alps/GeneratorCommon.fs
+++ b/src/Frank.Statecharts/Alps/GeneratorCommon.fs
@@ -53,8 +53,7 @@ let tryGetDescriptorHref (t: TransitionEdge) : string option =
         | _ -> None)
 
 /// Check if a transition is a shared transition (has AlpsDescriptorHref).
-let isSharedTransition (t: TransitionEdge) : bool =
-    tryGetDescriptorHref t |> Option.isSome
+let isSharedTransition (t: TransitionEdge) : bool = tryGetDescriptorHref t |> Option.isSome
 
 /// Extract documentation annotation from an annotation list.
 let tryGetDocAnnotation (annotations: Annotation list) : (string option * string) option =
@@ -74,9 +73,23 @@ let getExtAnnotations (annotations: Annotation list) : (string * string option *
         | AlpsAnnotation meta ->
             match meta with
             | AlpsExtension(id, href, value) -> Some(id, href, value)
-            | AlpsRole(id, value) -> Some(id, None, Some value)
+            | AlpsRole(kind, value) ->
+                let id =
+                    match kind with
+                    | ProjectedRole -> Classification.ProjectedRoleExtId
+                    | ProtocolState -> Classification.ProtocolStateExtId
+
+                Some(id, None, Some value)
             | AlpsGuardExt value -> Some(Classification.GuardExtId, None, Some value)
-            | AlpsDuality(id, value) -> Some(id, None, Some value)
+            | AlpsDuality(kind, value) ->
+                let id =
+                    match kind with
+                    | ClientObligation -> Classification.ClientObligationExtId
+                    | AdvancesProtocol -> Classification.AdvancesProtocolExtId
+                    | DualOf -> Classification.DualOfExtId
+                    | CutPoint -> Classification.CutPointExtId
+
+                Some(id, None, Some value)
             | AlpsAvailableInStates states ->
                 // Normalized: no spaces (classifyExtension trims on parse)
                 Some(Classification.AvailableInStatesExtId, None, Some(states |> String.concat ","))
@@ -108,8 +121,10 @@ let getDataDescriptors (annotations: Annotation list) : (string * (string option
 let rtValue (target: string option) : string option =
     target
     |> Option.map (fun t ->
-        if t.StartsWith("http://") || t.StartsWith("https://") then t
-        else "#" + t)
+        if t.StartsWith("http://") || t.StartsWith("https://") then
+            t
+        else
+            "#" + t)
 
 /// Collect shared transitions: group by event name, take the first (canonical) transition.
 let collectSharedTransitions (transitions: TransitionEdge list) : (string * TransitionEdge) list =

--- a/src/Frank.Statecharts/TransitionExtractor.fs
+++ b/src/Frank.Statecharts/TransitionExtractor.fs
@@ -1,7 +1,6 @@
 module Frank.Statecharts.TransitionExtractor
 
 open Frank.Statecharts.Ast
-open Frank.Statecharts.Alps.Classification
 open Frank.Resources.Model
 
 // ---------------------------------------------------------------------------
@@ -9,14 +8,14 @@ open Frank.Resources.Model
 // ---------------------------------------------------------------------------
 
 /// Extract RoleConstraint from a transition edge's annotations.
-/// Finds AlpsRole annotations whose id matches ProjectedRoleExtId and
+/// Finds AlpsRole annotations with ProjectedRole kind and
 /// collects their values into RestrictedTo; no matches yields Unrestricted.
 let private resolveConstraint (annotations: Annotation list) : RoleConstraint =
     let roleValues =
         annotations
         |> List.choose (fun ann ->
             match ann with
-            | AlpsAnnotation(AlpsRole(id, value)) when id = ProjectedRoleExtId -> Some value
+            | AlpsAnnotation(AlpsRole(ProjectedRole, value)) -> Some value
             | _ -> None)
 
     match roleValues with
@@ -25,13 +24,13 @@ let private resolveConstraint (annotations: Annotation list) : RoleConstraint =
 
 /// Extract RoleInfo list from document-level annotations.
 /// Roles declared at the document level appear as AlpsRole annotations
-/// with id = ProjectedRoleExtId. Comma-separated values are split into
+/// with ProjectedRole kind. Comma-separated values are split into
 /// individual roles (e.g., "PlayerX,PlayerO,Spectator" → 3 RoleInfo).
 let extractRoles (doc: StatechartDocument) : RoleInfo list =
     doc.Annotations
     |> List.collect (fun ann ->
         match ann with
-        | AlpsAnnotation(AlpsRole(id, value)) when id = ProjectedRoleExtId ->
+        | AlpsAnnotation(AlpsRole(ProjectedRole, value)) ->
             value.Split(
                 ',',
                 System.StringSplitOptions.RemoveEmptyEntries

--- a/test/Frank.Statecharts.Tests/Alps/ExtensionClassificationTests.fs
+++ b/test/Frank.Statecharts.Tests/Alps/ExtensionClassificationTests.fs
@@ -43,7 +43,7 @@ let classifyExtensionTests =
                     Value = Some "admin" }
 
               let result = classifyExtension ext
-              Expect.equal result (AlpsAnnotation(AlpsRole(ProjectedRoleExtId, "admin"))) "projectedRole → AlpsRole"
+              Expect.equal result (AlpsAnnotation(AlpsRole(ProjectedRole, "admin"))) "projectedRole → AlpsRole"
 
           testCase "protocolState → AlpsRole"
           <| fun () ->
@@ -56,7 +56,7 @@ let classifyExtensionTests =
 
               Expect.equal
                   result
-                  (AlpsAnnotation(AlpsRole(ProtocolStateExtId, "authenticated")))
+                  (AlpsAnnotation(AlpsRole(ProtocolState, "authenticated")))
                   "protocolState → AlpsRole"
 
           // Duality extensions
@@ -71,7 +71,7 @@ let classifyExtensionTests =
 
               Expect.equal
                   result
-                  (AlpsAnnotation(AlpsDuality(ClientObligationExtId, "must-ack")))
+                  (AlpsAnnotation(AlpsDuality(ClientObligation, "must-ack")))
                   "clientObligation → AlpsDuality"
 
           testCase "advancesProtocol → AlpsDuality"
@@ -85,7 +85,7 @@ let classifyExtensionTests =
 
               Expect.equal
                   result
-                  (AlpsAnnotation(AlpsDuality(AdvancesProtocolExtId, "true")))
+                  (AlpsAnnotation(AlpsDuality(AdvancesProtocol, "true")))
                   "advancesProtocol → AlpsDuality"
 
           testCase "dualOf → AlpsDuality"
@@ -97,7 +97,7 @@ let classifyExtensionTests =
 
               let result = classifyExtension ext
 
-              Expect.equal result (AlpsAnnotation(AlpsDuality(DualOfExtId, "serverAction"))) "dualOf → AlpsDuality"
+              Expect.equal result (AlpsAnnotation(AlpsDuality(DualOf, "serverAction"))) "dualOf → AlpsDuality"
 
           testCase "cutPoint → AlpsDuality"
           <| fun () ->
@@ -108,7 +108,7 @@ let classifyExtensionTests =
 
               let result = classifyExtension ext
 
-              Expect.equal result (AlpsAnnotation(AlpsDuality(CutPointExtId, "true"))) "cutPoint → AlpsDuality"
+              Expect.equal result (AlpsAnnotation(AlpsDuality(CutPoint, "true"))) "cutPoint → AlpsDuality"
 
           // AvailableInStates extension
           testCase "availableInStates → AlpsAvailableInStates"
@@ -201,7 +201,7 @@ let classifyExtensionTests =
 
               Expect.equal
                   result
-                  (AlpsAnnotation(AlpsRole("https://frank-fs.github.io/alps-ext/projectedRole", "admin")))
+                  (AlpsAnnotation(AlpsRole(ProjectedRole, "admin")))
                   "projectedRole URI → AlpsRole"
 
           testCase "protocolState URI → AlpsRole"
@@ -215,7 +215,7 @@ let classifyExtensionTests =
 
               Expect.equal
                   result
-                  (AlpsAnnotation(AlpsRole("https://frank-fs.github.io/alps-ext/protocolState", "authenticated")))
+                  (AlpsAnnotation(AlpsRole(ProtocolState, "authenticated")))
                   "protocolState URI → AlpsRole"
 
           testCase "availableInStates URI → AlpsAvailableInStates"
@@ -243,7 +243,7 @@ let classifyExtensionTests =
 
               Expect.equal
                   result
-                  (AlpsAnnotation(AlpsDuality("https://frank-fs.github.io/alps-ext/clientObligation", "must-ack")))
+                  (AlpsAnnotation(AlpsDuality(ClientObligation, "must-ack")))
                   "clientObligation URI → AlpsDuality"
 
           testCase "advancesProtocol URI → AlpsDuality"
@@ -257,7 +257,7 @@ let classifyExtensionTests =
 
               Expect.equal
                   result
-                  (AlpsAnnotation(AlpsDuality("https://frank-fs.github.io/alps-ext/advancesProtocol", "true")))
+                  (AlpsAnnotation(AlpsDuality(AdvancesProtocol, "true")))
                   "advancesProtocol URI → AlpsDuality"
 
           testCase "dualOf URI → AlpsDuality"
@@ -271,7 +271,7 @@ let classifyExtensionTests =
 
               Expect.equal
                   result
-                  (AlpsAnnotation(AlpsDuality("https://frank-fs.github.io/alps-ext/dualOf", "serverAction")))
+                  (AlpsAnnotation(AlpsDuality(DualOf, "serverAction")))
                   "dualOf URI → AlpsDuality"
 
           testCase "cutPoint URI → AlpsDuality"
@@ -285,7 +285,7 @@ let classifyExtensionTests =
 
               Expect.equal
                   result
-                  (AlpsAnnotation(AlpsDuality("https://frank-fs.github.io/alps-ext/cutPoint", "true")))
+                  (AlpsAnnotation(AlpsDuality(CutPoint, "true")))
                   "cutPoint URI → AlpsDuality"
 
           // --- Backward compat: old bare names still classify correctly ---
@@ -310,7 +310,7 @@ let classifyExtensionTests =
 
               Expect.equal
                   result
-                  (AlpsAnnotation(AlpsRole(ProjectedRoleExtId, "admin")))
+                  (AlpsAnnotation(AlpsRole(ProjectedRole, "admin")))
                   "bare projectedRole normalizes to URI"
 
           testCase "bare protocolState → AlpsRole with canonical URI (backward compat)"
@@ -324,7 +324,7 @@ let classifyExtensionTests =
 
               Expect.equal
                   result
-                  (AlpsAnnotation(AlpsRole(ProtocolStateExtId, "running")))
+                  (AlpsAnnotation(AlpsRole(ProtocolState, "running")))
                   "bare protocolState normalizes to URI"
 
           testCase "bare availableInStates → AlpsAvailableInStates (backward compat)"
@@ -352,7 +352,7 @@ let classifyExtensionTests =
 
               Expect.equal
                   result
-                  (AlpsAnnotation(AlpsDuality(ClientObligationExtId, "must-ack")))
+                  (AlpsAnnotation(AlpsDuality(ClientObligation, "must-ack")))
                   "bare clientObligation normalizes to URI"
 
           testCase "bare advancesProtocol → AlpsDuality with canonical URI (backward compat)"
@@ -366,7 +366,7 @@ let classifyExtensionTests =
 
               Expect.equal
                   result
-                  (AlpsAnnotation(AlpsDuality(AdvancesProtocolExtId, "true")))
+                  (AlpsAnnotation(AlpsDuality(AdvancesProtocol, "true")))
                   "bare advancesProtocol normalizes to URI"
 
           testCase "bare dualOf → AlpsDuality with canonical URI (backward compat)"
@@ -380,7 +380,7 @@ let classifyExtensionTests =
 
               Expect.equal
                   result
-                  (AlpsAnnotation(AlpsDuality(DualOfExtId, "serverAction")))
+                  (AlpsAnnotation(AlpsDuality(DualOf, "serverAction")))
                   "bare dualOf normalizes to URI"
 
           testCase "bare cutPoint → AlpsDuality with canonical URI (backward compat)"
@@ -392,7 +392,7 @@ let classifyExtensionTests =
 
               let result = classifyExtension ext
 
-              Expect.equal result (AlpsAnnotation(AlpsDuality(CutPointExtId, "true"))) "bare cutPoint normalizes to URI"
+              Expect.equal result (AlpsAnnotation(AlpsDuality(CutPoint, "true"))) "bare cutPoint normalizes to URI"
 
           // --- Constants are HTTPS URIs ---
           testCase "GuardExtId is an HTTPS URI"
@@ -449,7 +449,7 @@ let buildStateAnnotationsTypedTests =
                   annotations
                   |> List.exists (fun a ->
                       match a with
-                      | AlpsAnnotation(AlpsRole(id, "PlayerX")) when id = ProjectedRoleExtId -> true
+                      | AlpsAnnotation(AlpsRole(ProjectedRole, "PlayerX")) -> true
                       | _ -> false)
 
               Expect.isTrue hasRole "should contain AlpsRole annotation"
@@ -530,7 +530,7 @@ let buildTransitionAnnotationsTypedTests =
                   annotations
                   |> List.exists (fun a ->
                       match a with
-                      | AlpsAnnotation(AlpsDuality(id, "must-ack")) when id = ClientObligationExtId -> true
+                      | AlpsAnnotation(AlpsDuality(ClientObligation, "must-ack")) -> true
                       | _ -> false)
 
               let hasGuard =
@@ -594,7 +594,7 @@ let generatedExtUriTests =
                               Children = []
                               Activities = None
                               Position = None
-                              Annotations = [ AlpsAnnotation(AlpsRole(ProjectedRoleExtId, "server")) ] } ]
+                              Annotations = [ AlpsAnnotation(AlpsRole(ProjectedRole, "server")) ] } ]
                     DataEntries = []
                     Annotations = [] }
 
@@ -648,7 +648,7 @@ let generatedExtUriTests =
                               Activities = None
                               Position = None
                               Annotations =
-                                [ AlpsAnnotation(AlpsRole(ProjectedRoleExtId, "server"))
+                                [ AlpsAnnotation(AlpsRole(ProjectedRole, "server"))
                                   AlpsAnnotation(AlpsAvailableInStates [ "Idle" ]) ] }
                         StateDecl
                             { Identifier = Some "Active"
@@ -658,8 +658,8 @@ let generatedExtUriTests =
                               Activities = None
                               Position = None
                               Annotations =
-                                [ AlpsAnnotation(AlpsRole(ProtocolStateExtId, "running"))
-                                  AlpsAnnotation(AlpsDuality(DualOfExtId, "start")) ] }
+                                [ AlpsAnnotation(AlpsRole(ProtocolState, "running"))
+                                  AlpsAnnotation(AlpsDuality(DualOf, "start")) ] }
                         TransitionElement
                             { Source = "Idle"
                               Target = Some "Active"
@@ -670,7 +670,7 @@ let generatedExtUriTests =
                               Position = None
                               Annotations =
                                 [ AlpsAnnotation(AlpsTransitionType AlpsTransitionKind.Unsafe)
-                                  AlpsAnnotation(AlpsDuality(ClientObligationExtId, "must-ack")) ] } ]
+                                  AlpsAnnotation(AlpsDuality(ClientObligation, "must-ack")) ] } ]
                     DataEntries = []
                     Annotations = [ AlpsAnnotation(AlpsVersion "1.0") ] }
 
@@ -707,7 +707,7 @@ let generatedExtUriTests =
                   idle.Annotations
                   |> List.exists (fun a ->
                       match a with
-                      | AlpsAnnotation(AlpsRole(id, "server")) when id = ProjectedRoleExtId -> true
+                      | AlpsAnnotation(AlpsRole(ProjectedRole, "server")) -> true
                       | _ -> false)
 
               Expect.isTrue hasRoleWithUri "bare projectedRole should normalize to URI in parsed AST"

--- a/test/Frank.Statecharts.Tests/Alps/SubDuTests.fs
+++ b/test/Frank.Statecharts.Tests/Alps/SubDuTests.fs
@@ -1,0 +1,383 @@
+module Frank.Statecharts.Tests.Alps.SubDuTests
+
+open Expecto
+open Frank.Statecharts.Ast
+open Frank.Statecharts.Alps.Classification
+
+// ---------------------------------------------------------------------------
+// #167: AlpsRoleKind and AlpsDualityKind sub-DU tests
+// ---------------------------------------------------------------------------
+
+/// Tests that the sub-DU types exist and have the correct cases.
+[<Tests>]
+let subDuTypeTests =
+    testList
+        "Sub-DU type construction (#167)"
+        [
+          // AlpsRoleKind cases exist
+          testCase "AlpsRoleKind.ProjectedRole exists"
+          <| fun () ->
+              let kind: AlpsRoleKind = ProjectedRole
+              Expect.equal kind ProjectedRole "ProjectedRole case"
+
+          testCase "AlpsRoleKind.ProtocolState exists"
+          <| fun () ->
+              let kind: AlpsRoleKind = ProtocolState
+              Expect.equal kind ProtocolState "ProtocolState case"
+
+          // AlpsDualityKind cases exist
+          testCase "AlpsDualityKind.ClientObligation exists"
+          <| fun () ->
+              let kind: AlpsDualityKind = ClientObligation
+              Expect.equal kind ClientObligation "ClientObligation case"
+
+          testCase "AlpsDualityKind.AdvancesProtocol exists"
+          <| fun () ->
+              let kind: AlpsDualityKind = AdvancesProtocol
+              Expect.equal kind AdvancesProtocol "AdvancesProtocol case"
+
+          testCase "AlpsDualityKind.DualOf exists"
+          <| fun () ->
+              let kind: AlpsDualityKind = DualOf
+              Expect.equal kind DualOf "DualOf case"
+
+          testCase "AlpsDualityKind.CutPoint exists"
+          <| fun () ->
+              let kind: AlpsDualityKind = CutPoint
+              Expect.equal kind CutPoint "CutPoint case"
+
+          // AlpsMeta uses sub-DU kinds (not string IDs)
+          testCase "AlpsRole takes AlpsRoleKind, not string id"
+          <| fun () ->
+              let meta = AlpsRole(ProjectedRole, "admin")
+              Expect.equal meta (AlpsRole(ProjectedRole, "admin")) "AlpsRole(ProjectedRole, value)"
+
+          testCase "AlpsDuality takes AlpsDualityKind, not string id"
+          <| fun () ->
+              let meta = AlpsDuality(ClientObligation, "must-ack")
+              Expect.equal meta (AlpsDuality(ClientObligation, "must-ack")) "AlpsDuality(ClientObligation, value)" ]
+
+/// Tests that classifyExtension maps to sub-DU kinds.
+[<Tests>]
+let classifyExtensionSubDuTests =
+    testList
+        "classifyExtension maps to sub-DU kinds (#167)"
+        [
+          // Role classification
+          testCase "projectedRole URI → AlpsRole(ProjectedRole, _)"
+          <| fun () ->
+              let ext =
+                  { Id = ProjectedRoleExtId
+                    Href = None
+                    Value = Some "admin" }
+
+              let result = classifyExtension ext
+              Expect.equal result (AlpsAnnotation(AlpsRole(ProjectedRole, "admin"))) "projectedRole → ProjectedRole"
+
+          testCase "protocolState URI → AlpsRole(ProtocolState, _)"
+          <| fun () ->
+              let ext =
+                  { Id = ProtocolStateExtId
+                    Href = None
+                    Value = Some "authenticated" }
+
+              let result = classifyExtension ext
+
+              Expect.equal
+                  result
+                  (AlpsAnnotation(AlpsRole(ProtocolState, "authenticated")))
+                  "protocolState → ProtocolState"
+
+          testCase "bare projectedRole → AlpsRole(ProjectedRole, _) (backward compat)"
+          <| fun () ->
+              let ext =
+                  { Id = "projectedRole"
+                    Href = None
+                    Value = Some "viewer" }
+
+              let result = classifyExtension ext
+              Expect.equal result (AlpsAnnotation(AlpsRole(ProjectedRole, "viewer"))) "bare projectedRole → ProjectedRole"
+
+          testCase "bare protocolState → AlpsRole(ProtocolState, _) (backward compat)"
+          <| fun () ->
+              let ext =
+                  { Id = "protocolState"
+                    Href = None
+                    Value = Some "running" }
+
+              let result = classifyExtension ext
+
+              Expect.equal
+                  result
+                  (AlpsAnnotation(AlpsRole(ProtocolState, "running")))
+                  "bare protocolState → ProtocolState"
+
+          // Duality classification
+          testCase "clientObligation URI → AlpsDuality(ClientObligation, _)"
+          <| fun () ->
+              let ext =
+                  { Id = ClientObligationExtId
+                    Href = None
+                    Value = Some "must-ack" }
+
+              let result = classifyExtension ext
+
+              Expect.equal
+                  result
+                  (AlpsAnnotation(AlpsDuality(ClientObligation, "must-ack")))
+                  "clientObligation → ClientObligation"
+
+          testCase "advancesProtocol URI → AlpsDuality(AdvancesProtocol, _)"
+          <| fun () ->
+              let ext =
+                  { Id = AdvancesProtocolExtId
+                    Href = None
+                    Value = Some "true" }
+
+              let result = classifyExtension ext
+
+              Expect.equal
+                  result
+                  (AlpsAnnotation(AlpsDuality(AdvancesProtocol, "true")))
+                  "advancesProtocol → AdvancesProtocol"
+
+          testCase "dualOf URI → AlpsDuality(DualOf, _)"
+          <| fun () ->
+              let ext =
+                  { Id = DualOfExtId
+                    Href = None
+                    Value = Some "serverAction" }
+
+              let result = classifyExtension ext
+              Expect.equal result (AlpsAnnotation(AlpsDuality(DualOf, "serverAction"))) "dualOf → DualOf"
+
+          testCase "cutPoint URI → AlpsDuality(CutPoint, _)"
+          <| fun () ->
+              let ext =
+                  { Id = CutPointExtId
+                    Href = None
+                    Value = Some "true" }
+
+              let result = classifyExtension ext
+              Expect.equal result (AlpsAnnotation(AlpsDuality(CutPoint, "true"))) "cutPoint → CutPoint"
+
+          testCase "bare clientObligation → AlpsDuality(ClientObligation, _) (backward compat)"
+          <| fun () ->
+              let ext =
+                  { Id = "clientObligation"
+                    Href = None
+                    Value = Some "must-ack" }
+
+              let result = classifyExtension ext
+
+              Expect.equal
+                  result
+                  (AlpsAnnotation(AlpsDuality(ClientObligation, "must-ack")))
+                  "bare clientObligation → ClientObligation"
+
+          testCase "bare advancesProtocol → AlpsDuality(AdvancesProtocol, _) (backward compat)"
+          <| fun () ->
+              let ext =
+                  { Id = "advancesProtocol"
+                    Href = None
+                    Value = Some "true" }
+
+              let result = classifyExtension ext
+
+              Expect.equal
+                  result
+                  (AlpsAnnotation(AlpsDuality(AdvancesProtocol, "true")))
+                  "bare advancesProtocol → AdvancesProtocol"
+
+          testCase "bare dualOf → AlpsDuality(DualOf, _) (backward compat)"
+          <| fun () ->
+              let ext =
+                  { Id = "dualOf"
+                    Href = None
+                    Value = Some "serverAction" }
+
+              let result = classifyExtension ext
+              Expect.equal result (AlpsAnnotation(AlpsDuality(DualOf, "serverAction"))) "bare dualOf → DualOf"
+
+          testCase "bare cutPoint → AlpsDuality(CutPoint, _) (backward compat)"
+          <| fun () ->
+              let ext =
+                  { Id = "cutPoint"
+                    Href = None
+                    Value = Some "true" }
+
+              let result = classifyExtension ext
+              Expect.equal result (AlpsAnnotation(AlpsDuality(CutPoint, "true"))) "bare cutPoint → CutPoint" ]
+
+/// Tests that generators round-trip correctly with sub-DU kinds.
+[<Tests>]
+let generatorRoundTripSubDuTests =
+    testList
+        "Generator round-trip with sub-DU kinds (#167)"
+        [ testCase "getExtAnnotations emits correct ext id for ProjectedRole"
+          <| fun () ->
+              let annotations =
+                  [ AlpsAnnotation(AlpsRole(ProjectedRole, "admin")) ]
+
+              let exts = Frank.Statecharts.Alps.GeneratorCommon.getExtAnnotations annotations
+              Expect.hasLength exts 1 "one ext"
+              let (id, href, value) = exts.[0]
+              Expect.equal id ProjectedRoleExtId "id is ProjectedRoleExtId URI"
+              Expect.isNone href "no href"
+              Expect.equal value (Some "admin") "value preserved"
+
+          testCase "getExtAnnotations emits correct ext id for ProtocolState"
+          <| fun () ->
+              let annotations =
+                  [ AlpsAnnotation(AlpsRole(ProtocolState, "authenticated")) ]
+
+              let exts = Frank.Statecharts.Alps.GeneratorCommon.getExtAnnotations annotations
+              Expect.hasLength exts 1 "one ext"
+              let (id, _, _) = exts.[0]
+              Expect.equal id ProtocolStateExtId "id is ProtocolStateExtId URI"
+
+          testCase "getExtAnnotations emits correct ext id for ClientObligation"
+          <| fun () ->
+              let annotations =
+                  [ AlpsAnnotation(AlpsDuality(ClientObligation, "must-ack")) ]
+
+              let exts = Frank.Statecharts.Alps.GeneratorCommon.getExtAnnotations annotations
+              Expect.hasLength exts 1 "one ext"
+              let (id, _, _) = exts.[0]
+              Expect.equal id ClientObligationExtId "id is ClientObligationExtId URI"
+
+          testCase "getExtAnnotations emits correct ext id for AdvancesProtocol"
+          <| fun () ->
+              let annotations =
+                  [ AlpsAnnotation(AlpsDuality(AdvancesProtocol, "true")) ]
+
+              let exts = Frank.Statecharts.Alps.GeneratorCommon.getExtAnnotations annotations
+              Expect.hasLength exts 1 "one ext"
+              let (id, _, _) = exts.[0]
+              Expect.equal id AdvancesProtocolExtId "id is AdvancesProtocolExtId URI"
+
+          testCase "getExtAnnotations emits correct ext id for DualOf"
+          <| fun () ->
+              let annotations =
+                  [ AlpsAnnotation(AlpsDuality(DualOf, "serverAction")) ]
+
+              let exts = Frank.Statecharts.Alps.GeneratorCommon.getExtAnnotations annotations
+              Expect.hasLength exts 1 "one ext"
+              let (id, _, _) = exts.[0]
+              Expect.equal id DualOfExtId "id is DualOfExtId URI"
+
+          testCase "getExtAnnotations emits correct ext id for CutPoint"
+          <| fun () ->
+              let annotations =
+                  [ AlpsAnnotation(AlpsDuality(CutPoint, "true")) ]
+
+              let exts = Frank.Statecharts.Alps.GeneratorCommon.getExtAnnotations annotations
+              Expect.hasLength exts 1 "one ext"
+              let (id, _, _) = exts.[0]
+              Expect.equal id CutPointExtId "id is CutPointExtId URI"
+
+          testCase "JSON round-trip preserves sub-DU kinds"
+          <| fun () ->
+              let doc: StatechartDocument =
+                  { Title = None
+                    InitialStateId = None
+                    Elements =
+                      [ StateDecl
+                            { Identifier = Some "Idle"
+                              Label = None
+                              Kind = StateKind.Regular
+                              Children = []
+                              Activities = None
+                              Position = None
+                              Annotations =
+                                [ AlpsAnnotation(AlpsRole(ProjectedRole, "server"))
+                                  AlpsAnnotation(AlpsAvailableInStates [ "Idle" ]) ] }
+                        StateDecl
+                            { Identifier = Some "Active"
+                              Label = None
+                              Kind = StateKind.Regular
+                              Children = []
+                              Activities = None
+                              Position = None
+                              Annotations =
+                                [ AlpsAnnotation(AlpsRole(ProtocolState, "running"))
+                                  AlpsAnnotation(AlpsDuality(DualOf, "start")) ] }
+                        TransitionElement
+                            { Source = "Idle"
+                              Target = Some "Active"
+                              Event = Some "start"
+                              Guard = Some "isReady"
+                              Action = None
+                              Parameters = []
+                              Position = None
+                              Annotations =
+                                [ AlpsAnnotation(AlpsTransitionType AlpsTransitionKind.Unsafe)
+                                  AlpsAnnotation(AlpsDuality(ClientObligation, "must-ack")) ] } ]
+                    DataEntries = []
+                    Annotations = [ AlpsAnnotation(AlpsVersion "1.0") ] }
+
+              let json = Frank.Statecharts.Alps.JsonGenerator.generateAlpsJson doc
+              let parsed = Frank.Statecharts.Alps.JsonParser.parseAlpsJson json
+              Expect.isEmpty parsed.Errors "parse should succeed"
+              Expect.equal parsed.Document doc "round-trip preserves AST with sub-DU kinds" ]
+
+/// Tests that TransitionExtractor correctly pattern-matches on sub-DU kinds.
+[<Tests>]
+let transitionExtractorSubDuTests =
+    testList
+        "TransitionExtractor with sub-DU kinds (#167)"
+        [ testCase "resolveConstraint matches AlpsRole(ProjectedRole, _)"
+          <| fun () ->
+              let doc: StatechartDocument =
+                  { Title = None
+                    InitialStateId = None
+                    Elements =
+                      [ TransitionElement
+                            { Source = "Idle"
+                              Target = Some "Active"
+                              Event = Some "start"
+                              Guard = None
+                              Action = None
+                              Parameters = []
+                              Position = None
+                              Annotations =
+                                [ AlpsAnnotation(AlpsTransitionType AlpsTransitionKind.Unsafe)
+                                  AlpsAnnotation(AlpsRole(ProjectedRole, "admin")) ] } ]
+                    DataEntries = []
+                    Annotations = [] }
+
+              let specs = Frank.Statecharts.TransitionExtractor.extract doc
+              Expect.hasLength specs 1 "one transition"
+              let spec = specs.[0]
+
+              match spec.Constraint with
+              | Frank.Resources.Model.RestrictedTo roles ->
+                  Expect.equal roles [ "admin" ] "admin role extracted"
+              | Frank.Resources.Model.Unrestricted -> failtest "expected RestrictedTo"
+
+          testCase "extractRoles extracts from AlpsRole(ProjectedRole, _) doc annotations"
+          <| fun () ->
+              let doc: StatechartDocument =
+                  { Title = None
+                    InitialStateId = None
+                    Elements = []
+                    DataEntries = []
+                    Annotations =
+                      [ AlpsAnnotation(AlpsRole(ProjectedRole, "PlayerX,PlayerO,Spectator")) ] }
+
+              let roles = Frank.Statecharts.TransitionExtractor.extractRoles doc
+              Expect.hasLength roles 3 "three roles"
+              Expect.equal (roles |> List.map (fun r -> r.Name)) [ "PlayerX"; "PlayerO"; "Spectator" ] "role names"
+
+          testCase "extractRoles ignores AlpsRole(ProtocolState, _)"
+          <| fun () ->
+              let doc: StatechartDocument =
+                  { Title = None
+                    InitialStateId = None
+                    Elements = []
+                    DataEntries = []
+                    Annotations =
+                      [ AlpsAnnotation(AlpsRole(ProtocolState, "authenticated")) ] }
+
+              let roles = Frank.Statecharts.TransitionExtractor.extractRoles doc
+              Expect.isEmpty roles "ProtocolState roles not extracted as projected roles" ]

--- a/test/Frank.Statecharts.Tests/Frank.Statecharts.Tests.fsproj
+++ b/test/Frank.Statecharts.Tests/Frank.Statecharts.Tests.fsproj
@@ -45,6 +45,7 @@
     <Compile Include="Alps/JsonGeneratorTests.fs" />
     <Compile Include="Alps/RoundTripTests.fs" />
     <Compile Include="Alps/ExtensionClassificationTests.fs" />
+    <Compile Include="Alps/SubDuTests.fs" />
     <Compile Include="Alps/XmlGeneratorTests.fs" />
     <!-- Validation tests -->
     <Compile Include="Validation/StringDistanceTests.fs" />


### PR DESCRIPTION
## Summary

Replaces string `id` fields with typed sub-DUs for `AlpsRole` and `AlpsDuality` cases in `AlpsMeta`, giving consumers exhaustive pattern matching instead of string comparison.

Closes #167

## Requirements

- [x] `AlpsRoleKind` DU: `ProjectedRole | ProtocolState` — **IMPLEMENTED** (`Types.fs:80`)
- [x] `AlpsDualityKind` DU: `ClientObligation | AdvancesProtocol | DualOf | CutPoint` — **IMPLEMENTED** (`Types.fs:84`)
- [x] `AlpsRole of kind: AlpsRoleKind * value: string` — **IMPLEMENTED** (`Types.fs:92`)
- [x] `AlpsDuality of kind: AlpsDualityKind * value: string` — **IMPLEMENTED** (`Types.fs:97`)
- [x] Parser maps string constants → sub-DU kinds — **IMPLEMENTED** (`Classification.fs`)
- [x] Generator maps sub-DU kinds → string IDs for serialization — **IMPLEMENTED** (`GeneratorCommon.fs`)
- [x] All consuming pattern matches updated — **IMPLEMENTED** (`TransitionExtractor.fs`)
- [x] Existing round-trip tests pass — **VERIFIED** (2,355 tests, 0 failures)
- [x] 30 new sub-DU-specific tests — **VERIFIED** (`SubDuTests.fs`)

## Test plan

- [x] `dotnet build Frank.sln` — 0 errors
- [x] `dotnet test Frank.sln --filter "FullyQualifiedName!~Sample"` — 2,355 passed, 0 failed
- [x] `dotnet fantomas --check` on all changed src/ files — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)