### PR TITLE
openapi: bump JsonSchema.OpenApi to 3.1.0, default route to /.well-known/openapi.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,14 +346,14 @@ Enable OpenAPI document generation in your application:
 let main args =
     webHost args {
         useDefaults
-        useOpenApi  // Adds /openapi/v1.json endpoint
+        useOpenApi  // Adds /.well-known/openapi.json endpoint
 
         resource productsResource
     }
     0
 ```
 
-The OpenAPI document will be available at `/openapi/v1.json`.
+The OpenAPI document will be available at `/.well-known/openapi.json`.
 
 ### Content Negotiation
 

--- a/sample/Frank.OpenApi.Sample/Handlers.fs
+++ b/sample/Frank.OpenApi.Sample/Handlers.fs
@@ -2,6 +2,7 @@ module Sample.OpenApi.Handlers
 
 open System
 open Microsoft.AspNetCore.Http
+open Frank.Builder
 open Frank.OpenApi
 open Sample.OpenApi
 

--- a/sample/Frank.OpenApi.Sample/Program.fs
+++ b/sample/Frank.OpenApi.Sample/Program.fs
@@ -58,7 +58,7 @@ let rootHandler =
             do! ctx.Response.WriteAsJsonAsync({|
                 name = "Product Catalog API"
                 version = "1.0.0"
-                openApiUrl = "/openapi/v1.json"
+                openApiUrl = "/.well-known/openapi.json"
                 scalarUrl = "/scalar/v1"
             |})
         })

--- a/sample/Frank.OpenApi.Sample/README.md
+++ b/sample/Frank.OpenApi.Sample/README.md
@@ -61,17 +61,17 @@ The application will start on `http://localhost:5000` (HTTP) and `https://localh
 | DELETE | `/api/products/{id}` | Delete a product |
 | POST | `/api/products/search` | Search products with filters |
 | GET | `/api/products/{id}/negotiate` | Content negotiation example |
-| GET | `/openapi/v1.json` | OpenAPI document |
+| GET | `/.well-known/openapi.json` | OpenAPI document |
 
 ## OpenAPI Document
 
 View the generated OpenAPI document:
 
 ```bash
-curl http://localhost:5000/openapi/v1.json | jq
+curl http://localhost:5000/.well-known/openapi.json | jq
 ```
 
-Or visit `http://localhost:5000/openapi/v1.json` in your browser.
+Or visit `http://localhost:5000/.well-known/openapi.json` in your browser.
 
 ## Example Requests
 

--- a/src/Frank.OpenApi/Frank.OpenApi.fsproj
+++ b/src/Frank.OpenApi/Frank.OpenApi.fsproj
@@ -23,14 +23,15 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="10.1.*" />
-    <!-- Pinned exact (not floating) 10.0.0: 10.0.3+ tightened UnwrapOpenApiSchema and
-         rejects the anyOf branches FSharp.Data.JsonSchema.OpenApi emits for F# DUs.
-         Do not float this until fsprojects/FSharp.Data.JsonSchema#30 is resolved. -->
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
-    <!-- Overrides the transitive floor Microsoft.AspNetCore.OpenApi 10.0.0 pulls (2.0.0),
+    <!-- Was pinned exact to 10.0.0 because 10.0.3+ tightened UnwrapOpenApiSchema and
+         rejected the anyOf branches FSharp.Data.JsonSchema.OpenApi emitted for F# DUs
+         (fsprojects/FSharp.Data.JsonSchema#30). Fixed upstream in
+         FSharp.Data.JsonSchema.OpenApi 3.1.0 — floating again. -->
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.*" />
+    <!-- Overrides the transitive floor Microsoft.AspNetCore.OpenApi pulls (2.0.0),
          which carries NU1903 (GHSA-v5pm-xwqc-g5wc). Keep >= 2.7.5 regardless of the pin above. -->
     <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
-    <PackageReference Include="FSharp.Data.JsonSchema.OpenApi" Version="3.0.1" />
+    <PackageReference Include="FSharp.Data.JsonSchema.OpenApi" Version="3.1.0" />
     <PackageReference Include="Scalar.AspNetCore" Version="1.2.38" />
   </ItemGroup>
 

--- a/src/Frank.OpenApi/WebHostBuilderExtensions.fs
+++ b/src/Frank.OpenApi/WebHostBuilderExtensions.fs
@@ -13,6 +13,13 @@ open Scalar.AspNetCore
 [<AutoOpen>]
 module WebHostBuilderExtensions =
 
+    let private openApiRoutePattern = "/.well-known/openapi.json"
+
+    let private mapOpenApiEndpoints (endpoints: IEndpointRouteBuilder) =
+        endpoints.MapOpenApi(openApiRoutePattern) |> ignore
+        endpoints.MapScalarApiReference(fun (options: ScalarOptions) ->
+            options.WithOpenApiRoutePattern(openApiRoutePattern) |> ignore) |> ignore
+
     let private configureOpenApiDefaults (options: OpenApiOptions) =
         options.AddSchemaTransformer(FSharpSchemaTransformer()) |> ignore
         options.AddOperationTransformer(fun operation context _ct ->
@@ -47,9 +54,7 @@ module WebHostBuilderExtensions =
                     ) |> ignore
                     services
                 Middleware = spec.Middleware >> fun app ->
-                    app.UseEndpoints(fun endpoints ->
-                        endpoints.MapOpenApi() |> ignore
-                        endpoints.MapScalarApiReference() |> ignore) |> ignore
+                    app.UseEndpoints(mapOpenApiEndpoints) |> ignore
                     app }
 
         [<CustomOperation("useOpenApi")>]
@@ -61,7 +66,5 @@ module WebHostBuilderExtensions =
                     ) |> ignore
                     services
                 Middleware = spec.Middleware >> fun app ->
-                    app.UseEndpoints(fun endpoints ->
-                        endpoints.MapOpenApi() |> ignore
-                        endpoints.MapScalarApiReference() |> ignore) |> ignore
+                    app.UseEndpoints(mapOpenApiEndpoints) |> ignore
                     app }

--- a/test/Frank.OpenApi.Tests/OpenApiDocumentTests.fs
+++ b/test/Frank.OpenApi.Tests/OpenApiDocumentTests.fs
@@ -25,6 +25,8 @@ type TestEndpointDataSource(endpoints: Endpoint[]) =
     override _.Endpoints = endpoints :> _
     override _.GetChangeToken() = NullChangeToken.Singleton :> _
 
+let openApiRoutePattern = "/.well-known/openapi.json"
+
 /// Creates a test server with Frank resources and OpenAPI enabled
 let createOpenApiTestServer (resources: Resource list) =
     let allEndpoints = resources |> List.collect (fun r -> r.Endpoints |> Array.toList) |> List.toArray
@@ -57,8 +59,9 @@ let createOpenApiTestServer (resources: Resource list) =
                             .UseRouting()
                             .UseEndpoints(fun endpoints ->
                                 endpoints.DataSources.Add(TestEndpointDataSource(allEndpoints))
-                                endpoints.MapOpenApi() |> ignore
-                                endpoints.MapScalarApiReference() |> ignore)
+                                endpoints.MapOpenApi(openApiRoutePattern) |> ignore
+                                endpoints.MapScalarApiReference(fun (options: ScalarOptions) ->
+                                    options.WithOpenApiRoutePattern(openApiRoutePattern) |> ignore) |> ignore)
                         |> ignore)
                 |> ignore)
 
@@ -99,7 +102,7 @@ let hasProperty (name: string) (element: JsonElement) =
 /// Helper to get and parse the OpenAPI document
 let getOpenApiDoc (client: HttpClient) =
     task {
-        let! (response: HttpResponseMessage) = client.GetAsync("/openapi/v1.json")
+        let! (response: HttpResponseMessage) = client.GetAsync(openApiRoutePattern)
         let! (body: string) = response.Content.ReadAsStringAsync()
         return response, JsonDocument.Parse(body : string)
     }
@@ -109,14 +112,14 @@ let getOpenApiDoc (client: HttpClient) =
 [<Tests>]
 let us1Tests =
     testList "US1 - Serve OpenAPI Document" [
-        testTask "GET /openapi/v1.json returns 200 with valid OpenAPI document" {
+        testTask "GET /.well-known/openapi.json returns 200 with valid OpenAPI document" {
             let products =
                 resource "/products" {
                     name "Products"
                     get simpleHandler
                 }
             let client = createOpenApiTestServer [ products ]
-            let! (response: HttpResponseMessage) = client.GetAsync("/openapi/v1.json")
+            let! (response: HttpResponseMessage) = client.GetAsync(openApiRoutePattern)
             Expect.equal response.StatusCode HttpStatusCode.OK "Should return 200"
 
             let! (body: string) = response.Content.ReadAsStringAsync()
@@ -181,14 +184,14 @@ let us1Tests =
             Expect.isTrue (hasProperty "get" usersPath) "Should have GET /users"
         }
 
-        testTask "App without OpenAPI does not expose /openapi/v1.json" {
+        testTask "App without OpenAPI does not expose /.well-known/openapi.json" {
             let products =
                 resource "/products" {
                     name "Products"
                     get simpleHandler
                 }
             let client = createPlainTestServer [ products ]
-            let! (response: HttpResponseMessage) = client.GetAsync("/openapi/v1.json")
+            let! (response: HttpResponseMessage) = client.GetAsync(openApiRoutePattern)
             Expect.equal response.StatusCode HttpStatusCode.NotFound "Should return 404 when OpenAPI is not configured"
         }
     ]

--- a/test/Frank.OpenApi.Tests/SchemaTests.fs
+++ b/test/Frank.OpenApi.Tests/SchemaTests.fs
@@ -43,7 +43,7 @@ let hasProperty (name: string) (element: JsonElement) =
 /// Helper to get and parse the OpenAPI document
 let getOpenApiDoc (client: HttpClient) =
     task {
-        let! (response: HttpResponseMessage) = client.GetAsync("/openapi/v1.json")
+        let! (response: HttpResponseMessage) = client.GetAsync(OpenApiDocumentTests.openApiRoutePattern)
         let! (body: string) = response.Content.ReadAsStringAsync()
         return response, JsonDocument.Parse(body : string)
     }


### PR DESCRIPTION
## Summary
- Bump `FSharp.Data.JsonSchema.OpenApi` 3.0.1 → 3.1.0, which fixes fsprojects/FSharp.Data.JsonSchema#30 (DU `anyOf` schemas rejected by ASP.NET Core 10.0.3+'s stricter `UnwrapOpenApiSchema`)
- Un-pin `Microsoft.AspNetCore.OpenApi` from exact `10.0.0` to floating `10.0.*` (resolves `10.0.10`) now that the reason for pinning is resolved upstream
- Default the OpenAPI document route to `/.well-known/openapi.json` instead of ASP.NET Core's `/openapi/v1.json`, wiring both `MapOpenApi(pattern)` and Scalar's `WithOpenApiRoutePattern` so the UI keeps finding the doc
- Fix a pre-existing sample build break (missing `open Frank.Builder` in `Handlers.fs`, left over from the `HandlerBuilder`/`HandlerDefinition` move to Frank core in 5315f52a)

## Test plan
- [x] `dotnet build src/Frank.OpenApi/Frank.OpenApi.fsproj` succeeds
- [x] `dotnet test test/Frank.OpenApi.Tests/Frank.OpenApi.Tests.fsproj` — 21/21 pass, including DU `anyOf` schema tests against the new package versions
- [x] `dotnet build Frank.sln` succeeds across net8.0/9.0/10.0
- [x] `dotnet build sample/Frank.OpenApi.Sample/Frank.OpenApi.Sample.fsproj` succeeds

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01BFBxS5oaFytAHNkFR8KXkU