### PR TITLE
feat: CLI dual commands (frank dual, --check-dual, --check-laws)

### DIFF
--- a/src/Frank.Cli.Core/Commands/DualCommand.fs
+++ b/src/Frank.Cli.Core/Commands/DualCommand.fs
@@ -1,0 +1,266 @@
+/// CLI command for generating client protocol duals and verifying dual consistency.
+///
+/// frank dual: Generate per-role client obligation annotations from a statechart.
+/// frank validate --check-dual: Verify dual consistency (deadlocks, session-complete placement).
+/// frank validate --check-laws: Verify algebraic composition laws via FsCheck.
+module Frank.Cli.Core.Commands.DualCommand
+
+open FsCheck
+open FsCheck.FSharp
+open Frank.Resources.Model
+open Frank.Statecharts
+open Frank.Statecharts.Dual
+
+// ---------------------------------------------------------------------------
+// Types for frank dual output
+// ---------------------------------------------------------------------------
+
+/// Flattened per-role annotation with state context for CLI output.
+type RoleDualAnnotation =
+    { State: string
+      Descriptor: string
+      Obligation: ClientObligation
+      AdvancesProtocol: bool
+      ChoiceGroupId: int option }
+
+/// Result of running 'frank dual' on a statechart.
+type DualExecuteResult =
+    {
+        /// Per-role flattened annotations keyed by role name.
+        RoleDuals: Map<string, RoleDualAnnotation list>
+        /// Non-final states where no role can advance the protocol.
+        ProtocolSinks: string list
+        /// Human-readable summary.
+        Summary: string
+    }
+
+// ---------------------------------------------------------------------------
+// Types for frank validate --check-dual
+// ---------------------------------------------------------------------------
+
+type DualIssue = { Severity: string; Message: string }
+
+type CheckDualResult =
+    { Issues: DualIssue list
+      IsConsistent: bool }
+
+// ---------------------------------------------------------------------------
+// Types for frank validate --check-laws
+// ---------------------------------------------------------------------------
+
+type LawCheckResult =
+    { Category: string
+      Name: string
+      Passed: bool
+      FailureMessage: string option }
+
+type CheckLawsResult =
+    { LawResults: LawCheckResult list
+      AllPassed: bool }
+
+// ---------------------------------------------------------------------------
+// frank dual: execute
+// ---------------------------------------------------------------------------
+
+/// Generate client protocol duals from a statechart.
+/// Runs projection + dual derivation and flattens to per-role annotations.
+let execute (statechart: ExtractedStatechart) : Result<DualExecuteResult, string> =
+    let projections = Projection.projectAll statechart
+    let deriveResult = derive statechart projections
+
+    let roleDuals =
+        deriveResult.Annotations
+        |> Map.toList
+        |> List.collect (fun ((role, state), annotations) ->
+            annotations
+            |> List.map (fun ann ->
+                role,
+                { State = state
+                  Descriptor = ann.Descriptor
+                  Obligation = ann.Obligation
+                  AdvancesProtocol = ann.AdvancesProtocol
+                  ChoiceGroupId = ann.ChoiceGroupId }))
+        |> List.groupBy fst
+        |> List.map (fun (role, pairs) -> role, pairs |> List.map snd)
+        |> Map.ofList
+
+    let roleCount = statechart.Roles.Length
+    let stateCount = statechart.StateNames.Length
+    let sinkCount = deriveResult.ProtocolSinks.Length
+
+    let sinkNote =
+        if sinkCount > 0 then
+            $"; %d{sinkCount} protocol sink(s) detected"
+        else
+            ""
+
+    let summary =
+        $"Derived client duals for %d{roleCount} role(s) across %d{stateCount} state(s)%s{sinkNote}"
+
+    Ok
+        { RoleDuals = roleDuals
+          ProtocolSinks = deriveResult.ProtocolSinks
+          Summary = summary }
+
+// ---------------------------------------------------------------------------
+// frank validate --check-dual
+// ---------------------------------------------------------------------------
+
+/// Verify dual consistency of a statechart.
+/// Checks: (1) no protocol sinks (deadlocks), (2) session-complete only at final states,
+/// (3) every must-select has a corresponding advancing transition.
+let checkDual (statechart: ExtractedStatechart) : Result<CheckDualResult, string> =
+    let projections = Projection.projectAll statechart
+    let deriveResult = derive statechart projections
+
+    let finalStates =
+        statechart.StateMetadata
+        |> Map.filter (fun _ info -> info.IsFinal)
+        |> Map.keys
+        |> Set.ofSeq
+
+    let issues = ResizeArray<DualIssue>()
+
+    // Check 1: protocol sinks (non-final states where no role can advance)
+    for sink in deriveResult.ProtocolSinks do
+        issues.Add(
+            { Severity = "error"
+              Message = $"Protocol sink (deadlock) at state '%s{sink}': no role can advance the protocol" }
+        )
+
+    // Check 2: session-complete only at final states
+    for KeyValue((role, state), annotations) in deriveResult.Annotations do
+        for ann in annotations do
+            if ann.Obligation = SessionComplete && not (Set.contains state finalStates) then
+                issues.Add(
+                    { Severity = "error"
+                      Message =
+                        $"session-complete at non-final state '%s{state}' for role '%s{role}' descriptor '%s{ann.Descriptor}'" }
+                )
+
+    // Check 3: every must-select has a corresponding advancing transition
+    for KeyValue((role, state), annotations) in deriveResult.Annotations do
+        for ann in annotations do
+            if ann.Obligation = MustSelect && not ann.AdvancesProtocol then
+                issues.Add(
+                    { Severity = "warning"
+                      Message =
+                        $"MustSelect obligation on '%s{ann.Descriptor}' in state '%s{state}' for role '%s{role}' does not advance the protocol" }
+                )
+
+    let issueList = issues |> Seq.toList
+
+    let hasErrors = issueList |> List.exists (fun i -> i.Severity = "error")
+
+    Ok
+        { Issues = issueList
+          IsConsistent = not hasErrors }
+
+// ---------------------------------------------------------------------------
+// frank validate --check-laws
+// ---------------------------------------------------------------------------
+
+/// Run a FsCheck property (as a thunk that throws on failure), returning a LawCheckResult.
+let private runProperty (category: string) (name: string) (check: unit -> unit) : LawCheckResult =
+    try
+        check ()
+
+        { Category = category
+          Name = name
+          Passed = true
+          FailureMessage = None }
+    with ex ->
+        { Category = category
+          Name = name
+          Passed = false
+          FailureMessage = Some ex.Message }
+
+/// Verify algebraic composition laws via FsCheck.
+/// Checks: GuardResult monoid laws (identity, associativity),
+/// TransitionResult functor laws (identity, composition).
+let checkLaws () : Result<CheckLawsResult, string> =
+    let genBlockReason: Gen<BlockReason> =
+        let defaultArbs = ArbMap.defaults
+
+        Gen.oneof
+            [ gen { return NotAllowed }
+              gen { return NotYourTurn }
+              gen { return InvalidTransition }
+              gen { return PreconditionFailed }
+              gen {
+                  let! code = (ArbMap.arbitrary<int> defaultArbs).Generator
+                  let! msg = (ArbMap.arbitrary<string> defaultArbs).Generator
+                  return Custom(code, msg)
+              } ]
+
+    let genGuardResult: Gen<GuardResult> =
+        Gen.oneof
+            [ gen { return Allowed }
+              gen {
+                  let! reason = genBlockReason
+                  return Blocked reason
+              } ]
+
+    let arbGuardResult: Arbitrary<GuardResult> = Arb.fromGen genGuardResult
+
+    let results = ResizeArray<LawCheckResult>()
+
+    // GuardResult monoid: left identity
+    results.Add(
+        runProperty "GuardResult monoid" "left identity" (fun () ->
+            Prop.forAll arbGuardResult (fun g -> GuardResult.compose GuardResult.identity g = g)
+            |> Check.QuickThrowOnFailure)
+    )
+
+    // GuardResult monoid: right identity
+    results.Add(
+        runProperty "GuardResult monoid" "right identity" (fun () ->
+            Prop.forAll arbGuardResult (fun g -> GuardResult.compose g GuardResult.identity = g)
+            |> Check.QuickThrowOnFailure)
+    )
+
+    // GuardResult monoid: associativity
+    results.Add(
+        runProperty "GuardResult monoid" "associativity" (fun () ->
+            Prop.forAll (Arb.fromGen (Gen.zip3 genGuardResult genGuardResult genGuardResult)) (fun (a, b, c) ->
+                let leftAssoc = GuardResult.compose (GuardResult.compose a b) c
+                let rightAssoc = GuardResult.compose a (GuardResult.compose b c)
+                leftAssoc = rightAssoc)
+            |> Check.QuickThrowOnFailure)
+    )
+
+    // TransitionResult functor: identity
+    results.Add(
+        runProperty "TransitionResult functor" "identity" (fun () ->
+            let check (s: string, c: int) =
+                let original = TransitionResult.Transitioned(s, c)
+                let mapped = TransitionResult.map id id original
+                mapped = original
+
+            Check.QuickThrowOnFailure check)
+    )
+
+    // TransitionResult functor: composition
+    results.Add(
+        runProperty "TransitionResult functor" "composition" (fun () ->
+            let check (s: string, c: int) =
+                let f (x: string) = x.Length
+                let g (n: int) = n * 2
+                let cf (x: int) = x + 1
+                let cg (x: int) = x * 3
+                let original = TransitionResult.Transitioned(s, c)
+                let composed = TransitionResult.map (f >> g) (cf >> cg) original
+
+                let sequential = original |> TransitionResult.map f cf |> TransitionResult.map g cg
+
+                composed = sequential
+
+            Check.QuickThrowOnFailure check)
+    )
+
+    let resultList = results |> Seq.toList
+    let allPassed = resultList |> List.forall (fun r -> r.Passed)
+
+    Ok
+        { LawResults = resultList
+          AllPassed = allPassed }

--- a/src/Frank.Cli.Core/Frank.Cli.Core.fsproj
+++ b/src/Frank.Cli.Core/Frank.Cli.Core.fsproj
@@ -59,6 +59,7 @@
     <Compile Include="Commands/StatusCommand.fs" />
     <Compile Include="Commands/StatechartExtractCommand.fs" />
     <Compile Include="Commands/StatechartGenerateCommand.fs" />
+    <Compile Include="Commands/DualCommand.fs" />
     <Compile Include="Commands/StatechartValidateCommand.fs" />
     <Compile Include="Commands/OpenApiValidateCommand.fs" />
     <Compile Include="Commands/StatechartParseCommand.fs" />
@@ -81,6 +82,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FsCheck" Version="3.3.2" />
     <PackageReference Include="dotNetRdf.Core" Version="3.5.1" />
     <PackageReference Include="dotNetRdf.Ontology" Version="3.5.1" />
     <PackageReference Include="dotNetRdf.Shacl" Version="3.5.1" />

--- a/test/Frank.Cli.Core.Tests/Commands/DualCommandTests.fs
+++ b/test/Frank.Cli.Core.Tests/Commands/DualCommandTests.fs
@@ -1,0 +1,387 @@
+module Frank.Cli.Core.Tests.DualCommandTests
+
+open Expecto
+open Frank.Resources.Model
+open Frank.Statecharts.Dual
+open Frank.Cli.Core.Commands.DualCommand
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let private mkTransition event source target guard roleConstraint =
+    { Event = event
+      Source = source
+      Target = target
+      Guard = guard
+      Constraint = roleConstraint }
+
+// ---------------------------------------------------------------------------
+// TicTacToe fixture
+// ---------------------------------------------------------------------------
+
+let private ticTacToeChart: ExtractedStatechart =
+    { RouteTemplate = "/games/{gameId}"
+      StateNames = [ "XTurn"; "OTurn"; "XWins"; "OWins"; "Draw" ]
+      InitialStateKey = "XTurn"
+      GuardNames = [ "TurnGuard" ]
+      StateMetadata =
+        Map.ofList
+            [ "XTurn",
+              { AllowedMethods = [ "GET"; "PUT" ]
+                IsFinal = false
+                Description = None }
+              "OTurn",
+              { AllowedMethods = [ "GET"; "PUT" ]
+                IsFinal = false
+                Description = None }
+              "XWins",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = true
+                Description = None }
+              "OWins",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = true
+                Description = None }
+              "Draw",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = true
+                Description = None } ]
+      Roles =
+        [ { Name = "PlayerX"
+            Description = Some "Player X" }
+          { Name = "PlayerO"
+            Description = Some "Player O" }
+          { Name = "Spectator"
+            Description = Some "Observer" } ]
+      Transitions =
+        [ mkTransition "getGame" "XTurn" "XTurn" None Unrestricted
+          mkTransition "getGame" "OTurn" "OTurn" None Unrestricted
+          mkTransition "getGame" "XWins" "XWins" None Unrestricted
+          mkTransition "getGame" "OWins" "OWins" None Unrestricted
+          mkTransition "getGame" "Draw" "Draw" None Unrestricted
+          mkTransition "makeMove" "XTurn" "OTurn" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "XTurn" "XWins" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "XTurn" "Draw" (Some "TurnGuard") (RestrictedTo [ "PlayerX" ])
+          mkTransition "makeMove" "OTurn" "XTurn" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ])
+          mkTransition "makeMove" "OTurn" "OWins" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ])
+          mkTransition "makeMove" "OTurn" "Draw" (Some "TurnGuard") (RestrictedTo [ "PlayerO" ]) ] }
+
+// ---------------------------------------------------------------------------
+// Order Fulfillment fixture
+// ---------------------------------------------------------------------------
+
+let private orderFulfillmentChart: ExtractedStatechart =
+    { RouteTemplate = "/orders/{orderId}"
+      StateNames =
+        [ "Submitted"
+          "Confirmed"
+          "Paid"
+          "Picking"
+          "Shipped"
+          "Completed"
+          "Cancelled" ]
+      InitialStateKey = "Submitted"
+      GuardNames = [ "SellerGuard"; "BuyerGuard"; "WarehouseGuard" ]
+      StateMetadata =
+        Map.ofList
+            [ "Submitted",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = false
+                Description = None }
+              "Confirmed",
+              { AllowedMethods = [ "GET"; "PUT" ]
+                IsFinal = false
+                Description = None }
+              "Paid",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = false
+                Description = None }
+              "Picking",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = false
+                Description = None }
+              "Shipped",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = false
+                Description = None }
+              "Completed",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = true
+                Description = None }
+              "Cancelled",
+              { AllowedMethods = [ "GET" ]
+                IsFinal = true
+                Description = None } ]
+      Roles =
+        [ { Name = "Buyer"; Description = None }
+          { Name = "Seller"; Description = None }
+          { Name = "Warehouse"
+            Description = None }
+          { Name = "Auditor"; Description = None } ]
+      Transitions =
+        [ mkTransition "viewOrder" "Submitted" "Submitted" None Unrestricted
+          mkTransition "confirmOrder" "Submitted" "Confirmed" (Some "SellerGuard") (RestrictedTo [ "Seller" ])
+          mkTransition "rejectOrder" "Submitted" "Cancelled" (Some "SellerGuard") (RestrictedTo [ "Seller" ])
+          mkTransition "viewOrder" "Confirmed" "Confirmed" None Unrestricted
+          mkTransition "submitPayment" "Confirmed" "Paid" (Some "BuyerGuard") (RestrictedTo [ "Buyer" ])
+          mkTransition "cancelOrder" "Confirmed" "Cancelled" (Some "BuyerGuard") (RestrictedTo [ "Buyer" ])
+          mkTransition "cancelBySeller" "Confirmed" "Cancelled" (Some "SellerGuard") (RestrictedTo [ "Seller" ])
+          mkTransition "viewOrder" "Paid" "Paid" None Unrestricted
+          mkTransition "beginPicking" "Paid" "Picking" (Some "WarehouseGuard") (RestrictedTo [ "Warehouse" ])
+          mkTransition "viewOrder" "Picking" "Picking" None Unrestricted
+          mkTransition "shipOrder" "Picking" "Shipped" (Some "WarehouseGuard") (RestrictedTo [ "Warehouse" ])
+          mkTransition "viewOrder" "Shipped" "Shipped" None Unrestricted
+          mkTransition "confirmDelivery" "Shipped" "Completed" (Some "SellerGuard") (RestrictedTo [ "Seller" ])
+          mkTransition "viewOrder" "Completed" "Completed" None Unrestricted
+          mkTransition "viewOrder" "Cancelled" "Cancelled" None Unrestricted ] }
+
+// ===========================================================================
+// frank dual -- execute tests
+// ===========================================================================
+
+[<Tests>]
+let dualCommandTests =
+    testList
+        "DualCommand.execute"
+        [ testCase "TicTacToe produces per-role annotations"
+          <| fun _ ->
+              let result = execute ticTacToeChart
+
+              Expect.isOk result "should succeed"
+
+              let dualResult =
+                  Result.defaultValue
+                      { RoleDuals = Map.empty
+                        ProtocolSinks = []
+                        Summary = "" }
+                      result
+
+              Expect.equal (dualResult.RoleDuals.Count) 3 "3 roles"
+              Expect.isTrue (dualResult.RoleDuals.ContainsKey "PlayerX") "has PlayerX"
+              Expect.isTrue (dualResult.RoleDuals.ContainsKey "PlayerO") "has PlayerO"
+              Expect.isTrue (dualResult.RoleDuals.ContainsKey "Spectator") "has Spectator"
+
+          testCase "TicTacToe PlayerX has MustSelect in XTurn"
+          <| fun _ ->
+              let result = execute ticTacToeChart
+
+              let dualResult =
+                  Result.defaultValue
+                      { RoleDuals = Map.empty
+                        ProtocolSinks = []
+                        Summary = "" }
+                      result
+
+              let playerXDuals = dualResult.RoleDuals |> Map.find "PlayerX"
+
+              let xTurnAnnotations = playerXDuals |> List.filter (fun a -> a.State = "XTurn")
+
+              let hasMustSelect =
+                  xTurnAnnotations
+                  |> List.exists (fun a -> a.Obligation = MustSelect && a.Descriptor = "makeMove")
+
+              Expect.isTrue hasMustSelect "PlayerX must-select makeMove in XTurn"
+
+          testCase "TicTacToe no protocol sinks"
+          <| fun _ ->
+              let result = execute ticTacToeChart
+
+              let dualResult =
+                  Result.defaultValue
+                      { RoleDuals = Map.empty
+                        ProtocolSinks = []
+                        Summary = "" }
+                      result
+
+              Expect.isEmpty dualResult.ProtocolSinks "no protocol sinks"
+
+          testCase "Order Fulfillment produces 4 role duals"
+          <| fun _ ->
+              let result = execute orderFulfillmentChart
+              Expect.isOk result "should succeed"
+
+              let dualResult =
+                  Result.defaultValue
+                      { RoleDuals = Map.empty
+                        ProtocolSinks = []
+                        Summary = "" }
+                      result
+
+              Expect.equal (dualResult.RoleDuals.Count) 4 "4 roles"
+
+          testCase "Order Fulfillment Auditor is observer-only (all MayPoll or SessionComplete)"
+          <| fun _ ->
+              let result = execute orderFulfillmentChart
+
+              let dualResult =
+                  Result.defaultValue
+                      { RoleDuals = Map.empty
+                        ProtocolSinks = []
+                        Summary = "" }
+                      result
+
+              let auditorDuals = dualResult.RoleDuals |> Map.find "Auditor"
+
+              let hasNoMustSelect =
+                  auditorDuals |> List.forall (fun a -> a.Obligation <> MustSelect)
+
+              Expect.isTrue hasNoMustSelect "Auditor should never have MustSelect"
+
+          testCase "Order Fulfillment Seller MustSelect in Submitted"
+          <| fun _ ->
+              let result = execute orderFulfillmentChart
+
+              let dualResult =
+                  Result.defaultValue
+                      { RoleDuals = Map.empty
+                        ProtocolSinks = []
+                        Summary = "" }
+                      result
+
+              let sellerDuals = dualResult.RoleDuals |> Map.find "Seller"
+
+              let submittedMustSelect =
+                  sellerDuals
+                  |> List.filter (fun a -> a.State = "Submitted" && a.Obligation = MustSelect)
+                  |> List.map (fun a -> a.Descriptor)
+                  |> Set.ofList
+
+              Expect.isTrue (Set.contains "confirmOrder" submittedMustSelect) "confirmOrder must-select"
+              Expect.isTrue (Set.contains "rejectOrder" submittedMustSelect) "rejectOrder must-select"
+
+          testCase "Order Fulfillment summary includes role count"
+          <| fun _ ->
+              let result = execute orderFulfillmentChart
+
+              let dualResult =
+                  Result.defaultValue
+                      { RoleDuals = Map.empty
+                        ProtocolSinks = []
+                        Summary = "" }
+                      result
+
+              Expect.stringContains dualResult.Summary "4" "summary mentions 4 roles"
+
+          testCase "empty roles chart returns empty duals"
+          <| fun _ ->
+              let emptyChart = { ticTacToeChart with Roles = [] }
+              let result = execute emptyChart
+              Expect.isOk result "should succeed"
+
+              let dualResult =
+                  Result.defaultValue
+                      { RoleDuals = Map.empty
+                        ProtocolSinks = []
+                        Summary = "" }
+                      result
+
+              Expect.isTrue (Map.isEmpty dualResult.RoleDuals) "no roles = no duals" ]
+
+// ===========================================================================
+// frank validate --check-dual tests
+// ===========================================================================
+
+[<Tests>]
+let checkDualTests =
+    testList
+        "DualCommand.checkDual"
+        [ testCase "valid TicTacToe protocol passes check-dual"
+          <| fun _ ->
+              let result = checkDual ticTacToeChart
+              Expect.isOk result "should succeed"
+
+              let checkResult = Result.defaultValue { Issues = []; IsConsistent = true } result
+
+              Expect.isTrue checkResult.IsConsistent "consistent protocol"
+              Expect.isEmpty checkResult.Issues "no issues"
+
+          testCase "valid OrderFulfillment protocol passes check-dual"
+          <| fun _ ->
+              let result = checkDual orderFulfillmentChart
+              Expect.isOk result "should succeed"
+
+              let checkResult = Result.defaultValue { Issues = []; IsConsistent = true } result
+
+              Expect.isTrue checkResult.IsConsistent "consistent protocol"
+
+          testCase "protocol with deadlock reports error"
+          <| fun _ ->
+              // Remove beginPicking from Paid -> deadlock
+              let deadlockChart =
+                  { orderFulfillmentChart with
+                      Transitions =
+                          orderFulfillmentChart.Transitions
+                          |> List.filter (fun t -> t.Event <> "beginPicking") }
+
+              let result = checkDual deadlockChart
+              Expect.isOk result "should not fail"
+
+              let checkResult = Result.defaultValue { Issues = []; IsConsistent = true } result
+
+              Expect.isFalse checkResult.IsConsistent "deadlock makes it inconsistent"
+
+              let hasDeadlockIssue =
+                  checkResult.Issues |> List.exists (fun i -> i.Message.Contains("Paid"))
+
+              Expect.isTrue hasDeadlockIssue "should mention Paid as protocol sink"
+
+          testCase "terminal states have session-complete obligations only"
+          <| fun _ ->
+              let result = checkDual ticTacToeChart
+
+              let checkResult = Result.defaultValue { Issues = []; IsConsistent = true } result
+
+              // No issue about session-complete at non-final states
+              let hasSessionCompleteAtNonFinal =
+                  checkResult.Issues
+                  |> List.exists (fun i -> i.Message.Contains("session-complete at non-final"))
+
+              Expect.isFalse hasSessionCompleteAtNonFinal "no session-complete at non-final states" ]
+
+// ===========================================================================
+// frank validate --check-laws tests
+// ===========================================================================
+
+[<Tests>]
+let checkLawsTests =
+    testList
+        "DualCommand.checkLaws"
+        [ testCase "guard monoid laws pass"
+          <| fun _ ->
+              let result = checkLaws ()
+              Expect.isOk result "should succeed"
+
+              let lawsResult = Result.defaultValue { LawResults = []; AllPassed = true } result
+
+              let guardLaws =
+                  lawsResult.LawResults
+                  |> List.filter (fun l -> l.Category = "GuardResult monoid")
+
+              Expect.isNonEmpty guardLaws "should check guard monoid laws"
+
+              for law in guardLaws do
+                  Expect.isTrue law.Passed $"guard monoid law '{law.Name}' should pass"
+
+          testCase "TransitionResult functor laws pass"
+          <| fun _ ->
+              let result = checkLaws ()
+
+              let lawsResult = Result.defaultValue { LawResults = []; AllPassed = true } result
+
+              let functorLaws =
+                  lawsResult.LawResults
+                  |> List.filter (fun l -> l.Category = "TransitionResult functor")
+
+              Expect.isNonEmpty functorLaws "should check functor laws"
+
+              for law in functorLaws do
+                  Expect.isTrue law.Passed $"functor law '{law.Name}' should pass"
+
+          testCase "all laws pass overall"
+          <| fun _ ->
+              let result = checkLaws ()
+
+              let lawsResult = Result.defaultValue { LawResults = []; AllPassed = true } result
+
+              Expect.isTrue lawsResult.AllPassed "all algebraic laws should pass" ]

--- a/test/Frank.Cli.Core.Tests/Frank.Cli.Core.Tests.fsproj
+++ b/test/Frank.Cli.Core.Tests/Frank.Cli.Core.Tests.fsproj
@@ -27,6 +27,7 @@
     <Compile Include="Commands/ClarifyCommandTests.fs" />
     <Compile Include="Commands/ValidateCommandTests.fs" />
     <Compile Include="Commands/DiffCommandTests.fs" />
+    <Compile Include="Commands/DualCommandTests.fs" />
     <Compile Include="Commands/CompileCommandTests.fs" />
     <Compile Include="Output/JsonOutputTests.fs" />
     <Compile Include="Output/TextOutputTests.fs" />
@@ -45,6 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FsCheck" Version="3.3.2" />
     <PackageReference Include="MessagePack" Version="3.1.4" />
     <PackageReference Include="MessagePack.FSharpExtensions" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />


### PR DESCRIPTION
## Summary

Adds CLI commands for session type duality: derive client obligations, validate dual consistency, and verify algebraic laws via FsCheck.

Closes #181

## Requirements

- [x] **frank dual** — derives per-role client obligations from statechart
- [x] **frank validate --check-dual** — validates protocol sinks, session-complete placement
- [x] **frank validate --check-laws** — FsCheck property tests for guard monoid + TransitionResult functor laws
- [x] **TicTacToe + Order Fulfillment tests** — 15 tests covering both fixtures

## Test plan

- [x] `dotnet build Frank.sln` — 0 errors
- [x] `dotnet test` — 2,541 pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)