### PR TITLE
fix: enterState must include all ancestors up to root (#265)

### DIFF
--- a/sample/Frank.OrderFulfillment.Sample/test-e2e.sh
+++ b/sample/Frank.OrderFulfillment.Sample/test-e2e.sh
@@ -57,6 +57,23 @@ check_body_exact() {
     fi
 }
 
+# Check that a state name is an exact member of the config= field.
+# Extracts config= up to the next semicolon, wraps in commas, and matches ,<name>,
+# to avoid substring false positives (e.g., "Order" matching "orderId").
+check_config() {
+    local label="$1" url="$2" expected="$3"
+    local actual config
+    actual=$(curl -s "$url" 2>/dev/null)
+    config=$(echo "$actual" | grep -o 'config=[^;]*' | sed 's/config=//')
+    if echo ",$config," | grep -q ",$expected,"; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (expected '$expected' as member of config='$config')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
 check_log_contains() {
     local label="$1" expected="$2"
     if grep -q "$expected" "$SERVER_LOG"; then
@@ -187,10 +204,11 @@ curl -s -X POST "$BASE/orders/o3" > /dev/null         # Pending → Authorize
 sleep 1
 
 # Config should show full ancestor chain: Order, Processing, Payment, Authorize
-check_body   "AT4: config includes Order"       "$BASE/orders/o3" "Order"
-check_body   "AT4: config includes Processing"  "$BASE/orders/o3" "Processing"
-check_body   "AT4: config includes Payment"     "$BASE/orders/o3" "Payment"
-check_body   "AT4: config includes Authorize"   "$BASE/orders/o3" "Authorize"
+# Use check_config for exact member matching — avoids "Order" matching "orderId" (issue #265)
+check_config "AT4: config includes Order"       "$BASE/orders/o3" "Order"
+check_config "AT4: config includes Processing"  "$BASE/orders/o3" "Processing"
+check_config "AT4: config includes Payment"     "$BASE/orders/o3" "Payment"
+check_config "AT4: config includes Authorize"   "$BASE/orders/o3" "Authorize"
 check_body   "AT4: state is Authorize"          "$BASE/orders/o3" "state=Authorize"
 
 echo ""

--- a/src/Frank.Statecharts/Hierarchy.fs
+++ b/src/Frank.Statecharts/Hierarchy.fs
@@ -303,14 +303,29 @@ module HierarchicalRuntime =
     let private allDescendants (hierarchy: StateHierarchy) (stateId: string) : string list =
         Map.tryFind stateId hierarchy.DescendantMap |> Option.defaultValue []
 
+    /// Add all ancestors of a state up to the root to the active configuration.
+    /// Harel semantics: a state is active iff it or any descendant is the current atomic state;
+    /// all ancestors must be in the active configuration.
+    let private addAncestors (hierarchy: StateHierarchy) (stateId: string) (config: ActiveStateConfiguration) =
+        let rec loop current config =
+            match Map.tryFind current hierarchy.ParentMap with
+            | Some parent -> loop parent (ActiveStateConfiguration.add parent config)
+            | None -> config
+
+        loop stateId config
+
     /// Enter a state, recursively activating initial children for composite states.
     /// For AND composites, all children are entered. For XOR, only the initial child.
     /// Enforces XOR exclusivity: entering a child of an XOR composite deactivates siblings.
+    /// Adds all ancestors up to root per Harel semantics (issue #265).
     let rec enterState
         (hierarchy: StateHierarchy)
         (stateId: string)
         (config: ActiveStateConfiguration)
         : ActiveStateConfiguration =
+        // Harel semantics: all ancestors must be in the active configuration
+        let config = addAncestors hierarchy stateId config
+
         // Enforce XOR exclusivity: if parent is XOR, deactivate sibling children and their descendants
         let config =
             match Map.tryFind stateId hierarchy.ParentMap with
@@ -489,6 +504,9 @@ module HierarchicalRuntime =
         (config: ActiveStateConfiguration)
         (history: HistoryRecord)
         : ActiveStateConfiguration =
+        // Harel semantics: all ancestors must be in the active configuration,
+        // even on degenerate paths where no child enterState call occurs (issue #265).
+        let config = addAncestors hierarchy compositeStateId config
         let config = ActiveStateConfiguration.add compositeStateId config
 
         match HistoryRecord.tryGet compositeStateId history with

--- a/test/Frank.Statecharts.Tests/HierarchyTests.fs
+++ b/test/Frank.Statecharts.Tests/HierarchyTests.fs
@@ -1186,6 +1186,156 @@ let xorExclusivityTests =
               Expect.equal activeChildren.Head TrafficLight.yellow "That child is Yellow" ]
 
 // ==========================================================================
+// Issue #265: enterState must include all ancestors up to root
+//
+// Hierarchy: Order > Processing > Payment > Authorize
+//            Order > Pending (initial)
+//
+// Harel semantics: a state is active iff it or any descendant is the
+// current atomic state. All ancestors must be in the active configuration.
+// ==========================================================================
+
+/// State identifiers for the order fulfillment hierarchy (issue #265).
+[<RequireQualifiedAccess>]
+module OrderFulfillment =
+    let order = "Order"
+    let pending = "Pending"
+    let processing = "Processing"
+    let payment = "Payment"
+    let authorize = "Authorize"
+
+/// Build the order fulfillment hierarchy used by issue #265 tests.
+let private orderHierarchy =
+    StateHierarchy.build
+        { States =
+            [ { Id = OrderFulfillment.order
+                Kind = CompositeKind.XOR
+                Children = [ OrderFulfillment.pending; OrderFulfillment.processing ]
+                InitialChild = Some OrderFulfillment.pending
+                CompletionTarget = None }
+              { Id = OrderFulfillment.processing
+                Kind = CompositeKind.XOR
+                Children = [ OrderFulfillment.payment ]
+                InitialChild = Some OrderFulfillment.payment
+                CompletionTarget = None }
+              { Id = OrderFulfillment.payment
+                Kind = CompositeKind.XOR
+                Children = [ OrderFulfillment.authorize ]
+                InitialChild = Some OrderFulfillment.authorize
+                CompletionTarget = None } ] }
+
+[<Tests>]
+let enterStateAncestorTests =
+    testList
+        "Issue #265: enterState includes all ancestors"
+        [
+          // Acceptance test 1: Initial entry includes root
+          testCase "initial entry into Pending includes Order (root)"
+          <| fun () ->
+              let config =
+                  HierarchicalRuntime.enterState orderHierarchy OrderFulfillment.pending ActiveStateConfiguration.empty
+
+              let active = ActiveStateConfiguration.toSet config
+
+              Expect.isTrue
+                  (Set.contains OrderFulfillment.order active)
+                  "Order (root) must be in active config when entering Pending"
+
+              Expect.isTrue
+                  (Set.contains OrderFulfillment.pending active)
+                  "Pending must be in active config"
+
+              Expect.equal active (Set.ofList [ OrderFulfillment.order; OrderFulfillment.pending ]) "Active config = {Order, Pending}"
+
+          // Acceptance test 2: Transition preserves full ancestor chain
+          testCase "transition Pending → Authorize includes all four ancestors"
+          <| fun () ->
+              // Start with initial entry into Pending
+              let initialConfig =
+                  HierarchicalRuntime.enterState orderHierarchy OrderFulfillment.pending ActiveStateConfiguration.empty
+
+              // Transition Pending → Authorize
+              let result =
+                  HierarchicalRuntime.transition
+                      orderHierarchy
+                      initialConfig
+                      OrderFulfillment.pending
+                      OrderFulfillment.authorize
+                      HistoryRecord.empty
+
+              let active = ActiveStateConfiguration.toSet result.Configuration
+
+              Expect.equal
+                  active
+                  (Set.ofList
+                      [ OrderFulfillment.order
+                        OrderFulfillment.processing
+                        OrderFulfillment.payment
+                        OrderFulfillment.authorize ])
+                  "Active config = {Order, Processing, Payment, Authorize}"
+
+          // Acceptance test 3: Root never absent from active config
+          testCase "Order is always in active config for any reachable state"
+          <| fun () ->
+              // Test every reachable atomic state
+              let allAtomicStates =
+                  [ OrderFulfillment.pending; OrderFulfillment.authorize ]
+
+              for atomicState in allAtomicStates do
+                  let config =
+                      HierarchicalRuntime.enterState orderHierarchy atomicState ActiveStateConfiguration.empty
+
+                  Expect.isTrue
+                      (ActiveStateConfiguration.isActive OrderFulfillment.order config)
+                      (sprintf "Order must be active when in state %s" atomicState)
+
+          // Harel finding 5: enterWithHistory must include ancestors even on
+          // degenerate path where no child enterState call occurs.
+          // Shallow history on a composite with no matching child AND no initial child
+          // returns without calling enterState — ancestors would be missing.
+          testCase "enterWithHistory includes ancestors on degenerate shallow path"
+          <| fun () ->
+              // Root (XOR) > Inner (XOR, no initial child, no children in history)
+              let hierarchy =
+                  StateHierarchy.build
+                      { States =
+                          [ { Id = "Root"
+                              Kind = CompositeKind.XOR
+                              Children = [ "Inner"; "Other" ]
+                              InitialChild = Some "Inner"
+                              CompletionTarget = None }
+                            { Id = "Inner"
+                              Kind = CompositeKind.XOR
+                              Children = [ "A"; "B" ]
+                              // No initial child — degenerate
+                              InitialChild = None
+                              CompletionTarget = None } ] }
+
+              // Fabricate a history record where Inner's recorded config has a state
+              // that is NOT a current child of Inner (simulates stale/empty match)
+              let staleHistory =
+                  HistoryRecord.record "Inner" ActiveStateConfiguration.empty HistoryRecord.empty
+
+              // enterWithHistory on Inner from empty config with stale history:
+              // shallow history finds no matching child, no initial child → returns early
+              let restored =
+                  HierarchicalRuntime.enterWithHistory
+                      hierarchy
+                      HistoryKind.Shallow
+                      "Inner"
+                      ActiveStateConfiguration.empty
+                      staleHistory
+
+              // Root must still be in config — enterWithHistory must add ancestors
+              Expect.isTrue
+                  (ActiveStateConfiguration.isActive "Root" restored)
+                  "Root must be in config even on degenerate enterWithHistory path"
+
+              Expect.isTrue
+                  (ActiveStateConfiguration.isActive "Inner" restored)
+                  "Inner must be in config" ]
+
+// ==========================================================================
 // Composite StateKind in AST
 // ==========================================================================
 


### PR DESCRIPTION
## Summary

Fixes Harel semantics violation where `enterState` only added states on the entry path, permanently omitting ancestors above the LCA from the active configuration.

- **`addAncestors` helper** walks `ParentMap` to root — called at top of both `enterState` and `enterWithHistory`
- **`enterWithHistory` defensive fix** covers degenerate path where no child `enterState` call occurs (shallow history with no matching child and no initial child)
- **E2E AT4 false positive fix** — new `check_config` helper does exact member matching on the `config=` field, replacing `check_body` substring match that confused "Order" with "orderId"

## Requirements from #265

| Requirement | Status | Evidence |
|-------------|--------|----------|
| Initial entry includes root | Implemented | Test: "initial entry into Pending includes Order (root)" — asserts config = {Order, Pending} |
| Transition preserves full ancestor chain | Implemented | Test: "transition Pending → Authorize includes all four ancestors" — asserts config = {Order, Processing, Payment, Authorize} |
| Root never absent from active config | Implemented | Test: "Order is always in active config for any reachable state" — iterates all atomic states |
| enterWithHistory degenerate path (Harel finding 5) | Implemented | Test: "enterWithHistory includes ancestors on degenerate shallow path" — stale history, no initial child |

## Verified results

```
Unit tests: 2,526 passed, 0 failed
E2E tests:  31 passed, 0 failed
```

## Expert review

Harel approved twice (initial fix + finding 5 follow-up). Key findings:
- Core invariant correctly implemented, idempotent, no interference with XOR exclusivity
- `addAncestors` in `enterWithHistory` is necessary for degenerate paths
- Projection functions (`resolveHandlers`/`resolveAllowedMethods`) unaffected — already compensate with independent ancestor traversal

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)