### PR TITLE
feat: MayPoll observation rels + ALPS fragment URI link relations (#271)

### DIFF
--- a/PROMPT.md
+++ b/PROMPT.md
@@ -1,92 +1,99 @@
 ## Thesis
 
-HTTP method semantics are a protocol-level contract. Safe methods (GET) guarantee no side effects; unsafe methods (POST) do not. When Frank maps statechart transitions to HTTP affordances, it must respect this distinction. A read-only observation transition advertised as POST prevents caching, breaks prefetch, and violates RFC 9110 §9.2.1.
+In MPST, MayPoll is a first-class protocol obligation — a role observing state changes made by other roles. The affordance surface must make observation affordances visible to clients, not just transition affordances. A role with MayPoll obligations but no transitions must still receive guidance on what to do (GET the resource to observe).
+
+Additionally, link relation values must be valid per RFC 8288 §2.1.2 — either IANA-registered or extension relation URIs. Bare kebab-case strings are neither.
 
 ## Current problem
 
-`AffordanceMap.fromStatechart` hardcodes `Method = "POST"` for all transitions. A `getGame` or `viewStatus` transition is semantically safe (read-only) but is advertised as POST in Allow headers and Link relations.
+Two issues:
 
-## Definition: "correct method mapping"
+1. **MayPoll invisible.** \`AffordanceMap.fromStatechart\` only generates link relations for transitions (MustSelect/POST). A role with MayPoll in a state has zero link rels — indistinguishable from "no affordances." The protocol expects them to poll, but the affordance surface gives no guidance.
 
-Transitions carry safe/unsafe semantics. Safe transitions map to GET, unsafe transitions map to POST. The ALPS descriptor `type` attribute (`safe`, `unsafe`, `idempotent`) is the authoritative source when available.
+2. **Invalid link relation values.** Link rels use bare kebab-case strings (\`authorize-payment\`) which are neither IANA-registered nor valid extension URIs per RFC 8288 §2.1.2. ALPS-based rels should use the ALPS profile fragment URI: \`rel="http://example.com/alps/orders#authorizePayment"\`.
+
+## Definition: "complete affordance surface"
+
+Every MPST obligation (MustSelect AND MayPoll) produces a link relation. MayPoll produces a GET link relation. All link relation values are valid per RFC 8288 — either IANA-registered or extension relation URIs derived from the ALPS profile.
 
 ## Proposed solution
 
-Extend `TransitionSpec` (or the `transition` CE operation) with a safety annotation. Derive from ALPS descriptor type when available. Default to `unsafe` (POST) when unspecified — safe is the explicit opt-in.
+1. Generate MayPoll link relations in \`AffordanceMap.fromStatechart\` — Method = "GET", rel derived from state or obligation name.
+2. Use ALPS profile fragment URIs as link relation values: \`rel="{profileUri}#{descriptorId}"\` instead of bare kebab-case strings.
 
 ## Architectural constraints
 
-- Method mapping MUST be computed in `AffordanceMap.fromStatechart` (library), not overridden per-handler in sample code
-- Safety semantics MUST flow from the statechart/ALPS metadata, not from handler registration
-- Sample handlers MUST NOT set HTTP methods directly to work around incorrect mapping
+- MayPoll link generation MUST be in \`AffordanceMap.fromStatechart\` (library), not hand-coded in sample handlers
+- ALPS URI construction MUST be in the affordance pipeline, not per-handler
+- Sample handlers MUST NOT add custom Link headers to compensate for missing MayPoll rels
 
 ## Implementation sequence
 
-1. Add safety field to `TransitionSpec` or transition metadata — checkpoint: type compiles, existing tests pass
-2. Update `AffordanceMap.fromStatechart` to use safety for method selection — checkpoint: unit tests show GET for safe, POST for unsafe
-3. Wire ALPS descriptor type to safety annotation in extraction pipeline — checkpoint: ALPS profile with `type="safe"` produces GET transition
-4. Update sample to declare safe transitions — checkpoint: E2E shows GET for observation transitions
+1. Add MayPoll link relation generation to \`AffordanceMap.fromStatechart\` — checkpoint: unit tests show GET rels for MayPoll states
+2. Switch link relation values to ALPS profile fragment URIs — checkpoint: unit tests show URI-based rels
+3. Update sample to declare ALPS profile base URI — checkpoint: E2E shows correct ALPS fragment rels in Link headers
+4. Verify MayPoll roles receive link guidance — checkpoint: Customer in Authorize state gets a GET link rel
 
 ## Acceptance tests
 
-### 1. Safe transition maps to GET
-
-```fsharp
-// Transition marked safe in statechart
-AffordanceMap.fromStatechart extractedStatechart
-→ entry for safe transition has Method = "GET"
-```
-
-### 2. Unsafe transition maps to POST (default)
-
-```fsharp
-// Transition with no safety annotation
-AffordanceMap.fromStatechart extractedStatechart
-→ entry for unmarked transition has Method = "POST"
-```
-
-### 3. ALPS type annotation drives safety
-
-```fsharp
-// ALPS descriptor with type="safe"
-→ extracted transition carries safe = true
-→ affordance entry has Method = "GET"
-```
-
-### 4. Allow header reflects correct methods
+### 1. MayPoll role gets observation link relation
 
 ```
-GET /orders/o1 (in state with both safe and unsafe transitions)
-→ Allow: GET, POST (not just POST for everything)
+GET /orders/o1 -H "X-Role: Customer" (in Authorize state — Customer is MayPoll)
+→ 200
+→ Link header includes a GET-method rel for observing the order
+```
+
+Without this, Customer sees zero link rels in Authorize state despite having a protocol obligation.
+
+### 2. MustSelect role still gets transition link relations
+
+```
+GET /orders/o1 -H "X-Role: PaymentService" (in Authorize state — PaymentService is MustSelect)
+→ 200
+→ Link header includes POST-method rel for authorize-payment
+```
+
+Existing behavior preserved.
+
+### 3. Link relation values are valid URIs
+
+```
+GET /orders/o1
+→ Link header rels are ALPS profile fragment URIs
+→ e.g., rel="http://example.com/alps/orders#authorizePayment"
+→ NOT: rel="authorize-payment"
+```
+
+### 4. Bare kebab-case rels no longer appear
+
+```
+GET /orders/o1
+→ No Link header contains a bare kebab-case rel value
+→ All rels are either IANA-registered or valid extension URIs
 ```
 
 ## Dependencies
 
-- Independent of: #268, #270, #273
-- Affects: #251 (role projection needs correct methods per transition)
-- Affects: #271 (MayPoll is inherently safe/GET)
+- Depends on: #269 (safe method transitions — MayPoll rels need GET method mapping)
+- Depends on: #270 (toKebabCase — affects descriptor ID formatting)
+- Affects: #251 (role projection needs MayPoll rels to show different per-role views)
 
 ## Expert sources
 
-- **Miller** (review of #251): "conflates safe and unsafe transitions"
-- **Amundsen** (review of #251): "ALPS descriptors carry safe/unsafe/idempotent type"
+- **Amundsen** (review of #251): "MayPoll obligations invisible — roles with no transitions have no affordance guidance"
+- **Miller** (review of #251): "kebab-case bare strings are not valid ALPS extension relation URIs per RFC 8288"
 ### Design (from affordance pipeline exploration)
 
-**Files:**
-- `src/Frank.Resources.Model/ResourceTypes.fs` — add `IsSafe: bool` to `TransitionSpec` (default false)
-- `src/Frank.Resources.Model/AffordanceTypes.fs` — `AffordanceMap.fromStatechart` line 229: replace `Method = "POST"` with `Method = if t.IsSafe then "GET" else "POST"`
-- `src/Frank.Statecharts/StatefulResourceBuilder.fs` — new `safeTransition` CE operation (follows `useX`/`useXWith` naming pattern to avoid overload ambiguity)
+**MayPoll rels:**
 
-**Usage:**
-```fsharp
-// Existing (unchanged — defaults to unsafe/POST):
-transition PlaceOrder Pending Authorize Unrestricted
+In `AffordanceMap.fromStatechart` (AffordanceTypes.fs), after generating transition rels: for each state, for each role's projection, if the role has zero transitions from that state → add a GET link rel with `rel="monitor"` (IANA-registered, RFC 5765).
 
-// New — safe/GET:
-safeTransition ViewStatus Authorize Authorize Unrestricted
-```
+**ALPS extension URIs:**
 
-No ALPS integration in this issue — `safeTransition` is the CE-level mechanism. ALPS descriptor type → IsSafe derivation is a follow-up.
+`fromStatechart` already receives `baseUri: string` (added in PR #274). Change rel generation (line 227) from `Rel = toKebabCase t.Event` to `Rel = sprintf "%s#%s" baseUri t.Event`.
+
+Produces: `rel="http://example.com/alps/orders#AuthorizePayment"` — valid RFC 8288 extension URI and dereferenceable ALPS descriptor reference. Keep PascalCase in fragment (ALPS descriptor IDs are PascalCase). Kebab-case moves to display/logging only.
 
 ---
 

--- a/sample/Frank.OrderFulfillment.Sample/test-e2e.sh
+++ b/sample/Frank.OrderFulfillment.Sample/test-e2e.sh
@@ -457,11 +457,11 @@ echo "================================================================"
 echo ""
 
 # Same order (o4) in Authorize state:
-# PaymentService GET → Link includes authorize-payment
-check_header "RP-AT2: PaymentService Link includes authorize-payment" "$BASE/orders/o4" "Link" "authorize-payment" "PaymentService"
+# PaymentService GET → Link includes AuthorizePayment (ALPS fragment URI)
+check_header "RP-AT2: PaymentService Link includes AuthorizePayment" "$BASE/orders/o4" "Link" "AuthorizePayment" "PaymentService"
 
-# Customer GET → Link does NOT include authorize-payment
-check_header_absent "RP-AT2: Customer Link excludes authorize-payment" "$BASE/orders/o4" "Link" "authorize-payment" "Customer"
+# Customer GET → Link does NOT include AuthorizePayment
+check_header_absent "RP-AT2: Customer Link excludes AuthorizePayment" "$BASE/orders/o4" "Link" "AuthorizePayment" "Customer"
 
 echo ""
 echo "================================================================"
@@ -501,6 +501,29 @@ else
     echo "  FAIL: RP-AT4: transition counts should differ (Customer=$CUSTOMER_COUNT, PaymentService=$PAYMENT_COUNT)"
     FAIL=$((FAIL + 1))
 fi
+
+echo ""
+echo "================================================================"
+echo "=== ACCEPTANCE TEST: #271 MayPoll + ALPS Link Relations       ==="
+echo "================================================================"
+echo ""
+
+# #271 AT1: MayPoll role gets observation link relation
+# Customer in Authorize state has no transitions — should get rel="monitor" GET link
+check_header "#271 AT1: Customer gets monitor link in Authorize" "$BASE/orders/o3" "Link" "monitor" "Customer"
+
+# #271 AT2: MustSelect role still gets transition link relations
+# PaymentService in Authorize has AuthorizePayment transition — gets ALPS fragment URI link
+check_header "#271 AT2: PaymentService gets AuthorizePayment link" "$BASE/orders/o3" "Link" "AuthorizePayment" "PaymentService"
+
+# #271 AT3: Link relation values are valid URIs (ALPS fragment URIs)
+# PaymentService Link should contain alps/orders# (profile fragment URI, not bare kebab-case)
+check_header "#271 AT3: Link rels are ALPS fragment URIs" "$BASE/orders/o3" "Link" "alps/orders#" "PaymentService"
+
+# #271 AT4: Bare kebab-case rels no longer appear
+# Old format "authorize-payment" should not be in any Link header
+check_header_absent "#271 AT4: no bare kebab-case rels (PaymentService)" "$BASE/orders/o3" "Link" "authorize-payment" "PaymentService"
+check_header_absent "#271 AT4: no bare kebab-case rels (Customer)" "$BASE/orders/o3" "Link" "authorize-payment" "Customer"
 
 echo ""
 echo "================================================================"

--- a/sample/Frank.OrderFulfillment.Sample/test-e2e.sh
+++ b/sample/Frank.OrderFulfillment.Sample/test-e2e.sh
@@ -510,7 +510,7 @@ echo ""
 
 # #271 AT1: MayPoll role gets observation link relation
 # Customer in Authorize state has no transitions — should get rel="monitor" GET link
-check_header "#271 AT1: Customer gets monitor link in Authorize" "$BASE/orders/o3" "Link" "monitor" "Customer"
+check_header "#271 AT1: Customer gets monitor link in Authorize" "$BASE/orders/o3" "Link" 'rel="monitor"' "Customer"
 
 # #271 AT2: MustSelect role still gets transition link relations
 # PaymentService in Authorize has AuthorizePayment transition — gets ALPS fragment URI link

--- a/src/Frank.Resources.Model/AffordanceTypes.fs
+++ b/src/Frank.Resources.Model/AffordanceTypes.fs
@@ -217,8 +217,13 @@ module AffordanceMap =
     /// Each transition becomes an AffordanceLinkRelation with Roles derived from RoleConstraint.
     /// Method derived from TransitionSafety: Safe→GET, Unsafe→POST, Idempotent→PUT.
     /// Rel is an ALPS profile fragment URI: "{profileUrl}#{EventName}".
-    /// Roles with no transitions from a state get a "monitor" GET rel (IANA RFC 5765).
+    /// Roles with no transitions from a state get a "monitor" GET rel (IANA link relation
+    /// registry; registered via RFC 5765 for SIP but applicable to HTTP observation semantics).
+    /// Terminal states (no transitions for any role) do not generate monitor rels.
     let fromStatechart (baseUri: string) (sc: ExtractedStatechart) : AffordanceMap =
+        if System.String.IsNullOrWhiteSpace(baseUri) then
+            invalidArg (nameof baseUri) "baseUri must be a non-empty URI for ALPS profile fragment construction"
+
         let slug = ResourceModel.resourceSlug sc.RouteTemplate
         let profile = profileUrl baseUri slug
 
@@ -247,36 +252,40 @@ module AffordanceMap =
                             | Unsafe -> "POST"
                             | Idempotent -> "PUT"
 
-                        { AffordanceLinkRelation.Rel = sprintf "%s#%s" profile t.Event
+                        { AffordanceLinkRelation.Rel = String.Concat(profile, "#", t.Event)
                           AffordanceLinkRelation.Href = sc.RouteTemplate
                           AffordanceLinkRelation.Method = method
                           AffordanceLinkRelation.Title = None
                           AffordanceLinkRelation.Roles = roles })
 
                 // MayPoll: roles with no transitions from this state get a monitor GET rel.
-                // A role "has transitions" if any transition is Unrestricted or RestrictedTo includes the role.
+                // Only when SOME roles have transitions (not terminal states where nobody acts).
                 let hasUnrestricted = transitions |> List.exists (fun t -> t.Constraint = Unrestricted)
 
                 let monitorRels =
-                    if hasUnrestricted then
-                        [] // All roles participate in unrestricted transitions
+                    if hasUnrestricted || List.isEmpty transitions then
+                        [] // All roles participate (unrestricted) or terminal state (no actions)
                     else
-                        sc.Roles
-                        |> List.filter (fun role ->
+                        let activeRoles =
                             transitions
-                            |> List.exists (fun t ->
+                            |> List.collect (fun t ->
                                 match t.Constraint with
-                                | RestrictedTo roles -> roles |> List.contains role.Name
-                                | Unrestricted -> true)
-                            |> not)
+                                | RestrictedTo roles -> roles
+                                | Unrestricted -> [])
+                            |> Set.ofList
+
+                        sc.Roles
+                        |> List.filter (fun role -> not (activeRoles.Contains role.Name))
                         |> List.map (fun role ->
                             { AffordanceLinkRelation.Rel = "monitor"
                               AffordanceLinkRelation.Href = sc.RouteTemplate
                               AffordanceLinkRelation.Method = "GET"
-                              AffordanceLinkRelation.Title = None
+                              AffordanceLinkRelation.Title = Some stateKey
                               AffordanceLinkRelation.Roles = [ role.Name ] })
 
-                let linkRelations = transitionRels @ monitorRels
+                let linkRelations =
+                    if List.isEmpty monitorRels then transitionRels
+                    else transitionRels @ monitorRels
 
                 let allowedMethods =
                     let hasUnsafe = transitions |> List.exists (fun t -> t.Safety = Unsafe)

--- a/src/Frank.Resources.Model/AffordanceTypes.fs
+++ b/src/Frank.Resources.Model/AffordanceTypes.fs
@@ -216,7 +216,8 @@ module AffordanceMap =
     /// Generate an AffordanceMap from an ExtractedStatechart for CE-based apps.
     /// Each transition becomes an AffordanceLinkRelation with Roles derived from RoleConstraint.
     /// Method derived from TransitionSafety: Safe→GET, Unsafe→POST, Idempotent→PUT.
-    /// Rel is the event name converted to kebab-case.
+    /// Rel is an ALPS profile fragment URI: "{profileUrl}#{EventName}".
+    /// Roles with no transitions from a state get a "monitor" GET rel (IANA RFC 5765).
     let fromStatechart (baseUri: string) (sc: ExtractedStatechart) : AffordanceMap =
         let slug = ResourceModel.resourceSlug sc.RouteTemplate
         let profile = profileUrl baseUri slug
@@ -232,7 +233,7 @@ module AffordanceMap =
                         | RestrictedTo [] -> false // dead transition: no role can trigger it
                         | _ -> true)
 
-                let linkRelations =
+                let transitionRels =
                     transitions
                     |> List.map (fun t ->
                         let roles =
@@ -246,11 +247,36 @@ module AffordanceMap =
                             | Unsafe -> "POST"
                             | Idempotent -> "PUT"
 
-                        { AffordanceLinkRelation.Rel = toKebabCase t.Event
+                        { AffordanceLinkRelation.Rel = sprintf "%s#%s" profile t.Event
                           AffordanceLinkRelation.Href = sc.RouteTemplate
                           AffordanceLinkRelation.Method = method
                           AffordanceLinkRelation.Title = None
                           AffordanceLinkRelation.Roles = roles })
+
+                // MayPoll: roles with no transitions from this state get a monitor GET rel.
+                // A role "has transitions" if any transition is Unrestricted or RestrictedTo includes the role.
+                let hasUnrestricted = transitions |> List.exists (fun t -> t.Constraint = Unrestricted)
+
+                let monitorRels =
+                    if hasUnrestricted then
+                        [] // All roles participate in unrestricted transitions
+                    else
+                        sc.Roles
+                        |> List.filter (fun role ->
+                            transitions
+                            |> List.exists (fun t ->
+                                match t.Constraint with
+                                | RestrictedTo roles -> roles |> List.contains role.Name
+                                | Unrestricted -> true)
+                            |> not)
+                        |> List.map (fun role ->
+                            { AffordanceLinkRelation.Rel = "monitor"
+                              AffordanceLinkRelation.Href = sc.RouteTemplate
+                              AffordanceLinkRelation.Method = "GET"
+                              AffordanceLinkRelation.Title = None
+                              AffordanceLinkRelation.Roles = [ role.Name ] })
+
+                let linkRelations = transitionRels @ monitorRels
 
                 let allowedMethods =
                     let hasUnsafe = transitions |> List.exists (fun t -> t.Safety = Unsafe)

--- a/test/Frank.Resources.Model.Tests/AffordanceMapTests.fs
+++ b/test/Frank.Resources.Model.Tests/AffordanceMapTests.fs
@@ -263,7 +263,7 @@ let affordanceMapTests =
               let map = AffordanceMap.fromStatechart "http://example.com/alps" sc
               Expect.equal map.Version AffordanceMap.currentVersion "Version must match currentVersion"
 
-          testCase "fromStatechart converts event names to kebab-case rel"
+          testCase "fromStatechart uses ALPS profile fragment URI for transition rels"
           <| fun _ ->
               let sc: ExtractedStatechart =
                   { RouteTemplate = "/games/{gameId}"
@@ -283,7 +283,7 @@ let affordanceMapTests =
               let map = AffordanceMap.fromStatechart "http://example.com/alps" sc
               let entry = map.Entries |> List.head
               let rel = entry.LinkRelations |> List.head |> _.Rel
-              Expect.equal rel "make-move" "Event name should be kebab-cased"
+              Expect.equal rel "http://example.com/alps/games#makeMove" "Rel should be ALPS profile fragment URI"
 
           testCase "fromStatechart maps unsafe transition (default) to POST method"
           <| fun _ ->
@@ -561,4 +561,208 @@ let affordanceMapTests =
                     Transitions = [] }
 
               let map = AffordanceMap.fromStatechart "http://example.com/alps" sc
-              Expect.isEmpty map.Entries "No states means no entries" ]
+              Expect.isEmpty map.Entries "No states means no entries"
+
+          // #271 Phase 1: MayPoll link relation generation
+          testCase "fromStatechart adds monitor rel for role with no transitions in state"
+          <| fun _ ->
+              let sc: ExtractedStatechart =
+                  { RouteTemplate = "/orders/{orderId}"
+                    StateNames = [ "Authorize" ]
+                    InitialStateKey = "Authorize"
+                    GuardNames = []
+                    StateMetadata = Map.empty
+                    Roles =
+                      [ { Name = "Customer"; Description = None }
+                        { Name = "PaymentService"; Description = None } ]
+                    Transitions =
+                      [ { Event = "AuthorizePayment"
+                          Source = "Authorize"
+                          Target = "Shipped"
+                          Guard = None
+                          Constraint = RestrictedTo [ "PaymentService" ]
+                          Safety = Unsafe } ] }
+
+              let map = AffordanceMap.fromStatechart "http://example.com/alps" sc
+              let entry = map.Entries |> List.find (fun e -> e.StateKey = "Authorize")
+              let monitorRel = entry.LinkRelations |> List.tryFind (fun lr -> lr.Rel = "monitor")
+              Expect.isSome monitorRel "Role with no transitions should get monitor rel"
+              let monitor = monitorRel.Value
+              Expect.equal monitor.Method "GET" "Monitor rel should be GET"
+              Expect.equal monitor.Roles [ "Customer" ] "Monitor rel should be scoped to MayPoll role"
+              Expect.equal monitor.Href "/orders/{orderId}" "Monitor rel should target resource"
+
+          testCase "fromStatechart does not add monitor rel for role with transitions"
+          <| fun _ ->
+              let sc: ExtractedStatechart =
+                  { RouteTemplate = "/orders/{orderId}"
+                    StateNames = [ "Authorize" ]
+                    InitialStateKey = "Authorize"
+                    GuardNames = []
+                    StateMetadata = Map.empty
+                    Roles =
+                      [ { Name = "Customer"; Description = None }
+                        { Name = "PaymentService"; Description = None } ]
+                    Transitions =
+                      [ { Event = "AuthorizePayment"
+                          Source = "Authorize"
+                          Target = "Shipped"
+                          Guard = None
+                          Constraint = RestrictedTo [ "PaymentService" ]
+                          Safety = Unsafe } ] }
+
+              let map = AffordanceMap.fromStatechart "http://example.com/alps" sc
+              let entry = map.Entries |> List.find (fun e -> e.StateKey = "Authorize")
+              let paymentServiceMonitor =
+                  entry.LinkRelations
+                  |> List.tryFind (fun lr -> lr.Rel = "monitor" && lr.Roles = [ "PaymentService" ])
+              Expect.isNone paymentServiceMonitor "Role with transitions should not get monitor rel"
+
+          testCase "fromStatechart no monitor rels when Roles list is empty"
+          <| fun _ ->
+              let sc: ExtractedStatechart =
+                  { RouteTemplate = "/games/{gameId}"
+                    StateNames = [ "XTurn" ]
+                    InitialStateKey = "XTurn"
+                    GuardNames = []
+                    StateMetadata = Map.empty
+                    Roles = []
+                    Transitions =
+                      [ { Event = "makeMove"
+                          Source = "XTurn"
+                          Target = "OTurn"
+                          Guard = None
+                          Constraint = Unrestricted
+                          Safety = Unsafe } ] }
+
+              let map = AffordanceMap.fromStatechart "http://example.com/alps" sc
+              let entry = map.Entries |> List.head
+              let monitorRels = entry.LinkRelations |> List.filter (fun lr -> lr.Rel = "monitor")
+              Expect.isEmpty monitorRels "No monitor rels when no roles defined"
+
+          testCase "fromStatechart unrestricted transition means no monitor rels for any role"
+          <| fun _ ->
+              let sc: ExtractedStatechart =
+                  { RouteTemplate = "/games/{gameId}"
+                    StateNames = [ "XTurn" ]
+                    InitialStateKey = "XTurn"
+                    GuardNames = []
+                    StateMetadata = Map.empty
+                    Roles =
+                      [ { Name = "PlayerX"; Description = None }
+                        { Name = "PlayerO"; Description = None } ]
+                    Transitions =
+                      [ { Event = "makeMove"
+                          Source = "XTurn"
+                          Target = "OTurn"
+                          Guard = None
+                          Constraint = Unrestricted
+                          Safety = Unsafe } ] }
+
+              let map = AffordanceMap.fromStatechart "http://example.com/alps" sc
+              let entry = map.Entries |> List.head
+              let monitorRels = entry.LinkRelations |> List.filter (fun lr -> lr.Rel = "monitor")
+              Expect.isEmpty monitorRels "Unrestricted transitions mean all roles participate — no monitor rels"
+
+          testCase "fromStatechart multiple roles with no transitions each get own monitor rel"
+          <| fun _ ->
+              let sc: ExtractedStatechart =
+                  { RouteTemplate = "/orders/{orderId}"
+                    StateNames = [ "Processing" ]
+                    InitialStateKey = "Processing"
+                    GuardNames = []
+                    StateMetadata = Map.empty
+                    Roles =
+                      [ { Name = "Customer"; Description = None }
+                        { Name = "Auditor"; Description = None }
+                        { Name = "Warehouse"; Description = None } ]
+                    Transitions =
+                      [ { Event = "ShipOrder"
+                          Source = "Processing"
+                          Target = "Shipped"
+                          Guard = None
+                          Constraint = RestrictedTo [ "Warehouse" ]
+                          Safety = Unsafe } ] }
+
+              let map = AffordanceMap.fromStatechart "http://example.com/alps" sc
+              let entry = map.Entries |> List.head
+              let monitorRels = entry.LinkRelations |> List.filter (fun lr -> lr.Rel = "monitor")
+              Expect.equal monitorRels.Length 2 "Two roles without transitions should each get monitor rel"
+              let monitorRoles = monitorRels |> List.collect _.Roles |> List.sort
+              Expect.equal monitorRoles [ "Auditor"; "Customer" ] "Monitor rels for Auditor and Customer"
+
+          // #271 Phase 2: ALPS profile fragment URI rels
+          testCase "fromStatechart ALPS fragment URI preserves PascalCase event name"
+          <| fun _ ->
+              let sc: ExtractedStatechart =
+                  { RouteTemplate = "/orders/{orderId}"
+                    StateNames = [ "Pending" ]
+                    InitialStateKey = "Pending"
+                    GuardNames = []
+                    StateMetadata = Map.empty
+                    Roles = []
+                    Transitions =
+                      [ { Event = "AuthorizePayment"
+                          Source = "Pending"
+                          Target = "Authorized"
+                          Guard = None
+                          Constraint = Unrestricted
+                          Safety = Unsafe } ] }
+
+              let map = AffordanceMap.fromStatechart "http://example.com/alps" sc
+              let entry = map.Entries |> List.head
+              let rel = entry.LinkRelations |> List.head |> _.Rel
+              Expect.equal rel "http://example.com/alps/orders#AuthorizePayment" "PascalCase preserved in ALPS fragment"
+
+          testCase "fromStatechart no bare kebab-case rels in output"
+          <| fun _ ->
+              let sc: ExtractedStatechart =
+                  { RouteTemplate = "/orders/{orderId}"
+                    StateNames = [ "Authorize" ]
+                    InitialStateKey = "Authorize"
+                    GuardNames = []
+                    StateMetadata = Map.empty
+                    Roles =
+                      [ { Name = "Customer"; Description = None }
+                        { Name = "PaymentService"; Description = None } ]
+                    Transitions =
+                      [ { Event = "AuthorizePayment"
+                          Source = "Authorize"
+                          Target = "Shipped"
+                          Guard = None
+                          Constraint = RestrictedTo [ "PaymentService" ]
+                          Safety = Unsafe } ] }
+
+              let map = AffordanceMap.fromStatechart "http://example.com/alps" sc
+              let allRels =
+                  map.Entries
+                  |> List.collect (fun e -> e.LinkRelations |> List.map _.Rel)
+              for rel in allRels do
+                  let isIana = rel = "monitor"
+                  let isUri = rel.Contains("#") || rel.Contains("://")
+                  Expect.isTrue (isIana || isUri) (sprintf "Rel '%s' must be IANA-registered or a valid URI" rel)
+
+          testCase "fromStatechart monitor rel stays IANA-registered not ALPS URI"
+          <| fun _ ->
+              let sc: ExtractedStatechart =
+                  { RouteTemplate = "/orders/{orderId}"
+                    StateNames = [ "Authorize" ]
+                    InitialStateKey = "Authorize"
+                    GuardNames = []
+                    StateMetadata = Map.empty
+                    Roles =
+                      [ { Name = "Customer"; Description = None }
+                        { Name = "PaymentService"; Description = None } ]
+                    Transitions =
+                      [ { Event = "AuthorizePayment"
+                          Source = "Authorize"
+                          Target = "Shipped"
+                          Guard = None
+                          Constraint = RestrictedTo [ "PaymentService" ]
+                          Safety = Unsafe } ] }
+
+              let map = AffordanceMap.fromStatechart "http://example.com/alps" sc
+              let entry = map.Entries |> List.head
+              let monitorRel = entry.LinkRelations |> List.tryFind (fun lr -> lr.Rel = "monitor")
+              Expect.isSome monitorRel "Should have monitor rel"
+              Expect.equal monitorRel.Value.Rel "monitor" "monitor should be bare IANA-registered rel" ]

--- a/test/Frank.Resources.Model.Tests/AffordanceMapTests.fs
+++ b/test/Frank.Resources.Model.Tests/AffordanceMapTests.fs
@@ -591,6 +591,7 @@ let affordanceMapTests =
               Expect.equal monitor.Method "GET" "Monitor rel should be GET"
               Expect.equal monitor.Roles [ "Customer" ] "Monitor rel should be scoped to MayPoll role"
               Expect.equal monitor.Href "/orders/{orderId}" "Monitor rel should target resource"
+              Expect.equal monitor.Title (Some "Authorize") "Monitor rel should include state name as Title"
 
           testCase "fromStatechart does not add monitor rel for role with transitions"
           <| fun _ ->
@@ -690,6 +691,26 @@ let affordanceMapTests =
               Expect.equal monitorRels.Length 2 "Two roles without transitions should each get monitor rel"
               let monitorRoles = monitorRels |> List.collect _.Roles |> List.sort
               Expect.equal monitorRoles [ "Auditor"; "Customer" ] "Monitor rels for Auditor and Customer"
+              for mr in monitorRels do
+                  Expect.equal mr.Title (Some "Processing") "Monitor rels should include state name as Title"
+
+          testCase "fromStatechart no monitor rels in terminal state with roles"
+          <| fun _ ->
+              let sc: ExtractedStatechart =
+                  { RouteTemplate = "/orders/{orderId}"
+                    StateNames = [ "Delivered"; "Cancelled" ]
+                    InitialStateKey = "Delivered"
+                    GuardNames = []
+                    StateMetadata = Map.empty
+                    Roles =
+                      [ { Name = "Customer"; Description = None }
+                        { Name = "PaymentService"; Description = None } ]
+                    Transitions = [] }
+
+              let map = AffordanceMap.fromStatechart "http://example.com/alps" sc
+              for entry in map.Entries do
+                  let monitorRels = entry.LinkRelations |> List.filter (fun lr -> lr.Rel = "monitor")
+                  Expect.isEmpty monitorRels (sprintf "Terminal state %s should not get monitor rels" entry.StateKey)
 
           // #271 Phase 2: ALPS profile fragment URI rels
           testCase "fromStatechart ALPS fragment URI preserves PascalCase event name"
@@ -734,13 +755,16 @@ let affordanceMapTests =
                           Safety = Unsafe } ] }
 
               let map = AffordanceMap.fromStatechart "http://example.com/alps" sc
+              // Known IANA link relations used by the system
+              let ianaRels = Set.ofList [ "monitor"; "self"; "profile" ]
               let allRels =
                   map.Entries
                   |> List.collect (fun e -> e.LinkRelations |> List.map _.Rel)
               for rel in allRels do
-                  let isIana = rel = "monitor"
-                  let isUri = rel.Contains("#") || rel.Contains("://")
-                  Expect.isTrue (isIana || isUri) (sprintf "Rel '%s' must be IANA-registered or a valid URI" rel)
+                  let isIana = ianaRels.Contains rel
+                  let mutable uri = Unchecked.defaultof<System.Uri>
+                  let isUri = System.Uri.TryCreate(rel, System.UriKind.Absolute, &uri)
+                  Expect.isTrue (isIana || isUri) (sprintf "Rel '%s' must be IANA-registered or a valid absolute URI" rel)
 
           testCase "fromStatechart monitor rel stays IANA-registered not ALPS URI"
           <| fun _ ->


### PR DESCRIPTION
## Summary

- **MayPoll observation rels**: `fromStatechart` now generates `rel="monitor"` (IANA RFC 5765) GET link relations for roles with no transitions from a state. Customer in Authorize state gets observation guidance instead of zero affordances.
- **ALPS profile fragment URIs**: Transition rels use `{profileUrl}#{EventName}` format (e.g. `http://example.com/alps/orders#AuthorizePayment`) instead of bare kebab-case strings, satisfying RFC 8288 §2.1.2.
- All changes at the library level (`Frank.Resources.Model/AffordanceTypes.fs`), not in sample handlers.

Closes #271

## Requirements

| Requirement | Status | Evidence |
|-------------|--------|----------|
| MayPoll role gets observation link relation | Implemented | Unit: 5 tests; E2E: AT1 PASS |
| MustSelect role still gets transition rels | Implemented | Unit: existing tests pass; E2E: AT2 PASS |
| Link relation values are valid URIs | Implemented | Unit: 3 tests; E2E: AT3 PASS |
| Bare kebab-case rels no longer appear | Implemented | Unit: no-bare-kebab test; E2E: AT4 PASS |
| Solution in `AffordanceMap.fromStatechart` (library) | Implemented | Change in `AffordanceTypes.fs` only |
| No custom Link headers in sample handlers | Verified | Sample code unchanged |

## Verified results

```
Build: 0 errors
Tests: 2,757 passed, 0 failed (14 test projects)
E2E (OrderFulfillment): 63 passed, 0 failed
  #271 AT1: Customer gets monitor link in Authorize — PASS
  #271 AT2: PaymentService gets AuthorizePayment link — PASS
  #271 AT3: Link rels are ALPS fragment URIs — PASS
  #271 AT4: no bare kebab-case rels (PaymentService) — PASS
  #271 AT4: no bare kebab-case rels (Customer) — PASS
```

## Test plan

- [x] Unit tests: 8 new/updated AffordanceMap tests (5 MayPoll + 3 ALPS URI)
- [x] Regression: all 46 AffordanceMap tests pass (38 existing + 8 new)
- [x] Full suite: 2,757 tests across 14 projects
- [x] E2E: OrderFulfillment test-e2e.sh (63/63 pass)
- [ ] Expert review: pending (Fielding, Miller, @7sharp9, Amundsen dispatched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)