### PR TITLE
fix: toKebabCase keeps acronym runs together (issue #270)

### DIFF
--- a/src/Frank.Resources.Model/AffordanceTypes.fs
+++ b/src/Frank.Resources.Model/AffordanceTypes.fs
@@ -180,18 +180,28 @@ module AffordanceMap =
         generateFromResources state.Resources state.BaseUri
 
     /// Convert a PascalCase or camelCase identifier to kebab-case.
-    /// "AuthorizePayment" → "authorize-payment", "makeMove" → "make-move"
+    /// "AuthorizePayment" → "authorize-payment", "getHTMLParser" → "get-html-parser"
     let toKebabCase (name: string) : string =
         if System.String.IsNullOrEmpty(name) then
             name
         else
-            let sb = System.Text.StringBuilder()
+            let sb = System.Text.StringBuilder(name.Length + 2)
 
             for i in 0 .. name.Length - 1 do
                 let c = name.[i]
 
                 if i > 0 && System.Char.IsUpper(c) then
-                    sb.Append('-') |> ignore
+                    let prevIsLower = System.Char.IsLower(name.[i - 1])
+
+                    let isEndOfAcronym =
+                        i >= 2
+                        && System.Char.IsUpper(name.[i - 1])
+                        && System.Char.IsUpper(name.[i - 2])
+                        && i + 1 < name.Length
+                        && System.Char.IsLower(name.[i + 1])
+
+                    if prevIsLower || isEndOfAcronym then
+                        sb.Append('-') |> ignore
 
                 sb.Append(System.Char.ToLowerInvariant(c)) |> ignore
 

--- a/test/Frank.Resources.Model.Tests/AffordanceMapTests.fs
+++ b/test/Frank.Resources.Model.Tests/AffordanceMapTests.fs
@@ -198,6 +198,30 @@ let affordanceMapTests =
           <| fun _ ->
               Expect.equal (AffordanceMap.toKebabCase "") "" "empty string round-trips"
 
+          testCase "toKebabCase keeps acronym at start together"
+          <| fun _ ->
+              Expect.equal (AffordanceMap.toKebabCase "OAuthCallback") "oauth-callback" "acronym at start"
+
+          testCase "toKebabCase keeps acronym in middle together"
+          <| fun _ ->
+              Expect.equal (AffordanceMap.toKebabCase "getHTMLParser") "get-html-parser" "acronym in middle"
+
+          testCase "toKebabCase handles all-caps"
+          <| fun _ ->
+              Expect.equal (AffordanceMap.toKebabCase "HTML") "html" "all-caps becomes lowercase"
+
+          testCase "toKebabCase handles single letter before word"
+          <| fun _ ->
+              Expect.equal (AffordanceMap.toKebabCase "ATest") "atest" "single letter word"
+
+          testCase "toKebabCase splits three-letter acronym prefix"
+          <| fun _ ->
+              Expect.equal (AffordanceMap.toKebabCase "ABTest") "ab-test" "three-letter acronym prefix"
+
+          testCase "toKebabCase handles multiple consecutive acronyms"
+          <| fun _ ->
+              Expect.equal (AffordanceMap.toKebabCase "HTTPSURLParser") "httpsurl-parser" "multiple acronyms"
+
           // fromStatechart
           testCase "fromStatechart produces one entry per state"
           <| fun _ ->


### PR DESCRIPTION
## Summary

- `toKebabCase` now treats consecutive uppercase runs as single words, splitting only at the boundary before the next lowercase-led word
- Uppercase runs ≤ 2 chars stay together (`OAuthCallback` → `oauth-callback`, `ATest` → `atest`)
- Runs ≥ 3 chars split before the last uppercase that starts a new word (`getHTMLParser` → `get-html-parser`)

## Requirements from #270

| Requirement | Status | Evidence |
|-------------|--------|----------|
| `OAuthCallback` → `oauth-callback` | Implemented | Test: "keeps acronym at start together" |
| `getHTMLParser` → `get-html-parser` | Implemented | Test: "keeps acronym in middle together" |
| `HTML` → `html` | Implemented | Test: "handles all-caps" |
| `authorizePayment` → `authorize-payment` | Preserved | Test: "converts PascalCase to kebab-case" |
| `PlaceOrder` → `place-order` | Preserved | Test: "converts PascalCase to kebab-case" |
| `ATest` → `atest` | Implemented (updated from `a-test` per design decision) | Test: "handles single letter before word" |
| Fix in `AffordanceMap.toKebabCase` (library) | Implemented | `src/Frank.Resources.Model/AffordanceTypes.fs:184-208` |
| No special-casing of known acronyms | Verified | Algorithm is general (`i >= 2` + prev-prev uppercase check) |

## Additional tests from expert review

- `ABTest` → `ab-test` (exercises `i >= 2` guard directly)
- `HTTPSURLParser` → `httpsurl-parser` (multiple consecutive acronyms)

## Build + test evidence

- Build: 0 errors
- Tests: 2741 passed, 0 failed (10 toKebabCase tests, all green)

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)