### PR TITLE
feat: multi-role users see union of affordances (issue #268)

### DIFF
--- a/sample/Frank.TicTacToe.Sample/Program.fs
+++ b/sample/Frank.TicTacToe.Sample/Program.fs
@@ -161,7 +161,7 @@ let main args =
         // Seed game state after services are built
         plug seedInitialState
 
-        resource gameResource
+        resource gameResource.Resource
         resource sseResource
     }
 

--- a/src/Frank.Statecharts/Affordances/AffordanceMap.fs
+++ b/src/Frank.Statecharts/Affordances/AffordanceMap.fs
@@ -18,12 +18,45 @@ type PreComputedAffordance =
         /// Middleware must resolve templates against ctx.Request.RouteValues at request time
         /// because RFC 8288 Link targets must be URIs, not URI Templates.
         HasTemplateLinks: bool
+        /// The HTTP methods permitted for this affordance, e.g. ["GET"; "OPTIONS"; "POST"].
+        /// Stored as a sorted, distinct list to allow merge without re-parsing AllowHeaderValue.
+        Methods: string list
     }
 
 module AffordancePreCompute =
 
     /// Format a single link relation as an RFC 8288 Link header value.
     let internal formatLinkValue (href: string) (rel: string) : string = sprintf "<%s>; rel=\"%s\"" href rel
+
+    /// Merge multiple pre-computed affordance entries into one.
+    /// Used when a user holds multiple roles: the merged entry contains the union
+    /// of methods (deduplicated, sorted) and the union of link relations (deduplicated).
+    let internal merge (entries: PreComputedAffordance list) : PreComputedAffordance =
+        match entries with
+        | [] -> failwith "merge requires at least one entry"
+        | [ single ] -> single
+        | _ ->
+            let allMethods =
+                entries
+                |> List.collect _.Methods
+                |> List.distinct
+                |> List.sort
+
+            // Deduplication relies on consistent formatting from formatLinkValue:
+            // the same (href, rel) pair always produces a byte-identical string,
+            // so Array.distinct is sufficient to collapse duplicates across role entries.
+            let allLinks =
+                entries
+                |> Array.ofList
+                |> Array.collect (fun e -> e.LinkHeaderValues.ToArray())
+                |> Array.distinct
+
+            let hasTemplates = entries |> List.exists _.HasTemplateLinks
+
+            { AllowHeaderValue = StringValues(String.Join(", ", allMethods))
+              LinkHeaderValues = StringValues(allLinks)
+              HasTemplateLinks = hasTemplates
+              Methods = allMethods }
 
     // Note: Base entry AllowedMethods comes from AffordanceMapEntry.AllowedMethods (caller-provided).
     // Role entries derive AllowedMethods from their filtered link relations + GET + OPTIONS.
@@ -54,7 +87,8 @@ module AffordancePreCompute =
             dict.[key] <-
                 { AllowHeaderValue = allowHeader
                   LinkHeaderValues = linkHeader
-                  HasTemplateLinks = hasTemplates }
+                  HasTemplateLinks = hasTemplates
+                  Methods = entry.AllowedMethods }
 
             // Collect distinct roles from link relations
             let distinctRoles =
@@ -90,7 +124,8 @@ module AffordancePreCompute =
                 dict.[roleKey] <-
                     { AllowHeaderValue = roleAllowHeader
                       LinkHeaderValues = StringValues(roleLinkValues)
-                      HasTemplateLinks = roleLinkValues |> Array.exists (fun v -> v.Contains("{")) }
+                      HasTemplateLinks = roleLinkValues |> Array.exists (fun v -> v.Contains("{"))
+                      Methods = roleMethods }
 
             // Generate authenticated fallback entry: only role-agnostic links
             // Used when user has roles but none match any role-specific entry
@@ -120,6 +155,7 @@ module AffordancePreCompute =
                 dict.[authKey] <-
                     { AllowHeaderValue = authAllowHeader
                       LinkHeaderValues = StringValues(authLinkValues)
-                      HasTemplateLinks = authLinkValues |> Array.exists (fun v -> v.Contains("{")) }
+                      HasTemplateLinks = authLinkValues |> Array.exists (fun v -> v.Contains("{"))
+                      Methods = authMethods }
 
         dict

--- a/src/Frank.Statecharts/Affordances/AffordanceMiddleware.fs
+++ b/src/Frank.Statecharts/Affordances/AffordanceMiddleware.fs
@@ -59,6 +59,10 @@ type AffordanceMiddleware(next: RequestDelegate, lookup: Dictionary<string, PreC
     /// Apply role-projected profile Link header overlay.
     /// Swaps the global ALPS profile link for a role-specific one when roles are resolved.
     /// Returns true if the Link header was actually modified (for Vary header decision).
+    ///
+    /// Note: For multi-role users, profile overlay still uses first-match (alphabetical)
+    /// because RFC 6906 requires one rel="profile" per response. Composite profiles
+    /// for multi-role users is a Phase 2 enhancement.
     let applyRoleProfileOverlay (ctx: HttpContext) (routeTemplate: string) (roles: Set<string>) : bool =
         let roleLookup = ctx.RequestServices.GetService<RoleProfileLookup>()
 
@@ -158,32 +162,48 @@ type AffordanceMiddleware(next: RequestDelegate, lookup: Dictionary<string, PreC
 
                             let baseKey = AffordanceMap.lookupKey routeTemplate effectiveStateKey
 
-                            // Resolve entry: role-specific > authenticated fallback > base.
-                            // Role matching uses Set iteration order (alphabetical for strings).
-                            // When multiple roles match, the first alphabetically wins.
-                            // Role priority ordering is a potential Phase 2 enhancement.
+                            // Resolve entry: collect all matching role entries and merge > authenticated fallback > base.
+                            // Multi-role users see the union of their roles' affordances.
                             let roles = ctx.GetRoles()
                             let hasRoles = not (Set.isEmpty roles)
 
                             let resolved, usedRoleKey =
                                 if hasRoles then
-                                    let roleSpecific =
-                                        roles
-                                        |> Seq.tryPick (fun role ->
-                                            tryLookup (
-                                                AffordanceMap.lookupKeyWithRole routeTemplate effectiveStateKey role
-                                            ))
+                                    if Set.count roles = 1 then
+                                        // Fast path: single role, no list allocation
+                                        let role = Seq.head roles
 
-                                    match roleSpecific with
-                                    | Some entry -> Some entry, true
-                                    | None ->
-                                        let fallback =
-                                            tryLookup (
-                                                AffordanceMap.lookupKeyAuthenticated routeTemplate effectiveStateKey
-                                            )
-                                            |> Option.orElseWith (fun () -> tryLookup baseKey)
+                                        match tryLookup (AffordanceMap.lookupKeyWithRole routeTemplate effectiveStateKey role) with
+                                        | Some entry -> Some entry, true
+                                        | None ->
+                                            let fallback =
+                                                tryLookup (
+                                                    AffordanceMap.lookupKeyAuthenticated routeTemplate effectiveStateKey
+                                                )
+                                                |> Option.orElseWith (fun () -> tryLookup baseKey)
 
-                                        fallback, false
+                                            fallback, false
+                                    else
+                                        // Multi-role: collect all matching entries and merge
+                                        let roleEntries =
+                                            roles
+                                            |> Seq.choose (fun role ->
+                                                tryLookup (
+                                                    AffordanceMap.lookupKeyWithRole routeTemplate effectiveStateKey role
+                                                ))
+                                            |> Seq.toList
+
+                                        match roleEntries with
+                                        | [] ->
+                                            let fallback =
+                                                tryLookup (
+                                                    AffordanceMap.lookupKeyAuthenticated routeTemplate effectiveStateKey
+                                                )
+                                                |> Option.orElseWith (fun () -> tryLookup baseKey)
+
+                                            fallback, false
+                                        | [ single ] -> Some single, true
+                                        | multiple -> Some(AffordancePreCompute.merge multiple), true
                                 else
                                     // Unauthenticated: use authenticated fallback (role-agnostic links only).
                                     // Showing role-restricted transitions to unauthenticated users violates

--- a/test/Frank.Statecharts.Tests/Affordances/AffordanceMiddlewareTests.fs
+++ b/test/Frank.Statecharts.Tests/Affordances/AffordanceMiddlewareTests.fs
@@ -3,6 +3,9 @@ module Frank.Affordances.Tests.AffordanceMiddlewareTests
 open System.Net
 open System.Net.Http
 open Expecto
+open Microsoft.AspNetCore.Builder
+open Microsoft.AspNetCore.Http
+open Microsoft.AspNetCore.Routing
 open Microsoft.Extensions.Primitives
 open Frank.Affordances
 open Frank.Resources.Model
@@ -619,3 +622,220 @@ let roleFilteredMiddlewareTests =
               Expect.equal playerXAllow "GET, HEAD, OPTIONS, POST" "PlayerX Allow should include POST (makeMove transition)"
               // PlayerO has no role-specific entry; falls back to auth entry with only role-agnostic links (viewGame GET)
               Expect.equal playerOAllow "GET, HEAD, OPTIONS" "PlayerO Allow should NOT include POST (no matching role transitions)" ]
+
+[<Tests>]
+let mergeTests =
+    testList
+        "AffordancePreCompute.merge"
+        [ testCase "merges two entries: union of methods, union of rels"
+          <| fun _ ->
+              let entry1 =
+                  { AllowHeaderValue = StringValues("GET, HEAD, OPTIONS, POST")
+                    LinkHeaderValues =
+                      StringValues(
+                          [| "<https://example.com/alps/orders>; rel=\"profile\""
+                             "</orders/{orderId}/refund>; rel=\"refund\"" |]
+                      )
+                    HasTemplateLinks = true
+                    Methods = [ "GET"; "HEAD"; "OPTIONS"; "POST" ] }
+
+              let entry2 =
+                  { AllowHeaderValue = StringValues("GET, HEAD, OPTIONS, PUT")
+                    LinkHeaderValues =
+                      StringValues(
+                          [| "<https://example.com/alps/orders>; rel=\"profile\""
+                             "</orders/{orderId}/ship>; rel=\"ship\"" |]
+                      )
+                    HasTemplateLinks = true
+                    Methods = [ "GET"; "HEAD"; "OPTIONS"; "PUT" ] }
+
+              let merged = AffordancePreCompute.merge [ entry1; entry2 ]
+
+              // Allow: union of methods, sorted
+              Expect.equal
+                  (merged.AllowHeaderValue.ToString())
+                  "GET, HEAD, OPTIONS, POST, PUT"
+                  "Merged Allow should be union of both entries' methods"
+
+              // Link: union of rels, deduplicated (profile appears once)
+              let links = merged.LinkHeaderValues.ToArray()
+              Expect.equal links.Length 3 "Should have 3 links: profile + refund + ship (no duplicate profile)"
+
+              let allLinks = links |> String.concat " "
+              Expect.isTrue (allLinks.Contains("rel=\"profile\"")) "Should contain profile"
+              Expect.isTrue (allLinks.Contains("rel=\"refund\"")) "Should contain refund"
+              Expect.isTrue (allLinks.Contains("rel=\"ship\"")) "Should contain ship"
+
+              // HasTemplateLinks: true if any entry has templates
+              Expect.isTrue merged.HasTemplateLinks "Should have template links"
+
+          testCase "merge preserves HasTemplateLinks=false when no entries have templates"
+          <| fun _ ->
+              let entry1 =
+                  { AllowHeaderValue = StringValues("GET, HEAD, OPTIONS")
+                    LinkHeaderValues =
+                      StringValues([| "<https://example.com/alps/orders>; rel=\"profile\"" |])
+                    HasTemplateLinks = false
+                    Methods = [ "GET"; "HEAD"; "OPTIONS" ] }
+
+              let entry2 =
+                  { AllowHeaderValue = StringValues("GET, HEAD, OPTIONS, POST")
+                    LinkHeaderValues =
+                      StringValues(
+                          [| "<https://example.com/alps/orders>; rel=\"profile\""
+                             "</orders/123/ship>; rel=\"ship\"" |]
+                      )
+                    HasTemplateLinks = false
+                    Methods = [ "GET"; "HEAD"; "OPTIONS"; "POST" ] }
+
+              let merged = AffordancePreCompute.merge [ entry1; entry2 ]
+              Expect.isFalse merged.HasTemplateLinks "Should be false when no entries have template links"
+
+          testCase "merge single entry returns it unchanged"
+          <| fun _ ->
+              let entry =
+                  { AllowHeaderValue = StringValues("GET, HEAD, OPTIONS, POST")
+                    LinkHeaderValues =
+                      StringValues(
+                          [| "<https://example.com/alps/orders>; rel=\"profile\""
+                             "</orders/{orderId}/refund>; rel=\"refund\"" |]
+                      )
+                    HasTemplateLinks = true
+                    Methods = [ "GET"; "HEAD"; "OPTIONS"; "POST" ] }
+
+              let merged = AffordancePreCompute.merge [ entry ]
+              Expect.equal (merged.AllowHeaderValue.ToString()) "GET, HEAD, OPTIONS, POST" "Single entry methods unchanged"
+              Expect.equal (merged.LinkHeaderValues.ToArray().Length) 2 "Single entry links unchanged" ]
+
+[<Tests>]
+let multiRoleMiddlewareTests =
+    // Build lookup with two roles that have distinct affordances for the same (route, state)
+    let multiRoleMap =
+        { Version = AffordanceMap.currentVersion
+          Entries =
+            [ { RouteTemplate = "/orders/{orderId}"
+                StateKey = "Fulfillment"
+                AllowedMethods = [ "GET"; "HEAD"; "OPTIONS"; "POST"; "PUT" ]
+                LinkRelations =
+                  [ { Rel = "refund"
+                      Href = "/orders/{orderId}/refund"
+                      Method = "POST"
+                      Title = None
+                      Roles = [ "PaymentService" ] }
+                    { Rel = "ship"
+                      Href = "/orders/{orderId}/ship"
+                      Method = "POST"
+                      Title = None
+                      Roles = [ "Warehouse" ] }
+                    { Rel = "pack"
+                      Href = "/orders/{orderId}/pack"
+                      Method = "PUT"
+                      Title = None
+                      Roles = [ "Warehouse" ] }
+                    { Rel = "view-order"
+                      Href = "/orders/{orderId}"
+                      Method = "GET"
+                      Title = None
+                      Roles = [] } ]
+                ProfileUrl = "https://example.com/alps/orders" } ] }
+
+    let multiRoleLookup = AffordancePreCompute.preCompute multiRoleMap
+
+    let orderEndpoints (endpoints: IEndpointRouteBuilder) =
+        endpoints.MapGet(
+            "/orders/{orderId}",
+            RequestDelegate(fun ctx -> ctx.Response.WriteAsync("OK"))
+        )
+        |> ignore
+
+    testList
+        "AffordanceMiddleware multi-role resolution"
+        [
+          // Acceptance test 1: Multi-role user sees union of affordances
+          testCase "multi-role user sees union of methods and rels from both PaymentService and Warehouse"
+          <| fun _ ->
+              (withAffordanceServer
+                  multiRoleLookup
+                  (fun ctx ->
+                      ctx.SetStatechartState("Fulfillment", "Fulfillment", 0)
+                      ctx.SetRoles(Set [ "PaymentService"; "Warehouse" ]))
+                  orderEndpoints
+                  (fun client ->
+                      task {
+                          let! (response: HttpResponseMessage) = client.GetAsync("/orders/o1")
+
+                          Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+
+                          // Allow header includes methods from BOTH roles
+                          let allow = getHeaderValues response "Allow" |> String.concat ", "
+                          Expect.isTrue (allow.Contains("POST")) "Allow should include POST (from refund + ship)"
+                          Expect.isTrue (allow.Contains("PUT")) "Allow should include PUT (from pack)"
+                          Expect.isTrue (allow.Contains("GET")) "Allow should include GET"
+
+                          // Link header includes rels from BOTH roles
+                          let links = getHeaderValues response "Link"
+                          let allLinks = links |> String.concat " "
+                          Expect.isTrue (allLinks.Contains("rel=\"refund\"")) "Should contain refund (PaymentService)"
+                          Expect.isTrue (allLinks.Contains("rel=\"ship\"")) "Should contain ship (Warehouse)"
+                          Expect.isTrue (allLinks.Contains("rel=\"pack\"")) "Should contain pack (Warehouse)"
+                          Expect.isTrue (allLinks.Contains("rel=\"view-order\"")) "Should contain view-order (all roles)"
+                          Expect.isTrue (allLinks.Contains("rel=\"profile\"")) "Should contain profile"
+
+                          // Vary: Authorization must be present for role-dependent responses
+                          let vary = getHeaderValues response "Vary" |> String.concat ", "
+                          Expect.isTrue (vary.Contains("Authorization")) "Vary should include Authorization for multi-role response"
+                      }))
+                  .GetAwaiter()
+                  .GetResult()
+
+          // Acceptance test 2: Single-role behavior unchanged
+          testCase "single-role user sees only their role's affordances (no regression)"
+          <| fun _ ->
+              (withAffordanceServer
+                  multiRoleLookup
+                  (fun ctx ->
+                      ctx.SetStatechartState("Fulfillment", "Fulfillment", 0)
+                      ctx.SetRoles(Set [ "PaymentService" ]))
+                  orderEndpoints
+                  (fun client ->
+                      task {
+                          let! (response: HttpResponseMessage) = client.GetAsync("/orders/o1")
+
+                          Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+
+                          let links = getHeaderValues response "Link"
+                          let allLinks = links |> String.concat " "
+                          Expect.isTrue (allLinks.Contains("rel=\"refund\"")) "PaymentService should see refund"
+                          Expect.isFalse (allLinks.Contains("rel=\"ship\"")) "PaymentService should NOT see ship"
+                          Expect.isFalse (allLinks.Contains("rel=\"pack\"")) "PaymentService should NOT see pack"
+                          Expect.isTrue (allLinks.Contains("rel=\"view-order\"")) "Should see view-order (all roles)"
+                      }))
+                  .GetAwaiter()
+                  .GetResult()
+
+          // Acceptance test 3: No role duplication in merged output
+          testCase "multi-role merged output has no duplicate methods or rels"
+          <| fun _ ->
+              (withAffordanceServer
+                  multiRoleLookup
+                  (fun ctx ->
+                      ctx.SetStatechartState("Fulfillment", "Fulfillment", 0)
+                      ctx.SetRoles(Set [ "PaymentService"; "Warehouse" ]))
+                  orderEndpoints
+                  (fun client ->
+                      task {
+                          let! (response: HttpResponseMessage) = client.GetAsync("/orders/o1")
+
+                          Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
+
+                          // Check Allow header has no duplicate methods
+                          let allow = getHeaderValues response "Allow" |> String.concat ", "
+                          let methods = allow.Split(',') |> Array.map (fun s -> s.Trim()) |> Array.toList
+                          Expect.equal methods (methods |> List.distinct) "Allow header should have no duplicate methods"
+
+                          // Check Link header has no duplicate rels
+                          let links = getHeaderValues response "Link"
+                          Expect.equal links (links |> List.distinct) "Link header should have no duplicate rels"
+                      }))
+                  .GetAwaiter()
+                  .GetResult() ]

--- a/test/Frank.Statecharts.Tests/Affordances/AffordanceTestHelpers.fs
+++ b/test/Frank.Statecharts.Tests/Affordances/AffordanceTestHelpers.fs
@@ -46,17 +46,20 @@ let xTurnAffordance =
             [| "<https://example.com/alps/games>; rel=\"profile\""
                "</games/123/move>; rel=\"makeMove\"" |]
         )
-      HasTemplateLinks = false }
+      HasTemplateLinks = false
+      Methods = [ "GET"; "POST" ] }
 
 let wonAffordance =
     { AllowHeaderValue = StringValues("GET")
       LinkHeaderValues = StringValues([| "<https://example.com/alps/games>; rel=\"profile\"" |])
-      HasTemplateLinks = false }
+      HasTemplateLinks = false
+      Methods = [ "GET" ] }
 
 let healthAffordance =
     { AllowHeaderValue = StringValues("GET")
       LinkHeaderValues = StringValues([| "<https://example.com/alps/health>; rel=\"profile\"" |])
-      HasTemplateLinks = false }
+      HasTemplateLinks = false
+      Methods = [ "GET" ] }
 
 /// Run a test against a configured test server with AffordanceMiddleware,
 /// disposing all resources on completion.

--- a/test/Frank.Statecharts.Tests/Affordances/OptionsDiscoveryTests.fs
+++ b/test/Frank.Statecharts.Tests/Affordances/OptionsDiscoveryTests.fs
@@ -486,7 +486,8 @@ let stateAwareOptionsTests =
                           [| "<https://example.com/alps/games>; rel=\"profile\""
                              "</games/{gameId}/move>; rel=\"makeMove\"" |]
                       )
-                    HasTemplateLinks = true }
+                    HasTemplateLinks = true
+                    Methods = [ "GET"; "OPTIONS"; "POST" ] }
 
               let lookup = buildAffordanceLookup [ "/games/{gameId}|XTurn", xTurnAffordance ]
 
@@ -511,7 +512,8 @@ let stateAwareOptionsTests =
               let wonAffordance =
                   { AllowHeaderValue = StringValues("GET, OPTIONS")
                     LinkHeaderValues = StringValues([| "<https://example.com/alps/games>; rel=\"profile\"" |])
-                    HasTemplateLinks = false }
+                    HasTemplateLinks = false
+                    Methods = [ "GET"; "OPTIONS" ] }
 
               let lookup = buildAffordanceLookup [ "/games/{gameId}|Won", wonAffordance ]
 
@@ -544,7 +546,8 @@ let stateAwareOptionsTests =
                           [| "<https://example.com/alps/games>; rel=\"profile\""
                              "</games/{gameId}/move>; rel=\"makeMove\"" |]
                       )
-                    HasTemplateLinks = true }
+                    HasTemplateLinks = true
+                    Methods = [ "GET"; "OPTIONS"; "POST" ] }
 
               let lookup = buildAffordanceLookup [ "/games/{gameId}|XTurn", xTurnAffordance ]
 
@@ -572,7 +575,8 @@ let stateAwareOptionsTests =
               let wonAffordance =
                   { AllowHeaderValue = StringValues("GET, OPTIONS")
                     LinkHeaderValues = StringValues([| "<https://example.com/alps/games>; rel=\"profile\"" |])
-                    HasTemplateLinks = false }
+                    HasTemplateLinks = false
+                    Methods = [ "GET"; "OPTIONS" ] }
 
               let lookup = buildAffordanceLookup [ "/games/{gameId}|Won", wonAffordance ]
 
@@ -619,7 +623,8 @@ let stateAwareOptionsTests =
               let xTurnAffordance =
                   { AllowHeaderValue = StringValues("GET, OPTIONS, POST")
                     LinkHeaderValues = StringValues([| "</games/{gameId}>; rel=\"profile\"" |])
-                    HasTemplateLinks = true }
+                    HasTemplateLinks = true
+                    Methods = [ "GET"; "OPTIONS"; "POST" ] }
 
               let lookup = buildAffordanceLookup [ "/games/{gameId}|XTurn", xTurnAffordance ]
 


### PR DESCRIPTION
Closes #268

## Summary

- **AffordanceMiddleware** role resolution changed from `Seq.tryPick` (first alphabetical match) to `Seq.choose` + merge, so multi-role users see the union of all matching roles' methods and link relations
- **AffordancePreCompute.merge** added — computes union of methods (deduplicated, sorted) and union of links (deduplicated); `HasTemplateLinks = true` if any entry has templates
- **Single-role fast path** (`Set.count = 1`) avoids list allocation on the common case
- **Methods field** added to `PreComputedAffordance` so merge operates on structured data, not parsed strings

## Requirements from #268

| Requirement | Status |
|---|---|
| Multi-role user sees union of methods + rels | Implemented — `Seq.choose` + `AffordancePreCompute.merge` |
| Single-role behavior unchanged | Verified — fast path returns single entry directly |
| No duplicate methods or rels in merged output | Verified — `List.distinct`/`Array.distinct` |
| Resolution in middleware, not sample handlers | Implemented in `AffordanceMiddleware.fs` |
| No pre-declared role combinations required | Correct — merge happens at request time |
| Profile overlay first-match documented | Doc comment added; #278 created for Phase 2 composite profiles |

## Verified results

```
Build succeeded. 0 Error(s)
Passed! - Failed: 0, Passed: 2487, Skipped: 0
```

New tests:
- `AffordancePreCompute.merge` — 3 unit tests (union, HasTemplateLinks, single-entry passthrough)
- `AffordanceMiddleware multi-role resolution` — 3 integration tests (union of affordances, single-role regression, no duplicates)

## Expert review

Reviewed by Fielding, Miller, Fowler, @7sharp9. All 8 findings resolved in this PR:
1. `Methods` field eliminates fragile `Split(", ")` parsing
2. Profile overlay asymmetry documented, #278 created
3. `Vary: Authorization` test added for multi-role
4. Single-role fast path avoids list allocation
5. Merge uses `Array.collect`/`Array.distinct` (no intermediate lists)
6. `merge` made `internal`
7. Link dedup doc comment added
8. Test Allow header split uses `Split(',')` + `Trim`

🤖 Generated with [Claude Code](https://claude.com/claude-code)