### PR TITLE
fix: Wave 4 expert review — Link header URIs, middleware allocation, hierarchy perf

### DIFF
--- a/src/Frank.Statecharts/Affordances/DualProfileMiddleware.fs
+++ b/src/Frank.Statecharts/Affordances/DualProfileMiddleware.fs
@@ -17,6 +17,9 @@ open Frank.Statecharts
 /// - Adds `Vary: Prefer` so caches distinguish dual from non-dual responses
 type DualProfileMiddleware(next: RequestDelegate, dualLookup: DualProfileLookup) =
 
+    /// Pre-computed StringValues for Preference-Applied header (avoids per-request allocation).
+    static let preferenceAppliedValue = StringValues("return=dual")
+
     member _.Invoke(ctx: HttpContext) : Task =
         let endpoint = ctx.GetEndpoint()
 
@@ -39,47 +42,39 @@ type DualProfileMiddleware(next: RequestDelegate, dualLookup: DualProfileLookup)
                         let roles = ctx.GetRoles()
 
                         if not (Set.isEmpty roles) then
-                            // Get current statechart state
-                            let stateKey =
-                                let f = ctx.Features.Get<IStatechartFeature>()
+                            // Get current statechart state via idiomatic Option chain
+                            let stateKeyOpt = ctx.GetStatechartFeature() |> Option.bind (fun f -> f.StateKey)
 
-                                if obj.ReferenceEquals(f, null) then
-                                    null
-                                else
-                                    match f.StateKey with
-                                    | Some key -> key
-                                    | None -> null
-
-                            if not (isNull stateKey) then
+                            match stateKeyOpt with
+                            | Some stateKey ->
                                 match stateDict.TryGetValue(stateKey) with
                                 | true, roleDict ->
-                                    // First matching role wins (alphabetical via Set iteration)
-                                    let dualMatch =
+                                    // Sort roles explicitly for deterministic selection
+                                    // (F# Set iterates in order, but explicit sort documents the contract)
+                                    let dualEntry =
                                         roles
+                                        |> Seq.sort
                                         |> Seq.tryPick (fun role ->
                                             match roleDict.TryGetValue(role) with
-                                            | true, _alpsJson -> Some role
+                                            | true, entry -> Some entry
                                             | false, _ -> None)
 
-                                    match dualMatch with
-                                    | Some matchedRole ->
-                                        // Swap profile link to dual variant
+                                    match dualEntry with
+                                    | Some entry ->
+                                        // Swap profile link to dual variant using pre-computed Link header value
                                         let existingLinks = ctx.Response.Headers["Link"]
 
                                         if existingLinks.Count > 0 then
-                                            let dualLinkValue =
-                                                sprintf
-                                                    "<%s-%s-dual>; rel=\"profile\""
-                                                    (matchedRole.ToLowerInvariant())
-                                                    stateKey
-
                                             ctx.Response.Headers["Link"] <-
-                                                LinkHeaderRewriter.replaceProfileLink existingLinks dualLinkValue
+                                                LinkHeaderRewriter.replaceProfileLink
+                                                    existingLinks
+                                                    entry.LinkHeaderValue
 
                                         // RFC 7240: indicate the preference was applied
-                                        ctx.Response.Headers["Preference-Applied"] <- StringValues("return=dual")
+                                        ctx.Response.Headers["Preference-Applied"] <- preferenceAppliedValue
                                     | None -> ()
                                 | false, _ -> ()
+                            | None -> ()
                 | false, _ -> ()
 
         next.Invoke(ctx)

--- a/src/Frank.Statecharts/Affordances/DualProfileOverlay.fs
+++ b/src/Frank.Statecharts/Affordances/DualProfileOverlay.fs
@@ -8,12 +8,23 @@ open System.Text.Json
 open Frank.Resources.Model
 open Frank.Statecharts.Dual
 
-/// Pre-computed dual profile lookup: route template -> state -> role -> ALPS JSON.
+/// Pre-computed entry for a single (route, state, role) dual profile.
+/// Contains both the ALPS JSON content and the pre-formatted Link header value.
+type DualProfileEntry =
+    {
+        /// ALPS JSON string with duality annotations for serving content.
+        AlpsJson: string
+        /// Pre-formatted RFC 8288 Link header value (e.g., '<https://example.com/alps/orders-seller-Submitted-dual>; rel="profile"').
+        /// Built at startup so the middleware writes a cached string with zero per-request allocation.
+        LinkHeaderValue: string
+    }
+
+/// Pre-computed dual profile lookup: route template -> state -> role -> DualProfileEntry.
 /// Outer key: route template (e.g., "/orders/{orderId}")
 /// Middle key: state name (e.g., "Submitted")
 /// Inner key: role name (case-insensitive via OrdinalIgnoreCase comparer)
-/// Value: ALPS JSON string with duality annotations
-type DualProfileLookup = Dictionary<string, Dictionary<string, Dictionary<string, string>>>
+/// Value: DualProfileEntry with ALPS JSON and pre-computed Link header value
+type DualProfileLookup = Dictionary<string, Dictionary<string, Dictionary<string, DualProfileEntry>>>
 
 /// Parsing for RFC 7240 Prefer header values.
 module PreferHeader =
@@ -165,6 +176,7 @@ module DualProfileOverlay =
 
     /// Build a DualProfileLookup from a single ExtractedStatechart.
     /// Derives client duals via Dual.derive and generates ALPS JSON for each (role, state) pair.
+    /// Pre-computes Link header values at startup for zero per-request allocation.
     let buildFromStatechart (chart: ExtractedStatechart) (resourceSlug: string) (baseUri: string) : DualProfileLookup =
         let lookup = DualProfileLookup(StringComparer.Ordinal)
 
@@ -175,18 +187,29 @@ module DualProfileOverlay =
             let deriveResult = derive chart projections
 
             let stateDict =
-                Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal)
+                Dictionary<string, Dictionary<string, DualProfileEntry>>(StringComparer.Ordinal)
 
             for (roleName, stateName), annotations in deriveResult.Annotations |> Map.toSeq do
                 if not (List.isEmpty annotations) then
                     let alpsJson =
                         DualAlpsGenerator.generate annotations resourceSlug roleName stateName baseUri
 
+                    let roleLower = roleName.ToLowerInvariant()
+                    let dualSlug = sprintf "%s-%s-%s-dual" resourceSlug roleLower stateName
+                    let profileUrl = AffordanceMap.profileUrl baseUri dualSlug
+                    let linkHeaderValue = AffordancePreCompute.formatLinkValue profileUrl "profile"
+
+                    let entry =
+                        { AlpsJson = alpsJson
+                          LinkHeaderValue = linkHeaderValue }
+
                     match stateDict.TryGetValue(stateName) with
-                    | true, roleDict -> roleDict.[roleName] <- alpsJson
+                    | true, roleDict -> roleDict.[roleName] <- entry
                     | false, _ ->
-                        let roleDict = Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-                        roleDict.[roleName] <- alpsJson
+                        let roleDict =
+                            Dictionary<string, DualProfileEntry>(StringComparer.OrdinalIgnoreCase)
+
+                        roleDict.[roleName] <- entry
                         stateDict.[stateName] <- roleDict
 
             if stateDict.Count > 0 then
@@ -194,7 +217,7 @@ module DualProfileOverlay =
 
             lookup
 
-    /// Build a DualProfileLookup from a RuntimeState.
+    /// Build a DualProfileLookup from a list of UnifiedResources.
     /// Merges dual profiles from all resources that have statecharts with roles.
     let buildFromRuntimeState (resources: UnifiedResource list) (baseUri: string) : DualProfileLookup =
         let merged = DualProfileLookup(StringComparer.Ordinal)

--- a/src/Frank.Statecharts/Hierarchy.fs
+++ b/src/Frank.Statecharts/Hierarchy.fs
@@ -387,7 +387,8 @@ module HierarchicalRuntime =
                 config
 
         // Entry phase: add states to configuration, recursively entering composites.
-        // Accumulate entered states in reverse to avoid O(n^2) list concatenation.
+        // Accumulate entered states in reverse using cons-based accumulation
+        // to avoid O(n^2) list concatenation from List.rev + append.
         let configAfterEntry, enteredStatesRev =
             entryStates
             |> List.fold
@@ -395,8 +396,11 @@ module HierarchicalRuntime =
                     let before = ActiveStateConfiguration.toSet currentConfig
                     let nextConfig = enterState hierarchy entryState currentConfig
                     let after = ActiveStateConfiguration.toSet nextConfig
-                    let newlyEntered = Set.difference after before |> Set.toList
-                    (nextConfig, List.rev newlyEntered @ accRev))
+                    let newlyEntered = Set.difference after before
+
+                    let nextAccRev = Set.fold (fun acc s -> s :: acc) accRev newlyEntered
+
+                    (nextConfig, nextAccRev))
                 (configAfterExit, [])
 
         { Configuration = configAfterEntry

--- a/test/Frank.Statecharts.Tests/Affordances/DualProfileMiddlewareTests.fs
+++ b/test/Frank.Statecharts.Tests/Affordances/DualProfileMiddlewareTests.fs
@@ -21,18 +21,22 @@ open Frank.Affordances.Tests.AffordanceTestHelpers
 // -- Helpers --
 
 /// Build a test DualProfileLookup.
-let private buildDualLookup (entries: (string * (string * (string * string) list) list) list) : DualProfileLookup =
+let private buildDualLookup
+    (entries: (string * (string * (string * (string * string)) list) list) list)
+    : DualProfileLookup =
     let lookup = DualProfileLookup(StringComparer.Ordinal)
 
     for routeTemplate, states in entries do
         let stateDict =
-            Dictionary<string, Dictionary<string, string>>(StringComparer.Ordinal)
+            Dictionary<string, Dictionary<string, DualProfileEntry>>(StringComparer.Ordinal)
 
         for state, roles in states do
-            let roleDict = Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            let roleDict = Dictionary<string, DualProfileEntry>(StringComparer.OrdinalIgnoreCase)
 
-            for roleName, alpsJson in roles do
-                roleDict.[roleName] <- alpsJson
+            for roleName, (alpsJson, linkHeaderValue) in roles do
+                roleDict.[roleName] <-
+                    { AlpsJson = alpsJson
+                      LinkHeaderValue = linkHeaderValue }
 
             stateDict.[state] <- roleDict
 
@@ -40,11 +44,17 @@ let private buildDualLookup (entries: (string * (string * (string * string) list
 
     lookup
 
-/// Sample dual ALPS JSON for tests.
-let private sampleDualAlpsJson role state =
-    sprintf
-        """{"alps":{"version":"1.0","descriptor":[{"id":"%s","type":"semantic","ext":[{"id":"https://frank-fs.github.io/alps-ext/clientObligation","value":"must-select"}]}]}}"""
-        (sprintf "%s-%s-dual" role state)
+/// Sample dual ALPS JSON and Link header value for tests.
+let private sampleDualEntry role state =
+    let alpsJson =
+        sprintf
+            """{"alps":{"version":"1.0","descriptor":[{"id":"%s","type":"semantic","ext":[{"id":"https://frank-fs.github.io/alps-ext/clientObligation","value":"must-select"}]}]}}"""
+            (sprintf "%s-%s-dual" role state)
+
+    let linkHeaderValue =
+        sprintf "<https://example.com/alps/games-%s-%s-dual>; rel=\"profile\"" role state
+
+    (alpsJson, linkHeaderValue)
 
 /// Run a test against a server with AffordanceMiddleware, ProjectedProfileMiddleware, and DualProfileMiddleware.
 let private withDualServer
@@ -106,11 +116,11 @@ let private gamesDualLookup =
     buildDualLookup
         [ "/games/{gameId}",
           [ "XTurn",
-            [ "playerx", sampleDualAlpsJson "playerx" "XTurn"
-              "playero", sampleDualAlpsJson "playero" "XTurn" ]
+            [ "playerx", sampleDualEntry "playerx" "XTurn"
+              "playero", sampleDualEntry "playero" "XTurn" ]
             "OTurn",
-            [ "playerx", sampleDualAlpsJson "playerx" "OTurn"
-              "playero", sampleDualAlpsJson "playero" "OTurn" ] ] ]
+            [ "playerx", sampleDualEntry "playerx" "OTurn"
+              "playero", sampleDualEntry "playero" "OTurn" ] ] ]
 
 // -- Tests --
 
@@ -407,7 +417,16 @@ let dualProfileOverlayBuildTests =
 
               // The dual ALPS JSON should contain clientObligation annotation
               let sellerDual = submittedRoles.["Seller"]
-              Expect.isTrue (sellerDual.Contains("clientObligation")) "Dual should contain clientObligation"
+              Expect.isTrue (sellerDual.AlpsJson.Contains("clientObligation")) "Dual should contain clientObligation"
+
+              // The pre-computed Link header value should be a valid URI
+              Expect.isTrue
+                  (sellerDual.LinkHeaderValue.StartsWith("<https://"))
+                  "Link header value should start with valid URI"
+
+              Expect.isTrue
+                  (sellerDual.LinkHeaderValue.Contains("dual"))
+                  "Link header value should reference dual profile"
 
           testCase "empty roles produces empty lookup"
           <| fun _ ->
@@ -523,11 +542,11 @@ let orderFulfillmentDualIntegrationTests =
 
               // Parse and verify the dual ALPS JSON contains obligation annotations
               Expect.isTrue
-                  (sellerSubmitted.Contains("must-select"))
+                  (sellerSubmitted.AlpsJson.Contains("must-select"))
                   "Seller in Submitted should have must-select obligation (confirmOrder advances protocol)"
 
               Expect.isTrue
-                  (sellerSubmitted.Contains("advancesProtocol"))
+                  (sellerSubmitted.AlpsJson.Contains("advancesProtocol"))
                   "Seller in Submitted should have advancesProtocol annotation"
 
           testCase "Buyer in Submitted gets may-poll obligation only"
@@ -597,6 +616,10 @@ let orderFulfillmentDualIntegrationTests =
               let buyerSubmitted = stateDict.["Submitted"].["Buyer"]
 
               // Buyer in Submitted is observer: only may-poll
-              Expect.isTrue (buyerSubmitted.Contains("may-poll")) "Buyer in Submitted should have may-poll obligation"
+              Expect.isTrue
+                  (buyerSubmitted.AlpsJson.Contains("may-poll"))
+                  "Buyer in Submitted should have may-poll obligation"
 
-              Expect.isFalse (buyerSubmitted.Contains("must-select")) "Buyer in Submitted should NOT have must-select" ]
+              Expect.isFalse
+                  (buyerSubmitted.AlpsJson.Contains("must-select"))
+                  "Buyer in Submitted should NOT have must-select" ]


### PR DESCRIPTION
## Summary

Addresses expert review findings on merged Wave 4 code (PRs #230-#233).

## Findings Fixed

| Finding | Expert | Severity | Fix |
|---------|--------|----------|-----|
| C5: Invalid Link header URI (RFC 8288) | Fielding | Critical | Pre-compute full URI in `DualProfileEntry.LinkHeaderValue` at startup |
| C7: String allocation per-request | @7sharp9 | Critical | Pre-compute Link values + `preferenceAppliedValue` static field |
| I7: O(n²) list concat in entry phase | @7sharp9 | Important | `Set.fold` with cons replaces `List.rev @ accRev` |
| I8: Null vs Option mixing | @7sharp9 | Important | Idiomatic `Option.bind` chain via `GetStatechartFeature()` |
| I9: Non-deterministic role selection | Fielding | Important | Explicit `Seq.sort` before `Seq.tryPick` |

## Changes
- `DualProfileMiddleware.fs`: Zero-alloc request path, Option-based state lookup, sorted role selection
- `DualProfileOverlay.fs`: New `DualProfileEntry` type with pre-computed `LinkHeaderValue`, changed `DualProfileLookup` value type
- `Hierarchy.fs`: Cons-based accumulation in entry phase
- `DualProfileMiddlewareTests.fs`: Updated for `DualProfileEntry` type

## Test plan
- [ ] Verify `dotnet build Frank.sln` passes
- [ ] Verify all tests pass
- [ ] Verify Link header contains full URI (not bare token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)